### PR TITLE
fix: complete JarvisApi IPC contract coverage

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import type { DiscoveryProgress, LocalScanProgress, SecretsScanProgress } from '../plugins/types';
 import type {
   AgentSessionStartingPayload,
   AgentAnalysisCompletePayload,
@@ -86,8 +87,8 @@ contextBridge.exposeInMainWorld('jarvis', {
   listSecretFavorites: () => ipcRenderer.invoke('secrets:list-favorites'),
   addSecretFavorite: (targetType: string, targetName: string) => ipcRenderer.invoke('secrets:add-favorite', targetType, targetName),
   removeSecretFavorite: (targetName: string) => ipcRenderer.invoke('secrets:remove-favorite', targetName),
-  onSecretsProgress: (callback: (progress: Record<string, number>) => void) => {
-    const listener = (_event: unknown, progress: Record<string, number>) => callback(progress);
+  onSecretsProgress: (callback: (progress: SecretsScanProgress) => void) => {
+    const listener = (_event: unknown, progress: SecretsScanProgress) => callback(progress);
     ipcRenderer.on('secrets:scan-progress', listener);
     return () => { ipcRenderer.removeListener('secrets:scan-progress', listener); };
   },
@@ -101,23 +102,23 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.on('github:oauth-complete', listener);
     return () => { ipcRenderer.removeListener('github:oauth-complete', listener); };
   },
-  onDiscoveryProgress: (callback: (progress: Record<string, unknown>) => void) => {
-    const listener = (_event: unknown, progress: Record<string, unknown>) => callback(progress);
+  onDiscoveryProgress: (callback: (progress: DiscoveryProgress) => void) => {
+    const listener = (_event: unknown, progress: DiscoveryProgress) => callback(progress);
     ipcRenderer.on('github:discovery-progress', listener);
     return () => { ipcRenderer.removeListener('github:discovery-progress', listener); };
   },
-  onDiscoveryComplete: (callback: (progress: Record<string, unknown>) => void) => {
-    const listener = (_event: unknown, progress: Record<string, unknown>) => callback(progress);
+  onDiscoveryComplete: (callback: (progress: DiscoveryProgress) => void) => {
+    const listener = (_event: unknown, progress: DiscoveryProgress) => callback(progress);
     ipcRenderer.on('github:discovery-complete', listener);
     return () => { ipcRenderer.removeListener('github:discovery-complete', listener); };
   },
-  onLocalScanProgress: (callback: (progress: Record<string, unknown>) => void) => {
-    const listener = (_event: unknown, progress: Record<string, unknown>) => callback(progress);
+  onLocalScanProgress: (callback: (progress: LocalScanProgress) => void) => {
+    const listener = (_event: unknown, progress: LocalScanProgress) => callback(progress);
     ipcRenderer.on('local:scan-progress', listener);
     return () => { ipcRenderer.removeListener('local:scan-progress', listener); };
   },
-  onLocalScanComplete: (callback: (progress: Record<string, unknown>) => void) => {
-    const listener = (_event: unknown, progress: Record<string, unknown>) => callback(progress);
+  onLocalScanComplete: (callback: (progress: LocalScanProgress) => void) => {
+    const listener = (_event: unknown, progress: LocalScanProgress) => callback(progress);
     ipcRenderer.on('local:scan-complete', listener);
     return () => { ipcRenderer.removeListener('local:scan-complete', listener); };
   },

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -273,6 +273,8 @@ export interface FailedWorkflowRun {
 // ── Jarvis preload API contract ───────────────────────────────────────────────
 // This augments the global Window type so all plugin components get full
 // type-checking on window.jarvis calls without re-declaring it everywhere.
+export type { OnboardingStatus } from '../agent/onboarding';
+import type { OnboardingStatus } from '../agent/onboarding';
 import type {
   AgentSessionStartingPayload,
   AgentAnalysisCompletePayload,
@@ -292,6 +294,14 @@ export type {
 } from '../types/ipc-payloads';
 
 export interface JarvisApi {
+  getOnboardingStatus(): Promise<OnboardingStatus>;
+  startDiscovery(): Promise<{ started: boolean }>;
+  startPatDiscovery(): Promise<{ started?: boolean; error?: string }>;
+  startOAuthDiscovery(): Promise<{ ok: boolean }>;
+  savePat(pat: string): Promise<{ ok: boolean; error?: string }>;
+  deletePat(): Promise<{ ok: boolean }>;
+  getPatStatus(): Promise<{ hasPat: boolean; login?: string; name?: string; avatarUrl?: string }>;
+  logout(): Promise<{ ok: boolean }>;
   checkOllama(): Promise<OllamaStatus>;
   listOllamaModels(): Promise<{ available: boolean; models: OllamaModel[]; error?: string }>;
   getSelectedOllamaModel(): Promise<string | null>;

--- a/tests/unit/preload-jarvisapi-parity.test.ts
+++ b/tests/unit/preload-jarvisapi-parity.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Parity test: every key exposed in preload.ts must have a matching entry
+ * in the JarvisApi interface (src/plugins/types.ts).
+ *
+ * This is enforced by parsing the source files at test time with a simple
+ * regex, so it works without importing Electron or any browser APIs.
+ *
+ * Add new methods to both files — this test will catch gaps immediately.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const root = resolve(__dirname, '../../src');
+
+function extractPreloadKeys(src: string): string[] {
+  // Match the contextBridge.exposeInMainWorld object literal keys
+  const objectBody = src.match(/contextBridge\.exposeInMainWorld\('jarvis',\s*\{([\s\S]*)\}\s*\);/)?.[1] ?? '';
+  const keys: string[] = [];
+  for (const m of objectBody.matchAll(/^\s{2}(\w+)\s*:/gm)) {
+    keys.push(m[1]);
+  }
+  return keys;
+}
+
+function extractJarvisApiKeys(src: string): string[] {
+  const interfaceBody = src.match(/export interface JarvisApi \{([\s\S]*?)\n\}/)?.[1] ?? '';
+  const keys: string[] = [];
+  for (const m of interfaceBody.matchAll(/^\s+(\w+)\s*[(:]/gm)) {
+    keys.push(m[1]);
+  }
+  return keys;
+}
+
+describe('preload ↔ JarvisApi parity', () => {
+  const preloadSrc = readFileSync(resolve(root, 'main/preload.ts'), 'utf8');
+  const typesSrc = readFileSync(resolve(root, 'plugins/types.ts'), 'utf8');
+
+  const preloadKeys = extractPreloadKeys(preloadSrc);
+  const apiKeys = extractJarvisApiKeys(typesSrc);
+
+  it('has at least one key in preload and JarvisApi (sanity check)', () => {
+    expect(preloadKeys.length).toBeGreaterThan(10);
+    expect(apiKeys.length).toBeGreaterThan(10);
+  });
+
+  it('every preload key is declared in JarvisApi', () => {
+    const missing = preloadKeys.filter(k => !apiKeys.includes(k));
+    expect(
+      missing,
+      `Preload keys missing from JarvisApi: ${missing.join(', ')}`,
+    ).toHaveLength(0);
+  });
+
+  it('every JarvisApi key is exposed in preload', () => {
+    const missing = apiKeys.filter(k => !preloadKeys.includes(k));
+    expect(
+      missing,
+      `JarvisApi keys not exposed in preload: ${missing.join(', ')}`,
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #62

## Summary

Addresses all findings from the automated quality report on Electron IPC contract completeness.

### Changes

**`src/plugins/types.ts`**
- Add 8 missing method signatures to `JarvisApi` that were exposed in `preload.ts` but absent from the interface, causing implicit `any` for callers in `settings.tsx` and elsewhere:
  - `getOnboardingStatus`, `startDiscovery`, `startPatDiscovery`, `startOAuthDiscovery`
  - `savePat`, `deletePat`, `getPatStatus`, `logout`
- Re-export `OnboardingStatus` from `src/agent/onboarding.ts` so renderer components can import it from the canonical types module

**`src/main/preload.ts`**
- Fix 5 push-event listener internal types — replace generic `Record<string, unknown/number>` with the proper domain types:
  - `onDiscoveryProgress` / `onDiscoveryComplete` → `DiscoveryProgress`
  - `onLocalScanProgress` / `onLocalScanComplete` → `LocalScanProgress`
  - `onSecretsProgress` → `SecretsScanProgress`

**`tests/unit/preload-jarvisapi-parity.test.ts`** _(new)_
- Parses both `preload.ts` and `types.ts` source files at test time and asserts that every preload-exposed key has a matching `JarvisApi` declaration and vice versa — prevents future gaps from silently accumulating in CI.