### PR TITLE
feat: OneDrive customer folder discovery

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -19,6 +19,7 @@ import { registerHandlers as registerAgentsHandlers } from '../plugins/agents/ha
 import { registerHandlers as registerSecretsHandlers } from '../plugins/secrets/handler';
 import { registerHandlers as registerDashboardHandlers } from '../plugins/dashboard/handler';
 import { registerHandlers as registerGroupsHandlers } from '../plugins/groups/handler';
+import { registerHandlers as registerOnedriveHandlers } from '../plugins/onedrive/handler';
 
 // Re-export startDiscoveryIfAuthed so src/main/index.ts can call it on startup
 export { startDiscoveryIfAuthed } from '../plugins/discovery/handler';
@@ -44,4 +45,5 @@ export function registerIpcHandlers(
   registerSecretsHandlers(db, getWindow);
   registerDashboardHandlers(db, getWindow);
   registerGroupsHandlers(db, getWindow);
+  registerOnedriveHandlers(db, getWindow);
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -193,4 +193,17 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('groups:add-github-repo', groupId, githubRepoId),
   groupsRemoveGithubRepo: (groupId: number, githubRepoId: number) =>
     ipcRenderer.invoke('groups:remove-github-repo', groupId, githubRepoId),
+  // OneDrive
+  onedriveListRoots: () => ipcRenderer.invoke('onedrive:list-roots'),
+  onedriveAddRoot: (label: string, folderPath?: string) =>
+    ipcRenderer.invoke('onedrive:add-root', label, folderPath),
+  onedriveRemoveRoot: (rootId: number) => ipcRenderer.invoke('onedrive:remove-root', rootId),
+  onedriveDiscoverForGroup: (groupId: number) =>
+    ipcRenderer.invoke('onedrive:discover-for-group', groupId),
+  onedriveGetFolderInfo: (groupId: number) =>
+    ipcRenderer.invoke('onedrive:get-folder-info', groupId),
+  onedriveRescanFiles: (folderId: number) =>
+    ipcRenderer.invoke('onedrive:rescan-files', folderId),
+  onedriveListFilesForFolder: (folderId: number) =>
+    ipcRenderer.invoke('onedrive:list-files-for-folder', folderId),
 });

--- a/src/plugins/groups/GroupsPanel.tsx
+++ b/src/plugins/groups/GroupsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'preact/hooks';
-import type { Group, GroupDetail, LocalRepo } from '../types';
+import type { Group, GroupDetail, LocalRepo, OnedriveFolderInfo, OnedriveFile } from '../types';
 
 // ── GroupsPanel ───────────────────────────────────────────────────────────────
 // Allows users to create, rename, delete groups and assign local/remote repos
