### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,6 @@
 name: Dependency Review
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/Jarvis/security/code-scanning/2](https://github.com/rajbos/Jarvis/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block in the workflow so the `GITHUB_TOKEN` has only the minimal scopes required. For a dependency review workflow that just checks dependencies and does not modify repository content, `contents: read` is sufficient, and can be applied either at the workflow root (affecting all jobs) or at the job level (affecting just that job).

The best fix here, without changing behavior, is to add a root-level `permissions` block immediately after the `name:` line, specifying `contents: read`. This documents the intended least-privilege policy and ensures that, regardless of organization/repo defaults, this workflow will only have read access to repository contents. No additional imports or methods are needed because this is a YAML configuration change only.

Concretely, in `.github/workflows/dependency-review.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Dependency Review`) and line 3 (`on:`), preserving indentation and existing content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
