### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/Jarvis/security/code-scanning/1](https://github.com/rajbos/Jarvis/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the top level or per job) that grants only the minimal required access for the `GITHUB_TOKEN`. For this CI workflow, the steps only need to read the repository contents to check out code and run Node-related tasks, so `contents: read` is sufficient.

The single best way to fix this without changing existing functionality is to add a workflow-level `permissions` section just under the `name:` (or under `on:`) so it applies to all jobs. Specifically, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

near the top, before the `jobs:` section. No other changes are needed because the workflow does not perform any write actions (no tagging, releasing, commenting, or pushing), and `contents: read` is compatible with `actions/checkout` and the Node setup and test steps.

No additional imports, methods, or definitions are needed; this is purely a YAML configuration change inside the shown workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