@@ -27,6 +27,12 @@ export function GroupsPanel({ onClose }: GroupsPanelProps) {
   // Add repo search
   const [localRepos, setLocalRepos] = useState<LocalRepo[]>([]);
   const [repoSearch, setRepoSearch] = useState('');
+
+  // OneDrive state
+  const [onedriveDiscovering, setOnedriveDiscovering] = useState(false);
+  const [onedriveRescanningId, setOnedriveRescanningId] = useState<number | null>(null);
+  const [expandedFolderId, setExpandedFolderId] = useState<number | null>(null);
+  const [folderFiles, setFolderFiles] = useState<Record<number, OnedriveFile[]>>({});
 
   const refresh = async () => {
     try {
@@ -136,6 +142,52 @@ export function GroupsPanel({ onClose }: GroupsPanelProps) {
     const detail = await window.jarvis.groupsGet(selectedGroup.id);
     setSelectedGroup(detail);
     await refresh();
+  };
+
+  // ── OneDrive handlers ────────────────────────────────────────────────────────
+
+  const handleOnedriveDiscover = async () => {
+    if (!selectedGroup) return;
+    setOnedriveDiscovering(true);
+    try {
+      await window.jarvis.onedriveDiscoverForGroup(selectedGroup.id);
+      const detail = await window.jarvis.groupsGet(selectedGroup.id);
+      setSelectedGroup(detail);
+    } catch (err) {
+      console.error('[Groups] OneDrive discover failed:', err);
+    } finally {
+      setOnedriveDiscovering(false);
+    }
+  };
+
+  const handleOnedriveRescan = async (folderId: number) => {
+    setOnedriveRescanningId(folderId);
+    try {
+      await window.jarvis.onedriveRescanFiles(folderId);
+      const detail = await window.jarvis.groupsGet(selectedGroup!.id);
+      setSelectedGroup(detail);
+      // Refresh file list if expanded
+      if (expandedFolderId === folderId) {
+        const files = await window.jarvis.onedriveListFilesForFolder(folderId);
+        setFolderFiles((prev) => ({ ...prev, [folderId]: files }));
+      }
+    } catch (err) {
+      console.error('[Groups] OneDrive rescan failed:', err);
+    } finally {
+      setOnedriveRescanningId(null);
+    }
+  };
+
+  const handleToggleFiles = async (folder: OnedriveFolderInfo) => {
+    if (expandedFolderId === folder.id) {
+      setExpandedFolderId(null);
+      return;
+    }
+    setExpandedFolderId(folder.id);
+    if (!folderFiles[folder.id]) {
+      const files = await window.jarvis.onedriveListFilesForFolder(folder.id);
+      setFolderFiles((prev) => ({ ...prev, [folder.id]: files }));
+    }
   };
 
   // Repos not yet in the selected group (for the add panel)
@@ -306,6 +358,113 @@ export function GroupsPanel({ onClose }: GroupsPanelProps) {
                   </button>
                 </div>
               ))}
+
+              {/* OneDrive customer folder */}
+              <div style={{ marginTop: '0.75rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <div style={{ fontSize: '0.8rem', color: '#99a', fontWeight: 600 }}>
+                    Customer Data (OneDrive)
+                  </div>
+                  <button
+                    class="btn-save"
+                    style={{ padding: '0.15rem 0.5rem', fontSize: '0.75rem' }}
+                    onClick={() => void handleOnedriveDiscover()}
+                    disabled={onedriveDiscovering}
+                  >
+                    {onedriveDiscovering ? 'Scanning…' : '🔍 Discover'}
+                  </button>
+                </div>
+
+                {selectedGroup.onedriveFolders.length === 0 && (
+                  <div style={{ fontSize: '0.78rem', color: '#667' }}>
+                    No OneDrive roots configured. Add roots in Settings first, then click Discover.
+                  </div>
+                )}
+
+                {selectedGroup.onedriveFolders.map((folder) => (
+                  <div
+                    key={folder.id}
+                    style={{ marginBottom: '0.4rem', background: '#1a1a26', borderRadius: '4px', overflow: 'hidden' }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.3rem 0.5rem' }}>
+                      <div style={{ minWidth: 0 }}>
+                        <span style={{ fontSize: '0.82rem', color: '#ccd', fontWeight: 600 }}>{folder.rootLabel}</span>
+                        {folder.status === 'found' ? (
+                          <span style={{ marginLeft: '0.4rem', fontSize: '0.72rem', color: '#6a9', background: '#1a3a1a', padding: '0.1rem 0.3rem', borderRadius: '3px' }}>
+                            ✓ found
+                          </span>
+                        ) : (
+                          <span style={{ marginLeft: '0.4rem', fontSize: '0.72rem', color: '#f88', background: '#3a1a1a', padding: '0.1rem 0.3rem', borderRadius: '3px' }}>
+                            ✕ not found
+                          </span>
+                        )}
+                        {folder.status === 'found' && (
+                          <span style={{ marginLeft: '0.4rem', fontSize: '0.72rem', color: '#778' }}>
+                            {folder.fileCount} file{folder.fileCount !== 1 ? 's' : ''}
+                            {folder.lastScanned ? ` · scanned ${new Date(folder.lastScanned).toLocaleDateString()}` : ''}
+                          </span>
+                        )}
+                      </div>
+                      <div style={{ display: 'flex', gap: '0.25rem', flexShrink: 0 }}>
+                        {folder.status === 'found' && (
+                          <>
+                            <button
+                              title="Rescan files"
+                              class="btn-secondary"
+                              style={{ padding: '0.1rem 0.35rem', fontSize: '0.72rem' }}
+                              onClick={() => void handleOnedriveRescan(folder.id)}
+                              disabled={onedriveRescanningId === folder.id}
+                            >
+                              {onedriveRescanningId === folder.id ? '…' : '↻'}
+                            </button>
+                            <button
+                              title={expandedFolderId === folder.id ? 'Hide files' : 'Show files'}
+                              class="btn-secondary"
+                              style={{ padding: '0.1rem 0.35rem', fontSize: '0.72rem' }}
+                              onClick={() => void handleToggleFiles(folder)}
+                            >
+                              {expandedFolderId === folder.id ? '▲' : '▼'}
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+
+                    {folder.status === 'found' && folder.folderPath && (
+                      <div style={{ paddingLeft: '0.5rem', paddingBottom: '0.2rem', fontSize: '0.7rem', color: '#556', fontFamily: 'monospace' }}>
+                        {folder.folderPath}
+                      </div>
+                    )}
+
+                    {expandedFolderId === folder.id && (
+                      <div style={{ borderTop: '1px solid #2a2a3a', maxHeight: '200px', overflowY: 'auto' }}>
+                        {(folderFiles[folder.id] ?? []).length === 0 ? (
+                          <div style={{ padding: '0.35rem 0.5rem', fontSize: '0.77rem', color: '#556' }}>No files indexed.</div>
+                        ) : (
+                          (folderFiles[folder.id] ?? []).map((f) => (
+                            <div
+                              key={f.id}
+                              style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.2rem 0.5rem', borderBottom: '1px solid #1e1e28' }}
+                            >
+                              <div style={{ minWidth: 0 }}>
+                                <span style={{ fontSize: '0.78rem', color: '#bbc' }}>{f.name}</span>
+                                {f.relativePath !== f.name && (
+                                  <span style={{ fontSize: '0.68rem', color: '#556', marginLeft: '0.3rem', fontFamily: 'monospace' }}>
+                                    {f.relativePath}
+                                  </span>
+                                )}
+                              </div>
+                              <span style={{ fontSize: '0.7rem', color: '#667', flexShrink: 0, paddingLeft: '0.5rem' }}>
+                                {f.lastModified ? new Date(f.lastModified).toLocaleDateString() : '—'}
+                              </span>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
 
               {/* Add local repo */}
               {localRepos.length > 0 && (

--- a/src/plugins/onedrive/handler.ts
+++ b/src/plugins/onedrive/handler.ts
@@ -1,0 +1,111 @@
+// ── OneDrive IPC handlers ─────────────────────────────────────────────────────
+import { ipcMain, dialog, BrowserWindow } from 'electron';
+import type { Database as SqlJsDatabase } from 'sql.js';
+import { saveDatabase } from '../../storage/database';
+import {
+  listOnedriveRoots,
+  addOnedriveRoot,
+  removeOnedriveRoot,
+  discoverCustomerFolderForGroup,
+  getCustomerFolderInfo,
+  scanFilesForFolder,
+  listFilesForFolder,
+} from '../../services/onedrive';
+import { getGroup } from '../../services/groups';
+
+export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
+  ipcMain.handle('onedrive:list-roots', () => {
+    return listOnedriveRoots(db);
+  });
+
+  ipcMain.handle('onedrive:add-root', async (_event, label: string, folderPath?: string) => {
+    if (typeof label !== 'string' || label.trim().length === 0) {
+      return { ok: false, error: 'Label is required' };
+    }
+
+    let chosenPath = folderPath;
+    if (!chosenPath) {
+      const win = getWindow();
+      const result = await dialog.showOpenDialog(win ?? new BrowserWindow({ show: false }), {
+        properties: ['openDirectory'],
+        title: 'Select OneDrive root folder',
+      });
+      if (result.canceled || result.filePaths.length === 0) {
+        return { canceled: true };
+      }
+      chosenPath = result.filePaths[0];
+    }
+
+    try {
+      const root = addOnedriveRoot(db, chosenPath, label.trim());
+      saveDatabase();
+      return { ok: true, root };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle('onedrive:remove-root', (_event, rootId: number) => {
+    if (typeof rootId !== 'number') return { ok: false, error: 'Invalid rootId' };
+    try {
+      removeOnedriveRoot(db, rootId);
+      saveDatabase();
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle('onedrive:discover-for-group', (_event, groupId: number) => {
+    if (typeof groupId !== 'number') return { ok: false, error: 'Invalid groupId' };
+    try {
+      const group = getGroup(db, groupId);
+      if (!group) return { ok: false, error: 'Group not found' };
+
+      const folders = discoverCustomerFolderForGroup(db, groupId, group.name);
+
+      // Immediately scan files for any found folders
+      for (const folder of folders) {
+        if (folder.status === 'found') {
+          try {
+            scanFilesForFolder(db, folder.id);
+          } catch {
+            // Non-fatal — folder may have become inaccessible
+          }
+        }
+      }
+
+      // Return updated folder info (includes updated file counts)
+      const updated = getCustomerFolderInfo(db, groupId);
+      saveDatabase();
+      return { ok: true, folders: updated };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle('onedrive:get-folder-info', (_event, groupId: number) => {
+    if (typeof groupId !== 'number') return [];
+    return getCustomerFolderInfo(db, groupId);
+  });
+
+  ipcMain.handle('onedrive:rescan-files', (_event, folderId: number) => {
+    if (typeof folderId !== 'number') return { ok: false, error: 'Invalid folderId' };
+    try {
+      const fileCount = scanFilesForFolder(db, folderId);
+      saveDatabase();
+      return { ok: true, fileCount };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle('onedrive:list-files-for-folder', (_event, folderId: number) => {
+    if (typeof folderId !== 'number') return [];
+    return listFilesForFolder(db, folderId);
+  });
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -270,6 +270,39 @@ export interface FailedWorkflowRun {
   html_url: string;
 }
 
+// ── OneDrive types ────────────────────────────────────────────────────────────
+
+export interface OnedriveRoot {
+  id: number;
+  path: string;
+  label: string;
+  addedAt: string;
+}
+
+export interface OnedriveFolderInfo {
+  id: number;
+  groupId: number;
+  rootId: number;
+  rootLabel: string;
+  rootPath: string;
+  status: 'found' | 'not_found';
+  folderPath: string | null;
+  fileCount: number;
+  lastScanned: string | null;
+  discoveredAt: string;
+}
+
+export interface OnedriveFile {
+  id: number;
+  folderId: number;
+  name: string;
+  extension: string | null;
+  relativePath: string;
+  lastModified: string | null;
+  sizeBytes: number | null;
+  scannedAt: string;
+}
+
 // ── Groups types ──────────────────────────────────────────────────────────────
 
 export interface Group {
@@ -302,6 +335,7 @@ export interface GroupDetail {
   updatedAt: string;
   localRepos: GroupLocalRepoMember[];
   githubRepos: GroupGithubRepoMember[];
+  onedriveFolders: OnedriveFolderInfo[];
 }
 
 // ── Jarvis preload API contract ───────────────────────────────────────────────
@@ -423,6 +457,14 @@ export interface JarvisApi {
   groupsRemoveLocalRepo(groupId: number, localRepoId: number): Promise<{ ok: boolean; error?: string }>;
   groupsAddGithubRepo(groupId: number, githubRepoId: number): Promise<{ ok: boolean; error?: string }>;
   groupsRemoveGithubRepo(groupId: number, githubRepoId: number): Promise<{ ok: boolean; error?: string }>;
+  // OneDrive
+  onedriveListRoots(): Promise<OnedriveRoot[]>;
+  onedriveAddRoot(label: string, folderPath?: string): Promise<{ ok: boolean; root?: OnedriveRoot; canceled?: boolean; error?: string }>;
+  onedriveRemoveRoot(rootId: number): Promise<{ ok: boolean; error?: string }>;
+  onedriveDiscoverForGroup(groupId: number): Promise<{ ok: boolean; folders?: OnedriveFolderInfo[]; error?: string }>;
+  onedriveGetFolderInfo(groupId: number): Promise<OnedriveFolderInfo[]>;
+  onedriveRescanFiles(folderId: number): Promise<{ ok: boolean; fileCount?: number; error?: string }>;
+  onedriveListFilesForFolder(folderId: number): Promise<OnedriveFile[]>;
 }
 
 declare global {

--- a/src/renderer/settings.tsx
+++ b/src/renderer/settings.tsx
@@ -17,6 +17,13 @@ interface PatStatus {
   avatarUrl?: string;
 }
 
+interface OnedriveRoot {
+  id: number;
+  path: string;
+  label: string;
+  addedAt: string;
+}
+
 declare const window: Window & {
   jarvis: {
     getGitHubOAuthStatus(): Promise<OAuthStatus>;
@@ -28,6 +35,9 @@ declare const window: Window & {
     startPatDiscovery(): Promise<void>;
     agentsList(): Promise<Array<{ id: number; name: string; description: string; system_prompt: string }>>;
     agentsUpdate(agentId: number, systemPrompt: string): Promise<{ ok: boolean; error?: string }>;
+    onedriveListRoots(): Promise<OnedriveRoot[]>;
+    onedriveAddRoot(label: string, folderPath?: string): Promise<{ ok?: boolean; root?: OnedriveRoot; canceled?: boolean; error?: string }>;
+    onedriveRemoveRoot(rootId: number): Promise<{ ok: boolean; error?: string }>;
   };
 };
 
@@ -316,6 +326,127 @@ function AgentPromptsSection() {
   );
 }
 
+// ── OneDrive Section ─────────────────────────────────────────────────────────
+
+function OneDriveSection() {
+  const [roots, setRoots] = useState<OnedriveRoot[]>([]);
+  const [label, setLabel] = useState('');
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState('');
+
+  const refresh = async () => {
+    try {
+      setRoots(await window.jarvis.onedriveListRoots());
+    } catch (err) {
+      console.error('[OneDrive] Failed to list roots:', err);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleAdd = async () => {
+    if (!label.trim()) {
+      setError('Please enter a label for this root folder');
+      return;
+    }
+    setAdding(true);
+    setError('');
+    const result = await window.jarvis.onedriveAddRoot(label.trim());
+    setAdding(false);
+    if (result.canceled) return;
+    if (!result.ok) {
+      setError(result.error ?? 'Failed to add root');
+      return;
+    }
+    setLabel('');
+    await refresh();
+  };
+
+  const handleRemove = async (rootId: number, rootLabel: string) => {
+    if (!confirm(`Remove OneDrive root "${rootLabel}"? Customer folder links for this root will also be removed.`)) return;
+    const result = await window.jarvis.onedriveRemoveRoot(rootId);
+    if (!result.ok) {
+      setError(result.error ?? 'Failed to remove root');
+      return;
+    }
+    await refresh();
+  };
+
+  return (
+    <div class="section">
+      <h2>OneDrive Customer Data Roots</h2>
+      <p class="hint">
+        Configure the OneDrive folders where your customer data lives. Jarvis will discover
+        customer subfolders by matching group names — no files are downloaded.
+        Add one root per entity you work for.
+      </p>
+
+      <div class="btn-row" style={{ marginTop: '0.75rem', alignItems: 'flex-end', gap: '0.5rem' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+          <label for="onedrive-label" style={{ fontSize: '0.82rem', color: '#aaa' }}>
+            Label (e.g. "Contoso" or "Personal")
+          </label>
+          <input
+            type="text"
+            id="onedrive-label"
+            placeholder="Entity name…"
+            value={label}
+            onInput={(e: Event) => setLabel((e.target as HTMLInputElement).value)}
+            onKeyDown={(e: KeyboardEvent) => { if (e.key === 'Enter') void handleAdd(); }}
+          />
+        </div>
+        <button class="btn-save" onClick={handleAdd} disabled={adding || !label.trim()}>
+          {adding ? 'Browsing…' : 'Browse & Add'}
+        </button>
+      </div>
+
+      {error && <div class="pat-error" style={{ marginTop: '0.4rem' }}>{error}</div>}
+
+      {roots.length === 0 && (
+        <p style={{ fontSize: '0.85rem', color: '#778', marginTop: '0.75rem' }}>
+          No OneDrive roots configured yet.
+        </p>
+      )}
+
+      {roots.length > 0 && (
+        <ul style={{ listStyle: 'none', padding: 0, margin: '0.75rem 0 0' }}>
+          {roots.map((r) => (
+            <li
+              key={r.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '0.45rem 0.6rem',
+                marginBottom: '0.35rem',
+                background: '#1e1e2a',
+                borderRadius: '5px',
+                border: '1px solid #333',
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontWeight: 600, fontSize: '0.85rem', color: '#dde' }}>{r.label}</div>
+                <div style={{ fontSize: '0.75rem', color: '#778', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {r.path}
+                </div>
+              </div>
+              <button
+                class="btn-danger"
+                style={{ marginLeft: '0.75rem', padding: '0.2rem 0.5rem', fontSize: '0.78rem', flexShrink: 0 }}
+                onClick={() => void handleRemove(r.id, r.label)}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 // ── App ──────────────────────────────────────────────────────────────────────
 
 function App() {
@@ -324,6 +455,7 @@ function App() {
       <h1>Settings</h1>
       <OAuthSection />
       <PatSection />
+      <OneDriveSection />
       <AgentPromptsSection />
     </>
   );

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -2,6 +2,7 @@
 // CRUD operations and membership management for source groups.
 import type { Database as SqlJsDatabase } from 'sql.js';
 import type { Group, GroupDetail, GroupLocalRepoMember, GroupGithubRepoMember } from '../plugins/types';
+import { getCustomerFolderInfo } from './onedrive';
 
 // ── List ──────────────────────────────────────────────────────────────────────
 
@@ -98,6 +99,7 @@ export function getGroup(db: SqlJsDatabase, groupId: number): GroupDetail | null
     updatedAt: groupRow.updated_at,
     localRepos,
     githubRepos,
+    onedriveFolders: getCustomerFolderInfo(db, groupRow.id),
   };
 }
 

--- a/src/services/onedrive.ts
+++ b/src/services/onedrive.ts
@@ -1,0 +1,275 @@
+// ── OneDrive customer folder service ─────────────────────────────────────────
+// Discovers customer folders by matching group names against configured
+// OneDrive root directories. Indexes file metadata only — no file downloads.
+import fs from 'fs';
+import path from 'path';
+import type { Database as SqlJsDatabase } from 'sql.js';
+import type { OnedriveRoot, OnedriveFolderInfo, OnedriveFile } from '../plugins/types';
+
+// ── Roots ─────────────────────────────────────────────────────────────────────
+
+export function listOnedriveRoots(db: SqlJsDatabase): OnedriveRoot[] {
+  const stmt = db.prepare('SELECT id, path, label, added_at FROM onedrive_roots ORDER BY label COLLATE NOCASE');
+  const roots: OnedriveRoot[] = [];
+  try {
+    while (stmt.step()) {
+      const r = stmt.getAsObject() as { id: number; path: string; label: string; added_at: string };
+      roots.push({ id: r.id, path: r.path, label: r.label, addedAt: r.added_at });
+    }
+  } finally {
+    stmt.free();
+  }
+  return roots;
+}
+
+export function addOnedriveRoot(db: SqlJsDatabase, folderPath: string, label: string): OnedriveRoot {
+  db.run(
+    `INSERT INTO onedrive_roots (path, label, added_at) VALUES (?, ?, datetime('now'))`,
+    [folderPath, label],
+  );
+  const stmt = db.prepare('SELECT id, path, label, added_at FROM onedrive_roots WHERE path = ?');
+  stmt.bind([folderPath]);
+  stmt.step();
+  const r = stmt.getAsObject() as { id: number; path: string; label: string; added_at: string };
+  stmt.free();
+  return { id: r.id, path: r.path, label: r.label, addedAt: r.added_at };
+}
+
+export function removeOnedriveRoot(db: SqlJsDatabase, rootId: number): void {
+  // Manually cascade — sql.js does not enforce FK cascades without PRAGMA
+  const folders = db.exec(`SELECT id FROM onedrive_customer_folders WHERE root_id = ${rootId}`);
+  if (folders.length > 0 && folders[0].values.length > 0) {
+    for (const row of folders[0].values) {
+      const folderId = row[0] as number;
+      db.run('DELETE FROM onedrive_files WHERE folder_id = ?', [folderId]);
+    }
+  }
+  db.run('DELETE FROM onedrive_customer_folders WHERE root_id = ?', [rootId]);
+  db.run('DELETE FROM onedrive_roots WHERE id = ?', [rootId]);
+}
+
+// ── Folder discovery ──────────────────────────────────────────────────────────
+
+/**
+ * Search all configured roots for a subfolder whose name matches groupName
+ * (case-insensitive). Updates onedrive_customer_folders with status found/not_found.
+ * Returns the updated folder info for all roots.
+ */
+export function discoverCustomerFolderForGroup(
+  db: SqlJsDatabase,
+  groupId: number,
+  groupName: string,
+): OnedriveFolderInfo[] {
+  const roots = listOnedriveRoots(db);
+
+  for (const root of roots) {
+    let foundPath: string | null = null;
+
+    try {
+      if (fs.existsSync(root.path) && fs.statSync(root.path).isDirectory()) {
+        const entries = fs.readdirSync(root.path, { withFileTypes: true });
+        const match = entries.find(
+          (e) => e.isDirectory() && e.name.toLowerCase() === groupName.toLowerCase(),
+        );
+        if (match) {
+          foundPath = path.join(root.path, match.name);
+        }
+      }
+    } catch {
+      // Root not accessible — treat as not_found
+    }
+
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(group_id, root_id) DO UPDATE SET
+         folder_path   = excluded.folder_path,
+         status        = excluded.status,
+         discovered_at = excluded.discovered_at`,
+      [groupId, root.id, foundPath, foundPath ? 'found' : 'not_found'],
+    );
+  }
+
+  return getCustomerFolderInfo(db, groupId);
+}
+
+// ── Folder info query ─────────────────────────────────────────────────────────
+
+export function getCustomerFolderInfo(db: SqlJsDatabase, groupId: number): OnedriveFolderInfo[] {
+  const stmt = db.prepare(`
+    SELECT
+      cf.id,
+      cf.group_id,
+      cf.root_id,
+      r.label  AS root_label,
+      r.path   AS root_path,
+      cf.status,
+      cf.folder_path,
+      cf.discovered_at,
+      cf.scanned_at,
+      (SELECT COUNT(*) FROM onedrive_files f WHERE f.folder_id = cf.id) AS file_count
+    FROM onedrive_customer_folders cf
+    JOIN onedrive_roots r ON r.id = cf.root_id
+    WHERE cf.group_id = ?
+    ORDER BY r.label COLLATE NOCASE
+  `);
+  stmt.bind([groupId]);
+  const results: OnedriveFolderInfo[] = [];
+  try {
+    while (stmt.step()) {
+      const r = stmt.getAsObject() as {
+        id: number;
+        group_id: number;
+        root_id: number;
+        root_label: string;
+        root_path: string;
+        status: string;
+        folder_path: string | null;
+        discovered_at: string;
+        scanned_at: string | null;
+        file_count: number;
+      };
+      results.push({
+        id: r.id,
+        groupId: r.group_id,
+        rootId: r.root_id,
+        rootLabel: r.root_label,
+        rootPath: r.root_path,
+        status: r.status as 'found' | 'not_found',
+        folderPath: r.folder_path,
+        fileCount: r.file_count,
+        lastScanned: r.scanned_at,
+        discoveredAt: r.discovered_at,
+      });
+    }
+  } finally {
+    stmt.free();
+  }
+  return results;
+}
+
+// ── File scanning ─────────────────────────────────────────────────────────────
+
+const MAX_SCAN_DEPTH = 3;
+
+/**
+ * Scan files in a found customer folder, storing metadata only.
+ * Replaces all existing file records for this folder.
+ */
+export function scanFilesForFolder(db: SqlJsDatabase, folderId: number): number {
+  // Fetch the folder record
+  const stmt = db.prepare('SELECT folder_path, status FROM onedrive_customer_folders WHERE id = ?');
+  stmt.bind([folderId]);
+  if (!stmt.step()) {
+    stmt.free();
+    throw new Error(`Folder record ${folderId} not found`);
+  }
+  const row = stmt.getAsObject() as { folder_path: string | null; status: string };
+  stmt.free();
+
+  if (row.status !== 'found' || !row.folder_path) {
+    throw new Error('Cannot scan: folder not found on disk');
+  }
+
+  const folderPath = row.folder_path;
+
+  // Collect file metadata
+  const files: Array<{ name: string; ext: string | null; relPath: string; mtime: string | null; size: number | null }> = [];
+  collectFiles(folderPath, folderPath, 0, MAX_SCAN_DEPTH, files);
+
+  // Replace existing file records
+  db.run('DELETE FROM onedrive_files WHERE folder_id = ?', [folderId]);
+
+  for (const f of files) {
+    db.run(
+      `INSERT OR IGNORE INTO onedrive_files (folder_id, name, extension, relative_path, last_modified, size_bytes, scanned_at)
+       VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+      [folderId, f.name, f.ext, f.relPath, f.mtime, f.size],
+    );
+  }
+
+  db.run(
+    `UPDATE onedrive_customer_folders SET scanned_at = datetime('now') WHERE id = ?`,
+    [folderId],
+  );
+
+  return files.length;
+}
+
+function collectFiles(
+  rootDir: string,
+  currentDir: string,
+  depth: number,
+  maxDepth: number,
+  out: Array<{ name: string; ext: string | null; relPath: string; mtime: string | null; size: number | null }>,
+): void {
+  if (depth > maxDepth) return;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(currentDir, entry.name);
+    const relPath = path.relative(rootDir, fullPath);
+
+    if (entry.isFile()) {
+      let mtime: string | null = null;
+      let size: number | null = null;
+      try {
+        const stat = fs.statSync(fullPath);
+        mtime = stat.mtime.toISOString();
+        size = stat.size;
+      } catch {
+        // stat failed — store without mtime/size
+      }
+      const ext = path.extname(entry.name).toLowerCase() || null;
+      out.push({ name: entry.name, ext, relPath, mtime, size });
+    } else if (entry.isDirectory() && depth < maxDepth) {
+      collectFiles(rootDir, fullPath, depth + 1, maxDepth, out);
+    }
+  }
+}
+
+// ── File list query ───────────────────────────────────────────────────────────
+
+export function listFilesForFolder(db: SqlJsDatabase, folderId: number): OnedriveFile[] {
+  const stmt = db.prepare(`
+    SELECT id, folder_id, name, extension, relative_path, last_modified, size_bytes, scanned_at
+    FROM onedrive_files
+    WHERE folder_id = ?
+    ORDER BY relative_path COLLATE NOCASE
+  `);
+  stmt.bind([folderId]);
+  const files: OnedriveFile[] = [];
+  try {
+    while (stmt.step()) {
+      const r = stmt.getAsObject() as {
+        id: number;
+        folder_id: number;
+        name: string;
+        extension: string | null;
+        relative_path: string;
+        last_modified: string | null;
+        size_bytes: number | null;
+        scanned_at: string;
+      };
+      files.push({
+        id: r.id,
+        folderId: r.folder_id,
+        name: r.name,
+        extension: r.extension,
+        relativePath: r.relative_path,
+        lastModified: r.last_modified,
+        sizeBytes: r.size_bytes,
+        scannedAt: r.scanned_at,
+      });
+    }
+  } finally {
+    stmt.free();
+  }
+  return files;
+}

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -52,7 +52,7 @@ function initializeSchema(database: SqlJsDatabase): void {
   if (userVersion === 0) {
     database.run(getSchema());
     seedBuiltInAgents(database);
-    database.run('PRAGMA user_version = 12');
+    database.run('PRAGMA user_version = 13');
   }
 
   if (userVersion === 1) {
@@ -271,6 +271,46 @@ function initializeSchema(database: SqlJsDatabase): void {
       )
     `);
     database.run('PRAGMA user_version = 12');
+  }
+
+  if (userVersion === 12) {
+    // Migration v12 → v13: add OneDrive customer folder discovery tables
+    database.run(`
+      CREATE TABLE IF NOT EXISTS onedrive_roots (
+        id       INTEGER PRIMARY KEY AUTOINCREMENT,
+        path     TEXT NOT NULL UNIQUE,
+        label    TEXT NOT NULL,
+        added_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    database.run(`
+      CREATE TABLE IF NOT EXISTS onedrive_customer_folders (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        group_id      INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+        root_id       INTEGER NOT NULL REFERENCES onedrive_roots(id) ON DELETE CASCADE,
+        folder_path   TEXT,
+        status        TEXT NOT NULL DEFAULT 'not_found',
+        discovered_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        scanned_at    DATETIME,
+        UNIQUE(group_id, root_id)
+      )
+    `);
+    database.run('CREATE INDEX IF NOT EXISTS idx_onedrive_cf_group ON onedrive_customer_folders(group_id)');
+    database.run(`
+      CREATE TABLE IF NOT EXISTS onedrive_files (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        folder_id     INTEGER NOT NULL REFERENCES onedrive_customer_folders(id) ON DELETE CASCADE,
+        name          TEXT NOT NULL,
+        extension     TEXT,
+        relative_path TEXT NOT NULL,
+        last_modified DATETIME,
+        size_bytes    INTEGER,
+        scanned_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(folder_id, relative_path)
+      )
+    `);
+    database.run('CREATE INDEX IF NOT EXISTS idx_onedrive_files_folder ON onedrive_files(folder_id)');
+    database.run('PRAGMA user_version = 13');
   }
 }
 

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -52,7 +52,7 @@ function initializeSchema(database: SqlJsDatabase): void {
   if (userVersion === 0) {
     database.run(getSchema());
     seedBuiltInAgents(database);
-    database.run('PRAGMA user_version = 13');
+    database.run('PRAGMA user_version = 15');
   }
 
   if (userVersion === 1) {
@@ -311,6 +311,47 @@ function initializeSchema(database: SqlJsDatabase): void {
     `);
     database.run('CREATE INDEX IF NOT EXISTS idx_onedrive_files_folder ON onedrive_files(folder_id)');
     database.run('PRAGMA user_version = 13');
+  }
+
+  if (userVersion === 14) {
+    // Migration v14 → v15: add OneDrive customer folder discovery tables
+    // (for users who ran the browser-companion build which used v12→v13 and v13→v14)
+    database.run(`
+      CREATE TABLE IF NOT EXISTS onedrive_roots (
+        id       INTEGER PRIMARY KEY AUTOINCREMENT,
+        path     TEXT NOT NULL UNIQUE,
+        label    TEXT NOT NULL,
+        added_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    database.run(`
+      CREATE TABLE IF NOT EXISTS onedrive_customer_folders (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        group_id      INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+        root_id       INTEGER NOT NULL REFERENCES onedrive_roots(id) ON DELETE CASCADE,
+        folder_path   TEXT,
+        status        TEXT NOT NULL DEFAULT 'not_found',
+        discovered_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        scanned_at    DATETIME,
+        UNIQUE(group_id, root_id)
+      )
+    `);
+    database.run('CREATE INDEX IF NOT EXISTS idx_onedrive_cf_group ON onedrive_customer_folders(group_id)');
+    database.run(`
+      CREATE TABLE IF NOT EXISTS onedrive_files (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        folder_id     INTEGER NOT NULL REFERENCES onedrive_customer_folders(id) ON DELETE CASCADE,
+        name          TEXT NOT NULL,
+        extension     TEXT,
+        relative_path TEXT NOT NULL,
+        last_modified DATETIME,
+        size_bytes    INTEGER,
+        scanned_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(folder_id, relative_path)
+      )
+    `);
+    database.run('CREATE INDEX IF NOT EXISTS idx_onedrive_files_folder ON onedrive_files(folder_id)');
+    database.run('PRAGMA user_version = 15');
   }
 }
 

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -245,5 +245,40 @@ export function getSchema(): string {
         added_at       DATETIME DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (group_id, github_repo_id)
     );
+
+    -- OneDrive root folders (one per entity/company)
+    CREATE TABLE IF NOT EXISTS onedrive_roots (
+        id       INTEGER PRIMARY KEY AUTOINCREMENT,
+        path     TEXT NOT NULL UNIQUE,
+        label    TEXT NOT NULL,
+        added_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- Customer folder discovery result per (group × root)
+    CREATE TABLE IF NOT EXISTS onedrive_customer_folders (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        group_id      INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+        root_id       INTEGER NOT NULL REFERENCES onedrive_roots(id) ON DELETE CASCADE,
+        folder_path   TEXT,
+        status        TEXT NOT NULL DEFAULT 'not_found',
+        discovered_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        scanned_at    DATETIME,
+        UNIQUE(group_id, root_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_onedrive_cf_group ON onedrive_customer_folders(group_id);
+
+    -- File metadata only (no content) — linked to a customer folder
+    CREATE TABLE IF NOT EXISTS onedrive_files (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        folder_id     INTEGER NOT NULL REFERENCES onedrive_customer_folders(id) ON DELETE CASCADE,
+        name          TEXT NOT NULL,
+        extension     TEXT,
+        relative_path TEXT NOT NULL,
+        last_modified DATETIME,
+        size_bytes    INTEGER,
+        scanned_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(folder_id, relative_path)
+    );
+    CREATE INDEX IF NOT EXISTS idx_onedrive_files_folder ON onedrive_files(folder_id);
   `;
 }

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -126,6 +126,14 @@ const EXPECTED_CHANNELS = [
   'groups:remove-local-repo',
   'groups:add-github-repo',
   'groups:remove-github-repo',
+  // onedrive plugin
+  'onedrive:list-roots',
+  'onedrive:add-root',
+  'onedrive:remove-root',
+  'onedrive:discover-for-group',
+  'onedrive:get-folder-info',
+  'onedrive:rescan-files',
+  'onedrive:list-files-for-folder',
 ] as const;
 
 describe('IPC handler registration', () => {

--- a/tests/unit/onedrive.test.ts
+++ b/tests/unit/onedrive.test.ts
@@ -1,0 +1,302 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { getSchema } from '../../src/storage/schema';
+import {
+  listOnedriveRoots,
+  addOnedriveRoot,
+  removeOnedriveRoot,
+  discoverCustomerFolderForGroup,
+  getCustomerFolderInfo,
+  scanFilesForFolder,
+  listFilesForFolder,
+} from '../../src/services/onedrive';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function insertGroup(db: SqlJsDatabase, name: string): number {
+  db.run(
+    `INSERT INTO groups (name, created_at, updated_at) VALUES (?, datetime('now'), datetime('now'))`,
+    [name],
+  );
+  const stmt = db.prepare('SELECT last_insert_rowid() AS id');
+  stmt.step();
+  const { id } = stmt.getAsObject() as { id: number };
+  stmt.free();
+  return id as number;
+}
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-od-test-'));
+}
+
+function removeDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+describe('OneDrive service', () => {
+  let db: SqlJsDatabase;
+  const tempDirs: string[] = [];
+
+  const makeTempAndTrack = () => {
+    const d = makeTempDir();
+    tempDirs.push(d);
+    return d;
+  };
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+  });
+
+  afterEach(() => {
+    db.close();
+    for (const d of tempDirs.splice(0)) {
+      removeDir(d);
+    }
+  });
+
+  // ── Schema ──────────────────────────────────────────────────────────────────
+
+  it('creates onedrive tables in schema', () => {
+    const result = db.exec("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name");
+    const names = result[0].values.map((r: unknown[]) => r[0] as string);
+    expect(names).toContain('onedrive_roots');
+    expect(names).toContain('onedrive_customer_folders');
+    expect(names).toContain('onedrive_files');
+  });
+
+  // ── Roots CRUD ───────────────────────────────────────────────────────────────
+
+  it('listOnedriveRoots returns empty list initially', () => {
+    expect(listOnedriveRoots(db)).toHaveLength(0);
+  });
+
+  it('addOnedriveRoot creates and returns a root', () => {
+    const root = addOnedriveRoot(db, 'C:\\OneDrive\\ClientA', 'Client A');
+    expect(root.id).toBeGreaterThan(0);
+    expect(root.path).toBe('C:\\OneDrive\\ClientA');
+    expect(root.label).toBe('Client A');
+    expect(root.addedAt).toBeTruthy();
+  });
+
+  it('listOnedriveRoots returns added roots sorted by label', () => {
+    addOnedriveRoot(db, 'C:\\OD\\Beta', 'Beta Corp');
+    addOnedriveRoot(db, 'C:\\OD\\Alpha', 'Alpha Corp');
+    const roots = listOnedriveRoots(db);
+    expect(roots).toHaveLength(2);
+    expect(roots[0].label).toBe('Alpha Corp');
+    expect(roots[1].label).toBe('Beta Corp');
+  });
+
+  it('addOnedriveRoot rejects duplicate paths', () => {
+    addOnedriveRoot(db, 'C:\\OD\\Shared', 'Shared');
+    expect(() => addOnedriveRoot(db, 'C:\\OD\\Shared', 'Duplicate')).toThrow();
+  });
+
+  it('removeOnedriveRoot deletes the root', () => {
+    const root = addOnedriveRoot(db, 'C:\\OD\\Temp', 'Temp');
+    removeOnedriveRoot(db, root.id);
+    expect(listOnedriveRoots(db)).toHaveLength(0);
+  });
+
+  it('removeOnedriveRoot cascades to customer_folders and files', () => {
+    const root = addOnedriveRoot(db, 'C:\\OD\\X', 'X');
+    const gid = insertGroup(db, 'Customer X');
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, 'C:\\OD\\X\\Customer X', 'found', datetime('now'))`,
+      [gid, root.id],
+    );
+    const cf = db.exec('SELECT id FROM onedrive_customer_folders')[0].values[0][0] as number;
+    db.run(
+      `INSERT INTO onedrive_files (folder_id, name, relative_path) VALUES (?, 'file.pdf', 'file.pdf')`,
+      [cf],
+    );
+
+    removeOnedriveRoot(db, root.id);
+
+    const cfCount = db.exec('SELECT COUNT(*) FROM onedrive_customer_folders')[0].values[0][0] as number;
+    const fCount = db.exec('SELECT COUNT(*) FROM onedrive_files')[0].values[0][0] as number;
+    expect(cfCount).toBe(0);
+    expect(fCount).toBe(0);
+  });
+
+  // ── Folder discovery ─────────────────────────────────────────────────────────
+
+  it('discoverCustomerFolderForGroup stores not_found when root does not exist', () => {
+    const root = addOnedriveRoot(db, 'Z:\\NonExistent\\Path', 'Missing');
+    const gid = insertGroup(db, 'Acme');
+    const info = discoverCustomerFolderForGroup(db, gid, 'Acme');
+    expect(info).toHaveLength(1);
+    expect(info[0].status).toBe('not_found');
+    expect(info[0].rootId).toBe(root.id);
+    expect(info[0].folderPath).toBeNull();
+  });
+
+  it('discoverCustomerFolderForGroup finds matching subfolder case-insensitively', () => {
+    // Create a real temp directory with a matching subfolder (different case)
+    const rootDir = makeTempAndTrack();
+    const subDir = path.join(rootDir, 'ACME Corp'); // upper-case
+    fs.mkdirSync(subDir);
+
+    const root = addOnedriveRoot(db, rootDir, 'Work');
+    const gid = insertGroup(db, 'acme corp'); // lower-case
+
+    const info = discoverCustomerFolderForGroup(db, gid, 'acme corp');
+    expect(info).toHaveLength(1);
+    expect(info[0].status).toBe('found');
+    expect(info[0].folderPath).toContain('ACME Corp');
+  });
+
+  it('discoverCustomerFolderForGroup creates records for multiple roots', () => {
+    addOnedriveRoot(db, 'Z:\\RootA', 'Root A');
+    addOnedriveRoot(db, 'Z:\\RootB', 'Root B');
+    const gid = insertGroup(db, 'CustomerZ');
+    const info = discoverCustomerFolderForGroup(db, gid, 'CustomerZ');
+    expect(info).toHaveLength(2);
+    expect(info.every((f) => f.status === 'not_found')).toBe(true);
+  });
+
+  it('discoverCustomerFolderForGroup is idempotent (upsert)', () => {
+    addOnedriveRoot(db, 'Z:\\R', 'R');
+    const gid = insertGroup(db, 'Test');
+    discoverCustomerFolderForGroup(db, gid, 'Test');
+    discoverCustomerFolderForGroup(db, gid, 'Test');
+
+    const count = db.exec('SELECT COUNT(*) FROM onedrive_customer_folders')[0].values[0][0] as number;
+    expect(count).toBe(1);
+  });
+
+  // ── Folder info query ─────────────────────────────────────────────────────────
+
+  it('getCustomerFolderInfo returns empty when no roots configured', () => {
+    const gid = insertGroup(db, 'NoRoots');
+    expect(getCustomerFolderInfo(db, gid)).toHaveLength(0);
+  });
+
+  it('getCustomerFolderInfo includes file_count', () => {
+    const root = addOnedriveRoot(db, 'C:\\OD\\Y', 'Y');
+    const gid = insertGroup(db, 'With Files');
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, 'C:\\OD\\Y\\With Files', 'found', datetime('now'))`,
+      [gid, root.id],
+    );
+    const cf = db.exec('SELECT id FROM onedrive_customer_folders')[0].values[0][0] as number;
+    db.run(`INSERT INTO onedrive_files (folder_id, name, relative_path) VALUES (?, 'a.pdf', 'a.pdf')`, [cf]);
+    db.run(`INSERT INTO onedrive_files (folder_id, name, relative_path) VALUES (?, 'b.docx', 'b.docx')`, [cf]);
+
+    const info = getCustomerFolderInfo(db, gid);
+    expect(info).toHaveLength(1);
+    expect(info[0].fileCount).toBe(2);
+  });
+
+  // ── File scanning ─────────────────────────────────────────────────────────────
+
+  it('scanFilesForFolder throws when folder is not_found', () => {
+    const root = addOnedriveRoot(db, 'Z:\\Missing', 'M');
+    const gid = insertGroup(db, 'Nope');
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, NULL, 'not_found', datetime('now'))`,
+      [gid, root.id],
+    );
+    const cf = db.exec('SELECT id FROM onedrive_customer_folders')[0].values[0][0] as number;
+    expect(() => scanFilesForFolder(db, cf)).toThrow();
+  });
+
+  it('scanFilesForFolder indexes files from disk', () => {
+    const customerDir = makeTempAndTrack();
+    fs.writeFileSync(path.join(customerDir, 'report.pdf'), 'mock content');
+    fs.writeFileSync(path.join(customerDir, 'notes.docx'), 'mock content');
+
+    const root = addOnedriveRoot(db, path.dirname(customerDir), 'Z');
+    const gid = insertGroup(db, 'FileTest');
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, ?, 'found', datetime('now'))`,
+      [gid, root.id, customerDir],
+    );
+    const cf = db.exec('SELECT id FROM onedrive_customer_folders')[0].values[0][0] as number;
+
+    const count = scanFilesForFolder(db, cf);
+    expect(count).toBe(2);
+
+    const files = listFilesForFolder(db, cf);
+    expect(files).toHaveLength(2);
+    const names = files.map((f) => f.name);
+    expect(names).toContain('report.pdf');
+    expect(names).toContain('notes.docx');
+  });
+
+  it('scanFilesForFolder stores last_modified and size', () => {
+    const customerDir = makeTempAndTrack();
+    fs.writeFileSync(path.join(customerDir, 'contract.pdf'), 'content here');
+
+    const root = addOnedriveRoot(db, path.dirname(customerDir), 'ZZ');
+    const gid = insertGroup(db, 'ModTest');
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, ?, 'found', datetime('now'))`,
+      [gid, root.id, customerDir],
+    );
+    const cf = db.exec('SELECT id FROM onedrive_customer_folders')[0].values[0][0] as number;
+
+    scanFilesForFolder(db, cf);
+    const files = listFilesForFolder(db, cf);
+    expect(files[0].lastModified).toBeTruthy();
+    expect(files[0].sizeBytes).toBeGreaterThan(0);
+  });
+
+  it('scanFilesForFolder replaces existing file records', () => {
+    const customerDir = makeTempAndTrack();
+    fs.writeFileSync(path.join(customerDir, 'new.pdf'), 'new content');
+
+    const root = addOnedriveRoot(db, path.dirname(customerDir), 'W');
+    const gid = insertGroup(db, 'Rescan');
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, ?, 'found', datetime('now'))`,
+      [gid, root.id, customerDir],
+    );
+    const cf = db.exec('SELECT id FROM onedrive_customer_folders')[0].values[0][0] as number;
+
+    // Pre-populate with stale data
+    db.run(`INSERT INTO onedrive_files (folder_id, name, relative_path) VALUES (?, 'old.pdf', 'old.pdf')`, [cf]);
+
+    scanFilesForFolder(db, cf);
+    const files = listFilesForFolder(db, cf);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe('new.pdf');
+  });
+
+  // ── File list query ───────────────────────────────────────────────────────────
+
+  it('listFilesForFolder returns empty array for unknown folderId', () => {
+    expect(listFilesForFolder(db, 9999)).toHaveLength(0);
+  });
+
+  it('listFilesForFolder returns files sorted by relative_path', () => {
+    const root = addOnedriveRoot(db, 'C:\\OD\\Sort', 'Sort');
+    const gid = insertGroup(db, 'SortTest');
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status, discovered_at)
+       VALUES (?, ?, 'C:\\OD\\Sort\\SortTest', 'found', datetime('now'))`,
+      [gid, root.id],
+    );
+    const cf = db.exec('SELECT id FROM onedrive_customer_folders')[0].values[0][0] as number;
+    db.run(`INSERT INTO onedrive_files (folder_id, name, relative_path) VALUES (?, 'z.pdf', 'z.pdf')`, [cf]);
+    db.run(`INSERT INTO onedrive_files (folder_id, name, relative_path) VALUES (?, 'a.docx', 'a.docx')`, [cf]);
+
+    const files = listFilesForFolder(db, cf);
+    expect(files[0].name).toBe('a.docx');
+    expect(files[1].name).toBe('z.pdf');
+  });
+});


### PR DESCRIPTION
## Overview

Adds support for configuring one or more OneDrive root directories (one per entity/company you work for) and automatically discovering customer folders that match a group name. File metadata is indexed without downloading any file content.

## Features

### Global OneDrive Root Configuration (Settings)
- New **OneDrive Customer Data Roots** section in Settings
- Add a root folder: enter a label (e.g. "Contoso") + browse to the OneDrive root folder
- Multiple roots supported — one per entity you work for
- Remove a root (cascades to all linked folder records)

### Customer Folder Discovery (Groups panel)
- New **Customer Data (OneDrive)** sub-section in the group detail panel
- Click **🔍 Discover** to scan all configured roots for a subfolder whose name matches the group name (case-insensitive)
- Per-root status badge: ✓ found / ✕ not found
- Shows file count + last scanned date when found
- **↻ Rescan Files** button to re-index files in a found folder
- **▼ / ▲** toggle to expand/collapse the file list

### File Metadata Indexing
- Walks the customer folder recursively (up to 3 levels deep)
- Stores: file name, extension, relative path, last modified date, size in bytes
- **No file content is ever read or downloaded**

## New DB Tables

| Table | Purpose |
|-------|---------|
| `onedrive_roots` | Configured root folders with labels |
| `onedrive_customer_folders` | Discovery result per (group × root): found/not_found |
| `onedrive_files` | File metadata indexed from found folders |

## Changes

- **Schema**: 3 new tables + indexes
- **Service**: `src/services/onedrive.ts` — all DB and filesystem logic
- **Plugin**: `src/plugins/onedrive/handler.ts` — 7 IPC channels
- **Types**: New `OnedriveRoot`, `OnedriveFolderInfo`, `OnedriveFile` types; `GroupDetail.onedriveFolders` added
- **Groups service**: `getGroup()` now populates `onedriveFolders`
- **UI**: Settings OneDrive section + GroupsPanel customer data sub-panel
- **Tests**: 19 unit tests using real temp directories (no fs mocking)
- All 356 tests pass ✅