### PR TITLE
feat: OneNote section reader — step 1 for RAG indexing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@joplin/onenote-converter": "^3.5.1",
         "@types/node": "^25.5.2",
         "@vitest/coverage-v8": "^4.1.3",
         "concurrently": "^9.2.1",
@@ -1328,6 +1329,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@joplin/onenote-converter": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@joplin/onenote-converter/-/onenote-converter-3.5.1.tgz",
+      "integrity": "sha512-8IxoG2UkNLLn2yC8Ipwh9oJvFBAOFyUr5akl8KpEOd/JlLGvQ/59emnCkLpnLinRI1+lWDTk6g4MSf0bb6lXTA==",
+      "dev": true,
+      "license": "MPL-2.0-no-copyleft-exception"
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jarvis",
   "version": "0.1.0",
-  "description": "Jarvis \u2014 a locally-hosted personal assistant agent for GitHub repository maintenance",
+  "description": "Jarvis — a locally-hosted personal assistant agent for GitHub repository maintenance",
   "main": "dist/main/index.js",
   "scripts": {
     "build": "tsc && node scripts/build-renderer.mjs && npm run copy-static",
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@joplin/onenote-converter": "^3.5.1",
     "@types/node": "^25.5.2",
     "@vitest/coverage-v8": "^4.1.3",
     "concurrently": "^9.2.1",

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -206,4 +206,6 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('onedrive:rescan-files', folderId),
   onedriveListFilesForFolder: (folderId: number) =>
     ipcRenderer.invoke('onedrive:list-files-for-folder', folderId),
+  onedriveReadOneNoteFile: (filePath: string) =>
+    ipcRenderer.invoke('onedrive:read-onenote-file', filePath),
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -208,4 +208,8 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('onedrive:list-files-for-folder', folderId),
   onedriveReadOneNoteFile: (filePath: string) =>
     ipcRenderer.invoke('onedrive:read-onenote-file', filePath),
+  onedriveReadUrlShortcut: (filePath: string) =>
+    ipcRenderer.invoke('onedrive:read-url-shortcut', filePath),
+  shellOpenUrl: (url: string) =>
+    ipcRenderer.invoke('shell:open-url', url),
 });

--- a/src/plugins/groups/GroupsPanel.tsx
+++ b/src/plugins/groups/GroupsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'preact/hooks';
-import type { Group, GroupDetail, LocalRepo, OnedriveFolderInfo, OnedriveFile } from '../types';
+import type { Group, GroupDetail, LocalRepo, OnedriveFolderInfo, OnedriveFile, UrlShortcutInfo } from '../types';
 
 // ── GroupsPanel ───────────────────────────────────────────────────────────────
 // Allows users to create, rename, delete groups and assign local/remote repos
@@ -34,6 +34,8 @@ export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
   const [onedriveRescanningId, setOnedriveRescanningId] = useState<number | null>(null);
   const [expandedFolderId, setExpandedFolderId] = useState<number | null>(null);
   const [folderFiles, setFolderFiles] = useState<Record<number, OnedriveFile[]>>({});
+  // Cache parsed .url shortcut info keyed by file path
+  const [urlShortcuts, setUrlShortcuts] = useState<Record<string, UrlShortcutInfo & { loading?: boolean }>>({});
 
   const refresh = async () => {
     try {
@@ -188,6 +190,27 @@ export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
     if (!folderFiles[folder.id]) {
       const files = await window.jarvis.onedriveListFilesForFolder(folder.id);
       setFolderFiles((prev) => ({ ...prev, [folder.id]: files }));
+      // Pre-load URL shortcut info for .url files
+      if (folder.folderPath) {
+        for (const f of files.filter((f) => f.extension === '.url')) {
+          const fullPath = folder.folderPath + '\\' + f.relativePath;
+          if (!urlShortcuts[fullPath]) {
+            setUrlShortcuts((prev) => ({ ...prev, [fullPath]: { url: '', isOneNote: false, isSharePoint: false, loading: true } }));
+            window.jarvis.onedriveReadUrlShortcut(fullPath).then((result) => {
+              if (result.ok && result.url) {
+                setUrlShortcuts((prev) => ({
+                  ...prev,
+                  [fullPath]: { url: result.url!, isOneNote: result.isOneNote ?? false, isSharePoint: result.isSharePoint ?? false },
+                }));
+              } else {
+                setUrlShortcuts((prev) => ({ ...prev, [fullPath]: { url: '', isOneNote: false, isSharePoint: false } }));
+              }
+            }).catch(() => {
+              setUrlShortcuts((prev) => ({ ...prev, [fullPath]: { url: '', isOneNote: false, isSharePoint: false } }));
+            });
+          }
+        }
+      }
     }
   };
 
@@ -444,9 +467,12 @@ export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
                         ) : (
                           (folderFiles[folder.id] ?? []).map((f) => {
                             const isOneNote = f.extension === '.one';
+                            const isUrlShortcut = f.extension === '.url';
                             const fullPath = folder.folderPath
                               ? folder.folderPath + '\\' + f.relativePath
                               : null;
+                            const shortcutInfo = fullPath ? urlShortcuts[fullPath] : null;
+                            const isOneNoteUrl = isUrlShortcut && shortcutInfo?.isOneNote;
                             return (
                               <div
                                 key={f.id}
@@ -456,8 +482,16 @@ export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
                                   {isOneNote && (
                                     <span style={{ fontSize: '0.78rem', flexShrink: 0 }}>📓</span>
                                   )}
+                                  {isUrlShortcut && (
+                                    <span style={{ fontSize: '0.78rem', flexShrink: 0 }}>{isOneNoteUrl ? '📓🌐' : '🔗'}</span>
+                                  )}
                                   <div style={{ minWidth: 0 }}>
-                                    <span style={{ fontSize: '0.78rem', color: isOneNote ? '#cce' : '#bbc' }}>{f.name}</span>
+                                    <span style={{ fontSize: '0.78rem', color: (isOneNote || isOneNoteUrl) ? '#cce' : '#bbc' }}>{f.name}</span>
+                                    {isUrlShortcut && shortcutInfo?.isSharePoint && (
+                                      <span style={{ marginLeft: '0.35rem', fontSize: '0.68rem', color: '#88a', background: '#1a1a30', padding: '0.05rem 0.25rem', borderRadius: '3px' }}>
+                                        SharePoint
+                                      </span>
+                                    )}
                                     {f.relativePath !== f.name && (
                                       <span style={{ fontSize: '0.68rem', color: '#556', marginLeft: '0.3rem', fontFamily: 'monospace' }}>
                                         {f.relativePath}
@@ -477,6 +511,16 @@ export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
                                       onClick={() => onOpenOneNote(fullPath)}
                                     >
                                       📖
+                                    </button>
+                                  )}
+                                  {isUrlShortcut && shortcutInfo?.url && (
+                                    <button
+                                      title={`Open in ${shortcutInfo.isOneNote ? 'OneNote' : 'browser'}: ${shortcutInfo.url}`}
+                                      class="btn-secondary"
+                                      style={{ padding: '0.05rem 0.3rem', fontSize: '0.7rem' }}
+                                      onClick={() => void window.jarvis.shellOpenUrl(shortcutInfo.url)}
+                                    >
+                                      🌐
                                     </button>
                                   )}
                                 </div>

--- a/src/plugins/groups/GroupsPanel.tsx
+++ b/src/plugins/groups/GroupsPanel.tsx
@@ -7,9 +7,10 @@ import type { Group, GroupDetail, LocalRepo, OnedriveFolderInfo, OnedriveFile } 
 
 interface GroupsPanelProps {
   onClose: () => void;
+  onOpenOneNote?: (filePath: string) => void;
 }
 
-export function GroupsPanel({ onClose }: GroupsPanelProps) {
+export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
   const [groups, setGroups] = useState<Group[]>([]);
   const [selectedGroup, setSelectedGroup] = useState<GroupDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -441,24 +442,47 @@ export function GroupsPanel({ onClose }: GroupsPanelProps) {
                         {(folderFiles[folder.id] ?? []).length === 0 ? (
                           <div style={{ padding: '0.35rem 0.5rem', fontSize: '0.77rem', color: '#556' }}>No files indexed.</div>
                         ) : (
-                          (folderFiles[folder.id] ?? []).map((f) => (
-                            <div
-                              key={f.id}
-                              style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.2rem 0.5rem', borderBottom: '1px solid #1e1e28' }}
-                            >
-                              <div style={{ minWidth: 0 }}>
-                                <span style={{ fontSize: '0.78rem', color: '#bbc' }}>{f.name}</span>
-                                {f.relativePath !== f.name && (
-                                  <span style={{ fontSize: '0.68rem', color: '#556', marginLeft: '0.3rem', fontFamily: 'monospace' }}>
-                                    {f.relativePath}
+                          (folderFiles[folder.id] ?? []).map((f) => {
+                            const isOneNote = f.extension === '.one';
+                            const fullPath = folder.folderPath
+                              ? folder.folderPath + '\\' + f.relativePath
+                              : null;
+                            return (
+                              <div
+                                key={f.id}
+                                style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.2rem 0.5rem', borderBottom: '1px solid #1e1e28' }}
+                              >
+                                <div style={{ minWidth: 0, display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+                                  {isOneNote && (
+                                    <span style={{ fontSize: '0.78rem', flexShrink: 0 }}>📓</span>
+                                  )}
+                                  <div style={{ minWidth: 0 }}>
+                                    <span style={{ fontSize: '0.78rem', color: isOneNote ? '#cce' : '#bbc' }}>{f.name}</span>
+                                    {f.relativePath !== f.name && (
+                                      <span style={{ fontSize: '0.68rem', color: '#556', marginLeft: '0.3rem', fontFamily: 'monospace' }}>
+                                        {f.relativePath}
+                                      </span>
+                                    )}
+                                  </div>
+                                </div>
+                                <div style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', flexShrink: 0, paddingLeft: '0.5rem' }}>
+                                  <span style={{ fontSize: '0.7rem', color: '#667' }}>
+                                    {f.lastModified ? new Date(f.lastModified).toLocaleDateString() : '—'}
                                   </span>
-                                )}
+                                  {isOneNote && fullPath && onOpenOneNote && (
+                                    <button
+                                      title="View note content"
+                                      class="btn-secondary"
+                                      style={{ padding: '0.05rem 0.3rem', fontSize: '0.7rem' }}
+                                      onClick={() => onOpenOneNote(fullPath)}
+                                    >
+                                      📖
+                                    </button>
+                                  )}
+                                </div>
                               </div>
-                              <span style={{ fontSize: '0.7rem', color: '#667', flexShrink: 0, paddingLeft: '0.5rem' }}>
-                                {f.lastModified ? new Date(f.lastModified).toLocaleDateString() : '—'}
-                              </span>
-                            </div>
-                          ))
+                            );
+                          })
                         )}
                       </div>
                     )}

--- a/src/plugins/groups/OneNoteSectionPanel.tsx
+++ b/src/plugins/groups/OneNoteSectionPanel.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect } from 'preact/hooks';
+import type { OneNoteSectionContent, OneNotePageContent } from '../types';
+
+// ── OneNoteSectionPanel ───────────────────────────────────────────────────────
+// Shows the extracted text of a single .one section file — its pages, titles,
+// dates, and body content. Opens as a sub-panel to the right of GroupsPanel.
+
+interface Props {
+  filePath: string;
+  onClose: () => void;
+}
+
+export function OneNoteSectionPanel({ filePath, onClose }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [section, setSection] = useState<OneNoteSectionContent | null>(null);
+  const [expandedPages, setExpandedPages] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    setSection(null);
+    setExpandedPages(new Set());
+
+    window.jarvis.onedriveReadOneNoteFile(filePath)
+      .then((result) => {
+        if (result.ok && result.section) {
+          setSection(result.section);
+        } else {
+          setError(result.error ?? 'Failed to read OneNote file');
+        }
+      })
+      .catch((err: unknown) => {
+        setError(String(err));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [filePath]);
+
+  const togglePage = (pageIndex: number) => {
+    setExpandedPages((prev) => {
+      const next = new Set(prev);
+      if (next.has(pageIndex)) {
+        next.delete(pageIndex);
+      } else {
+        next.add(pageIndex);
+      }
+      return next;
+    });
+  };
+
+  // Derive section name from path for the header (fallback before data loads)
+  const sectionName = section?.sectionName
+    ?? filePath.replace(/\\/g, '/').split('/').pop()?.replace(/\.one$/i, '')
+    ?? 'OneNote Section';
+
+  return (
+    <div class="org-panel onenote-section-panel">
+      <div class="org-panel-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span>📓 {sectionName}</span>
+        <button class="repo-panel-close" title="Close" onClick={onClose}>&times;</button>
+      </div>
+
+      {loading && (
+        <div style={{ color: '#99a', fontSize: '0.82rem', padding: '0.5rem 0' }}>Reading file…</div>
+      )}
+
+      {!loading && error && (
+        <div style={{ color: '#f88', fontSize: '0.82rem', padding: '0.5rem 0', wordBreak: 'break-word' }}>
+          {error}
+        </div>
+      )}
+
+      {!loading && section && (
+        <>
+          <div style={{ fontSize: '0.73rem', color: '#556', marginBottom: '0.65rem', fontStyle: 'italic' }}>
+            {section.pageCount} page{section.pageCount !== 1 ? 's' : ''}
+          </div>
+
+          {section.pages.map((page) => (
+            <PageCard
+              key={page.pageIndex}
+              page={page}
+              expanded={expandedPages.has(page.pageIndex)}
+              onToggle={() => togglePage(page.pageIndex)}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── PageCard ──────────────────────────────────────────────────────────────────
+
+const CONTENT_PREVIEW_CHARS = 320;
+
+function PageCard({
+  page,
+  expanded,
+  onToggle,
+}: {
+  page: OneNotePageContent;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const hasLongContent = page.content.length > CONTENT_PREVIEW_CHARS;
+  const displayContent =
+    expanded || !hasLongContent
+      ? page.content
+      : page.content.slice(0, CONTENT_PREVIEW_CHARS) + '…';
+
+  return (
+    <div
+      style={{
+        marginBottom: '0.6rem',
+        borderRadius: '5px',
+        background: '#1a1a26',
+        padding: '0.5rem 0.6rem',
+        border: '1px solid #232340',
+      }}
+    >
+      {/* Page heading row */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: '0.15rem' }}>
+        <div
+          style={{
+            fontWeight: 600,
+            fontSize: '0.84rem',
+            color: '#cce',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            flex: 1,
+          }}
+          title={page.title || undefined}
+        >
+          {page.title || `Page ${page.pageIndex}`}
+        </div>
+        <div style={{ fontSize: '0.7rem', color: '#445', flexShrink: 0, paddingLeft: '0.5rem' }}>
+          #{page.pageIndex}
+        </div>
+      </div>
+
+      {/* Date */}
+      {page.date && (
+        <div style={{ fontSize: '0.72rem', color: '#778', marginBottom: '0.3rem' }}>
+          {page.date}
+        </div>
+      )}
+
+      {/* Body text */}
+      {page.content ? (
+        <>
+          <div
+            style={{
+              fontSize: '0.77rem',
+              color: '#aab',
+              lineHeight: '1.55',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {displayContent}
+          </div>
+          {hasLongContent && (
+            <button
+              onClick={onToggle}
+              style={{
+                marginTop: '0.3rem',
+                background: 'none',
+                border: 'none',
+                color: '#66a',
+                fontSize: '0.72rem',
+                cursor: 'pointer',
+                padding: 0,
+              }}
+            >
+              {expanded ? '▲ Show less' : '▼ Show more'}
+            </button>
+          )}
+        </>
+      ) : (
+        <div style={{ fontSize: '0.74rem', color: '#445', fontStyle: 'italic' }}>
+          No body text found
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/plugins/onedrive/handler.ts
+++ b/src/plugins/onedrive/handler.ts
@@ -1,5 +1,5 @@
 // ── OneDrive IPC handlers ─────────────────────────────────────────────────────
-import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { ipcMain, dialog, BrowserWindow, shell } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import { saveDatabase } from '../../storage/database';
 import {
@@ -12,6 +12,7 @@ import {
   listFilesForFolder,
 } from '../../services/onedrive';
 import { readOneNoteSection } from '../../services/onenote-reader';
+import { readUrlShortcut } from '../../services/url-shortcut';
 import { getGroup } from '../../services/groups';
 
 export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
@@ -124,5 +125,29 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
       const msg = err instanceof Error ? err.message : String(err);
       return { ok: false, error: msg };
     }
+  });
+
+  ipcMain.handle('onedrive:read-url-shortcut', (_event, filePath: string) => {
+    if (typeof filePath !== 'string' || filePath.trim().length === 0) {
+      return { ok: false, error: 'filePath is required' };
+    }
+    if (!filePath.toLowerCase().endsWith('.url')) {
+      return { ok: false, error: 'Only .url files are supported' };
+    }
+    try {
+      const info = readUrlShortcut(filePath);
+      return { ok: true, ...info };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle('shell:open-url', (_event, url: string) => {
+    if (typeof url !== 'string') return { ok: false, error: 'url is required' };
+    const safe = url.startsWith('https://') || url.startsWith('http://') || url.startsWith('onenote:');
+    if (!safe) return { ok: false, error: 'Unsupported URL scheme' };
+    void shell.openExternal(url);
+    return { ok: true };
   });
 }

--- a/src/plugins/onedrive/handler.ts
+++ b/src/plugins/onedrive/handler.ts
@@ -11,6 +11,7 @@ import {
   scanFilesForFolder,
   listFilesForFolder,
 } from '../../services/onedrive';
+import { readOneNoteSection } from '../../services/onenote-reader';
 import { getGroup } from '../../services/groups';
 
 export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
@@ -107,5 +108,21 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
   ipcMain.handle('onedrive:list-files-for-folder', (_event, folderId: number) => {
     if (typeof folderId !== 'number') return [];
     return listFilesForFolder(db, folderId);
+  });
+
+  ipcMain.handle('onedrive:read-onenote-file', (_event, filePath: string) => {
+    if (typeof filePath !== 'string' || filePath.trim().length === 0) {
+      return { ok: false, error: 'filePath is required' };
+    }
+    if (!filePath.toLowerCase().endsWith('.one')) {
+      return { ok: false, error: 'Only .one files are supported' };
+    }
+    try {
+      const section = readOneNoteSection(filePath);
+      return { ok: true, section };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
   });
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -270,6 +270,32 @@ export interface FailedWorkflowRun {
   html_url: string;
 }
 
+// ── OneNote types ─────────────────────────────────────────────────────────────
+
+export interface OneNotePageContent {
+  /** 1-based page index within the section file. */
+  pageIndex: number;
+  /** Best-effort page title (may be empty for untitled pages). */
+  title: string;
+  /** Best-effort page date string (e.g. "Thursday, September 25, 2025"). */
+  date: string;
+  /** All body text found in this page, joined with spaces. */
+  content: string;
+}
+
+export interface OneNoteSectionContent {
+  /** Human-readable name derived from the filename (without extension). */
+  sectionName: string;
+  /** Absolute path of the source `.one` file. */
+  filePath: string;
+  /** Number of pages found in this section. */
+  pageCount: number;
+  /** Per-page content. */
+  pages: OneNotePageContent[];
+  /** Full concatenated text — convenient for whole-section RAG. */
+  textContent: string;
+}
+
 // ── OneDrive types ────────────────────────────────────────────────────────────
 
 export interface OnedriveRoot {
@@ -465,6 +491,7 @@ export interface JarvisApi {
   onedriveGetFolderInfo(groupId: number): Promise<OnedriveFolderInfo[]>;
   onedriveRescanFiles(folderId: number): Promise<{ ok: boolean; fileCount?: number; error?: string }>;
   onedriveListFilesForFolder(folderId: number): Promise<OnedriveFile[]>;
+  onedriveReadOneNoteFile(filePath: string): Promise<{ ok: boolean; section?: OneNoteSectionContent; error?: string }>;
 }
 
 declare global {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -296,6 +296,17 @@ export interface OneNoteSectionContent {
   textContent: string;
 }
 
+// ── URL shortcut types ────────────────────────────────────────────────────────
+
+export interface UrlShortcutInfo {
+  /** Raw URL from the shortcut file. */
+  url: string;
+  /** True when the URL appears to be a OneNote notebook link. */
+  isOneNote: boolean;
+  /** True when the URL points to SharePoint (content requires Graph API). */
+  isSharePoint: boolean;
+}
+
 // ── OneDrive types ────────────────────────────────────────────────────────────
 
 export interface OnedriveRoot {
@@ -492,6 +503,8 @@ export interface JarvisApi {
   onedriveRescanFiles(folderId: number): Promise<{ ok: boolean; fileCount?: number; error?: string }>;
   onedriveListFilesForFolder(folderId: number): Promise<OnedriveFile[]>;
   onedriveReadOneNoteFile(filePath: string): Promise<{ ok: boolean; section?: OneNoteSectionContent; error?: string }>;
+  onedriveReadUrlShortcut(filePath: string): Promise<{ ok: boolean; url?: string; isOneNote?: boolean; isSharePoint?: boolean; error?: string }>;
+  shellOpenUrl(url: string): Promise<{ ok: boolean; error?: string }>;
 }
 
 declare global {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -26,6 +26,7 @@ import { SecretsScanPanel } from '../plugins/secrets/SecretsScanPanel';
 import { DashboardPanel } from '../plugins/dashboard/DashboardPanel';
 import { GroupsStep } from '../plugins/groups/GroupsStep';
 import { GroupsPanel } from '../plugins/groups/GroupsPanel';
+import { OneNoteSectionPanel } from '../plugins/groups/OneNoteSectionPanel';
 
 // ── Types (imported from single source of truth in plugins/types.ts) ─────────
 // The global augmentation `Window.jarvis` is declared in plugins/types.ts and
@@ -118,6 +119,7 @@ function App() {
   // Groups state
   const [groups, setGroups] = useState<Group[]>([]);
   const [showGroupsPanel, setShowGroupsPanel] = useState(false);
+  const [oneNoteFilePath, setOneNoteFilePath] = useState<string | null>(null);
 
   const currentUserLogin = oauthStatus?.login ?? null;
 
@@ -472,6 +474,7 @@ function App() {
     setShowSecretsPanel(false);
     // Groups
     setShowGroupsPanel(false);
+    setOneNoteFilePath(null);
     // Ollama + Chat sub-panel
     setShowOllamaPanel(false);
     setShowChatPanel(false);
@@ -675,6 +678,7 @@ function App() {
 
   const handleGroupsClose = async () => {
     setShowGroupsPanel(false);
+    setOneNoteFilePath(null);
     // Refresh group list so the step badge stays current
     try {
       const list = await window.jarvis.groupsList();
@@ -931,7 +935,17 @@ function App() {
         </div>
 
         {showGroupsPanel && (
-          <GroupsPanel onClose={() => void handleGroupsClose()} />
+          <GroupsPanel
+            onClose={() => void handleGroupsClose()}
+            onOpenOneNote={(path) => setOneNoteFilePath(path)}
+          />
+        )}
+
+        {oneNoteFilePath && (
+          <OneNoteSectionPanel
+            filePath={oneNoteFilePath}
+            onClose={() => setOneNoteFilePath(null)}
+          />
         )}
       </div>
 

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -2875,3 +2875,11 @@ h5.ec-heading { font-size: 0.85rem; }
   min-width: 0;
   overflow-y: auto;
 }
+
+/* ── OneNote section panel ────────────────────────────────────────────────── */
+.onenote-section-panel {
+  flex: 0 0 420px;
+  width: 420px;
+  max-height: 80vh;
+  overflow-y: auto;
+}

--- a/src/services/onenote-reader.ts
+++ b/src/services/onenote-reader.ts
@@ -1,0 +1,277 @@
+// ── OneNote section file reader ───────────────────────────────────────────────
+// Extracts text content from `.one` (MS-ONESTORE) binary files without
+// requiring OneNote to be installed or a native parser.
+//
+// Strategy:
+//   1. Extract UTF-16BE readable strings  — covers metadata (page titles,
+//      dates, font names) and content in newer OneNote format files.
+//   2. Extract ASCII readable strings     — covers content in older format
+//      files (pre-~2022) where body text is stored as single-byte characters.
+//   3. Use the sentinel string "PageTitle" (always UTF-16BE) to count pages
+//      and assign a rough per-page boundary.
+//   4. Strip well-known noise tokens (font names, XML fragments, property
+//      keys, GUIDs) before returning.
+//
+// Output is suitable for downstream RAG chunking — no layout is preserved.
+
+import fs from 'fs';
+import path from 'path';
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface OneNotePage {
+  /** Index of this page within the section (1-based). */
+  pageIndex: number;
+  /** Best-effort page title extracted from the binary. May be empty. */
+  title: string;
+  /** Best-effort page date string, e.g. "Thursday, September 25, 2025". */
+  date: string;
+  /** All body text found in this page's region of the file, joined with spaces. */
+  content: string;
+}
+
+export interface OneNoteSection {
+  /** Human-readable name derived from the filename (without extension). */
+  sectionName: string;
+  /** Absolute path of the source file. */
+  filePath: string;
+  /** Number of pages detected via "PageTitle" sentinels. */
+  pageCount: number;
+  /** Pages with individual titles and content. */
+  pages: OneNotePage[];
+  /** Full concatenated text (all pages) — convenient for whole-section RAG. */
+  textContent: string;
+}
+
+// ── Internal types ────────────────────────────────────────────────────────────
+
+interface ExtractedString {
+  offset: number;
+  encoding: 'utf16be' | 'ascii';
+  text: string;
+}
+
+// ── Noise filter ──────────────────────────────────────────────────────────────
+
+// Strings that appear in the binary as structural metadata, not user content.
+const NOISE_TOKENS = new Set([
+  'PageTitle',
+  'PageDateTime',
+  'Calibri',
+  'Calibri Light',
+  'Arial',
+  'Times New Roman',
+  'Courier New',
+  'Consolas',
+  'Microsoft YaHei',
+  'Verdana',
+  'Wingdings',
+  'Symbol',
+  'Segoe UI',
+  'blockquote',
+  'cite',
+  'code',
+  'table',
+  'th',
+  'td',
+  'tr',
+]);
+
+function isNoise(s: string): boolean {
+  if (NOISE_TOKENS.has(s)) return true;
+  // GUID-like strings
+  if (/^\{[0-9a-fA-F-]{30,}\}$/.test(s)) return true;
+  // XML/HTML fragments
+  if (s.startsWith('<') || s.startsWith('resolutionId')) return true;
+  // Pure whitespace or very short tokens
+  if (s.trim().length < 3) return true;
+  // Binary noise: strings with too many special characters
+  const printable = s.replace(/[^\x20-\x7E\u00A0-\u02FF]/g, '');
+  if (printable.length < s.length * 0.6) return true;
+  return false;
+}
+
+// ── String extraction ─────────────────────────────────────────────────────────
+
+const MIN_UTF16BE_LEN = 3;
+const MIN_ASCII_LEN = 5;
+
+/**
+ * Extract all readable string runs from a binary buffer using two strategies:
+ * UTF-16BE (high byte first) and ASCII (single byte).
+ * Results are sorted by file offset.
+ */
+export function extractStrings(buf: Buffer): ExtractedString[] {
+  const results: ExtractedString[] = [];
+
+  // ── UTF-16BE pass ─────────────────────────────────────────────────────────
+  // A UTF-16BE "printable" codepoint has the high byte as 0x00 (ASCII range)
+  // or 0x00-0x02 (Latin Extended).
+  for (let i = 0; i < buf.length - 1; i++) {
+    const chars: string[] = [];
+    let j = i;
+    while (j < buf.length - 1) {
+      const hi = buf[j];
+      const lo = buf[j + 1];
+      const cp = (hi << 8) | lo;
+      // Accept printable ASCII and Latin-Extended codepoints
+      if ((cp >= 0x0020 && cp < 0x007F) || (cp >= 0x00A0 && cp <= 0x02FF)) {
+        chars.push(String.fromCodePoint(cp));
+        j += 2;
+      } else {
+        break;
+      }
+    }
+    if (chars.length >= MIN_UTF16BE_LEN) {
+      const text = chars.join('').trim();
+      if (text.length >= MIN_UTF16BE_LEN) {
+        results.push({ offset: i, encoding: 'utf16be', text });
+        i = j - 1; // advance past this run
+      }
+    }
+  }
+
+  // ── ASCII pass ────────────────────────────────────────────────────────────
+  let current = '';
+  let startOffset = 0;
+  for (let i = 0; i <= buf.length; i++) {
+    const b = buf[i];
+    if (b !== undefined && b >= 0x20 && b < 0x7F) {
+      if (current.length === 0) startOffset = i;
+      current += String.fromCharCode(b);
+    } else {
+      if (current.length >= MIN_ASCII_LEN) {
+        results.push({ offset: startOffset, encoding: 'ascii', text: current.trim() });
+      }
+      current = '';
+    }
+  }
+
+  // Sort by file offset, then deduplicate by text
+  results.sort((a, b) => a.offset - b.offset);
+  const seen = new Set<string>();
+  return results.filter(s => {
+    if (seen.has(s.text)) return false;
+    seen.add(s.text);
+    return true;
+  });
+}
+
+// ── Page segmentation ─────────────────────────────────────────────────────────
+
+/**
+ * Build a OneNotePage from the strings found between two byte offsets.
+ * The first non-noise string after the PageTitle sentinel is used as the
+ * page title; the first date-like string is used as the date; everything
+ * else becomes body content.
+ */
+function buildPage(
+  pageIndex: number,
+  strings: ExtractedString[],
+  startOffset: number,
+  endOffset: number,
+): OneNotePage {
+  const pageStrings = strings
+    .filter(s => s.offset >= startOffset && s.offset < endOffset && !isNoise(s.text));
+
+  // The "PageDateTime" sentinel is a UTF-16BE anchor. The first non-noise
+  // string shortly after it is the date value.
+  const pageDateTimeIdx = strings.findIndex(
+    s => s.offset >= startOffset && s.offset < endOffset && s.text === 'PageDateTime',
+  );
+
+  let title = '';
+  let date = '';
+  const contentParts: string[] = [];
+
+  // Find a plausible title: first meaningful non-noise string before or after
+  // "PageDateTime" that looks like a sentence (has spaces or is long enough).
+  // Find a date string: something matching a date-like pattern.
+  const DATE_PATTERN = /\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d{1,2}:\d{2})\b/i;
+  const LONG_DATE_PATTERN = /\b(january|february|march|april|may|june|july|august|september|october|november|december|\d{4})\b/i;
+
+  for (const s of pageStrings) {
+    const isDateLike = DATE_PATTERN.test(s.text) || LONG_DATE_PATTERN.test(s.text);
+    if (isDateLike && !date) {
+      date = s.text;
+      continue;
+    }
+    // The first longish non-date string is the title candidate
+    if (!title && s.text.length >= 4 && s.offset < startOffset + 2000) {
+      title = s.text;
+      continue;
+    }
+    contentParts.push(s.text);
+  }
+
+  // Suppress the page-datetime sentinel index (already used for date)
+  void pageDateTimeIdx;
+
+  return {
+    pageIndex,
+    title,
+    date,
+    content: contentParts.join(' '),
+  };
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Read a OneNote section file (`.one`) and extract all text content.
+ * Returns a structured `OneNoteSection` with per-page text and a
+ * combined `textContent` field for whole-section RAG indexing.
+ *
+ * @throws if the file cannot be read.
+ */
+export function readOneNoteSection(filePath: string): OneNoteSection {
+  const buf = fs.readFileSync(filePath);
+  const sectionName = path.basename(filePath, '.one');
+
+  const allStrings = extractStrings(buf);
+
+  // Locate "PageTitle" sentinels — each marks one page in the section
+  const pageSentinels = allStrings
+    .filter(s => s.text === 'PageTitle')
+    .map(s => s.offset);
+
+  let pages: OneNotePage[];
+
+  if (pageSentinels.length === 0) {
+    // No page structure detected — treat the whole file as one page
+    const contentStrings = allStrings.filter(s => !isNoise(s.text));
+    const content = contentStrings.map(s => s.text).join(' ');
+    pages = [{ pageIndex: 1, title: sectionName, date: '', content }];
+  } else {
+    pages = pageSentinels.map((sentinelOffset, i) => {
+      const nextSentinelOffset = pageSentinels[i + 1] ?? buf.length;
+      return buildPage(i + 1, allStrings, sentinelOffset, nextSentinelOffset);
+    });
+
+    // Also capture any content that appears BEFORE the first PageTitle sentinel
+    // (older format files store body text before metadata).
+    const prePageStrings = allStrings
+      .filter(s => s.offset < pageSentinels[0] && !isNoise(s.text));
+    if (prePageStrings.length > 0) {
+      const preContent = prePageStrings.map(s => s.text).join(' ');
+      // Append pre-content to the first page
+      const first = pages[0];
+      pages[0] = {
+        ...first,
+        content: preContent + (first.content ? ' ' + first.content : ''),
+      };
+    }
+  }
+
+  const textContent = pages
+    .map(p => [p.title, p.date, p.content].filter(Boolean).join(' '))
+    .join('\n\n');
+
+  return {
+    sectionName,
+    filePath,
+    pageCount: pages.length,
+    pages,
+    textContent,
+  };
+}

--- a/src/services/url-shortcut.ts
+++ b/src/services/url-shortcut.ts
@@ -36,7 +36,15 @@ export function readUrlShortcut(filePath: string): UrlShortcutInfo {
     lower.includes('onenote') ||
     lower.includes('callerscenarioid=onenote');
 
-  const isSharePoint = lower.includes('sharepoint.com');
+  let isSharePoint = false;
+  try {
+    const parsed = new URL(url);
+    isSharePoint =
+      parsed.hostname === 'sharepoint.com' ||
+      parsed.hostname.endsWith('.sharepoint.com');
+  } catch {
+    // Malformed URL — not SharePoint
+  }
 
   return { url, isOneNote, isSharePoint };
 }

--- a/src/services/url-shortcut.ts
+++ b/src/services/url-shortcut.ts
@@ -1,0 +1,42 @@
+// ── Windows Internet Shortcut reader ─────────────────────────────────────────
+// Parses `.url` files (INI-format) to extract the target URL.
+// These shortcuts are created by OneNote/OneDrive to link to notebooks that
+// are hosted on SharePoint or OneDrive cloud but not locally synced as .one files.
+
+import fs from 'fs';
+
+export interface UrlShortcutInfo {
+  /** Raw URL extracted from the shortcut. */
+  url: string;
+  /** True when the URL appears to be a OneNote notebook link. */
+  isOneNote: boolean;
+  /** True when the URL points to SharePoint (may need Graph API for content). */
+  isSharePoint: boolean;
+}
+
+/**
+ * Read a Windows `.url` Internet Shortcut file and return the target URL.
+ * @throws if the file cannot be read or contains no URL.
+ */
+export function readUrlShortcut(filePath: string): UrlShortcutInfo {
+  const content = fs.readFileSync(filePath, 'utf-8');
+
+  // URL is on a line of the form: URL=https://...
+  const match = content.match(/^URL=(.+)$/im);
+  if (!match) {
+    throw new Error(`No URL= entry found in shortcut file: ${filePath}`);
+  }
+
+  const url = match[1].trim();
+  const lower = url.toLowerCase();
+
+  const isOneNote =
+    lower.startsWith('onenote:') ||
+    lower.includes('skysyncredir') || // SharePoint OneNote sync redirect
+    lower.includes('onenote') ||
+    lower.includes('callerscenarioid=onenote');
+
+  const isSharePoint = lower.includes('sharepoint.com');
+
+  return { url, isOneNote, isSharePoint };
+}

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -135,6 +135,8 @@ const EXPECTED_CHANNELS = [
   'onedrive:rescan-files',
   'onedrive:list-files-for-folder',
   'onedrive:read-onenote-file',
+  'onedrive:read-url-shortcut',
+  'shell:open-url',
 ] as const;
 
 describe('IPC handler registration', () => {

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -134,6 +134,7 @@ const EXPECTED_CHANNELS = [
   'onedrive:get-folder-info',
   'onedrive:rescan-files',
   'onedrive:list-files-for-folder',
+  'onedrive:read-onenote-file',
 ] as const;
 
 describe('IPC handler registration', () => {

--- a/tests/unit/onenote-folder-integration.test.ts
+++ b/tests/unit/onenote-folder-integration.test.ts
@@ -1,0 +1,204 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+// ── OneNote folder integration ─────────────────────────────────────────────────
+// Proves the full pipeline from group/OneDrive folder discovery through
+// file scanning to OneNote content extraction.
+//
+// Uses the real `.one` fixture files shipped in the @joplin/onenote-converter
+// package so the test runs on any machine without needing actual OneDrive files.
+// The fixture directory structure mirrors a real OneDrive layout:
+//
+//   test-data/              ← OneDrive root
+//     single-page/          ← customer folder (= "group" in Jarvis)
+//       Untitled Section.one
+//     onenote-2016/
+//       OneWithFileData.one
+//
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import * as path from 'path';
+import { getSchema } from '../../src/storage/schema';
+import {
+  addOnedriveRoot,
+  discoverCustomerFolderForGroup,
+  scanFilesForFolder,
+  listFilesForFolder,
+} from '../../src/services/onedrive';
+import { readOneNoteSection } from '../../src/services/onenote-reader';
+import type { OnedriveFolderInfo, OnedriveFile } from '../../src/plugins/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function insertGroup(db: SqlJsDatabase, name: string): number {
+  db.run(
+    `INSERT INTO groups (name, created_at, updated_at) VALUES (?, datetime('now'), datetime('now'))`,
+    [name],
+  );
+  const stmt = db.prepare('SELECT last_insert_rowid() AS id');
+  stmt.step();
+  const { id } = stmt.getAsObject() as { id: number };
+  stmt.free();
+  return id as number;
+}
+
+/** Full path to the Joplin test fixture tree — used as a stand-in OneDrive root. */
+const FIXTURE_ROOT = path.join(
+  __dirname,
+  '../../node_modules/@joplin/onenote-converter/test-data',
+);
+
+/** Set up an OneDrive root at FIXTURE_ROOT, create a group with the given name,
+ *  discover its matching subfolder, and return both the folder record and its files. */
+function setupAndScan(
+  db: SqlJsDatabase,
+  groupName: string,
+): { folder: OnedriveFolderInfo; files: OnedriveFile[]; oneFiles: OnedriveFile[] } {
+  addOnedriveRoot(db, FIXTURE_ROOT, 'Fixtures');
+  const gid = insertGroup(db, groupName);
+  const folders = discoverCustomerFolderForGroup(db, gid, groupName);
+  const folder = folders[0];
+  scanFilesForFolder(db, folder.id);
+  const files = listFilesForFolder(db, folder.id);
+  const oneFiles = files.filter(f => f.extension === '.one');
+  return { folder, files, oneFiles };
+}
+
+/** Format a readable summary of an extracted section for test output. */
+function formatSectionReport(section: ReturnType<typeof readOneNoteSection>): string {
+  const lines: string[] = [
+    `  Section: "${section.sectionName}"  (${section.pageCount} page(s))`,
+  ];
+  for (const page of section.pages) {
+    const heading = page.title ? `"${page.title}"` : '(no title)';
+    const dateTag = page.date ? `  [${page.date}]` : '';
+    lines.push(`    Page ${page.pageIndex}: ${heading}${dateTag}`);
+    if (page.content.trim()) {
+      const preview = page.content.replace(/\s+/g, ' ').trim().slice(0, 120);
+      lines.push(`      ↳ ${preview}${page.content.length > 120 ? '…' : ''}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+describe('OneNote folder integration — full pipeline', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── single-page fixture group ─────────────────────────────────────────────
+
+  describe('group "single-page"', () => {
+    it('discovers the folder matching the group name', () => {
+      const { folder } = setupAndScan(db, 'single-page');
+      expect(folder.status).toBe('found');
+      expect(folder.folderPath).toBeTruthy();
+    });
+
+    it('finds at least one .one file after scanning', () => {
+      const { oneFiles } = setupAndScan(db, 'single-page');
+      expect(oneFiles.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('reads each .one file and returns a named section with pages', () => {
+      const { folder, oneFiles } = setupAndScan(db, 'single-page');
+
+      for (const file of oneFiles) {
+        const fullPath = path.join(folder.folderPath!, file.relativePath);
+        const section = readOneNoteSection(fullPath);
+
+        // Section name matches the filename (minus extension)
+        expect(section.sectionName).toBe(path.basename(file.name, '.one'));
+        // At least one page per section
+        expect(section.pageCount).toBeGreaterThanOrEqual(1);
+        expect(section.pages.length).toEqual(section.pageCount);
+        // All pages have a 1-based index
+        section.pages.forEach((p, i) => expect(p.pageIndex).toBe(i + 1));
+        // Combined text is non-empty
+        expect(section.textContent.trim().length).toBeGreaterThan(0);
+
+        console.log(formatSectionReport(section));
+      }
+    });
+
+    it('extracts "test" body text from the Untitled Section fixture', () => {
+      const { folder, oneFiles } = setupAndScan(db, 'single-page');
+      const untitled = oneFiles.find(f => f.name === 'Untitled Section.one');
+      expect(untitled).toBeDefined();
+
+      const fullPath = path.join(folder.folderPath!, untitled!.relativePath);
+      const section = readOneNoteSection(fullPath);
+      expect(section.textContent.toLowerCase()).toContain('test');
+    });
+  });
+
+  // ── onenote-2016 fixture group ────────────────────────────────────────────
+
+  describe('group "onenote-2016"', () => {
+    it('discovers the folder matching the group name', () => {
+      const { folder } = setupAndScan(db, 'onenote-2016');
+      expect(folder.status).toBe('found');
+    });
+
+    it('finds at least one .one file after scanning', () => {
+      const { oneFiles } = setupAndScan(db, 'onenote-2016');
+      expect(oneFiles.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('reads each .one file and returns pages with content', () => {
+      const { folder, oneFiles } = setupAndScan(db, 'onenote-2016');
+
+      for (const file of oneFiles) {
+        const fullPath = path.join(folder.folderPath!, file.relativePath);
+        const section = readOneNoteSection(fullPath);
+
+        expect(section.pageCount).toBeGreaterThanOrEqual(1);
+        expect(typeof section.sectionName).toBe('string');
+        expect(section.sectionName.length).toBeGreaterThan(0);
+
+        console.log(formatSectionReport(section));
+      }
+    });
+  });
+
+  // ── cross-group summary ───────────────────────────────────────────────────
+
+  it('can scan both groups and produce a combined section summary', () => {
+    const groupNames = ['single-page', 'onenote-2016'];
+    const summary: string[] = ['\n── OneNote section summary ──────────────────────────────'];
+
+    // Single root shared by both groups — path must be unique in the DB
+    addOnedriveRoot(db, FIXTURE_ROOT, 'Fixtures');
+
+    for (const groupName of groupNames) {
+      const gid = insertGroup(db, groupName);
+      const [folder] = discoverCustomerFolderForGroup(db, gid, groupName);
+      scanFilesForFolder(db, folder.id);
+
+      const files = listFilesForFolder(db, folder.id);
+      const oneFiles = files.filter(f => f.extension === '.one');
+
+      summary.push(`\nGroup: "${groupName}"  (${oneFiles.length} .one file(s) found)`);
+
+      for (const file of oneFiles) {
+        const fullPath = path.join(folder.folderPath!, file.relativePath);
+        const section = readOneNoteSection(fullPath);
+        summary.push(formatSectionReport(section));
+      }
+
+      expect(folder.status).toBe('found');
+      expect(oneFiles.length).toBeGreaterThanOrEqual(1);
+    }
+
+    summary.push('\n─────────────────────────────────────────────────────────');
+    console.log(summary.join('\n'));
+  });
+});

--- a/tests/unit/onenote-reader.test.ts
+++ b/tests/unit/onenote-reader.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  extractStrings,
+  readOneNoteSection,
+  type OneNoteSection,
+} from '../../src/services/onenote-reader';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Resolve the path to a test `.one` fixture shipped inside the Joplin
+ *  onenote-converter package so we don't need to commit binary blobs. */
+function fixtureFile(relativePath: string): string {
+  return path.join(
+    __dirname,
+    '../../node_modules/@joplin/onenote-converter/test-data',
+    relativePath,
+  );
+}
+
+// ── extractStrings() ──────────────────────────────────────────────────────────
+
+describe('extractStrings()', () => {
+  it('returns an empty array for an empty buffer', () => {
+    const result = extractStrings(Buffer.alloc(0));
+    expect(result).toEqual([]);
+  });
+
+  it('extracts ASCII runs of printable characters', () => {
+    // Build a buffer: some binary noise then "Hello World" then more noise
+    const text = 'Hello World';
+    const buf = Buffer.from([0x00, 0x01, ...Buffer.from(text, 'ascii'), 0x00]);
+    const result = extractStrings(buf);
+    const texts = result.map(s => s.text);
+    expect(texts).toContain('Hello World');
+  });
+
+  it('extracts UTF-16BE printable strings', () => {
+    // Encode "Test" as UTF-16BE bytes: 00 54 00 65 00 73 00 74
+    const utf16Bytes = Buffer.from([0x00, 0x54, 0x00, 0x65, 0x00, 0x73, 0x00, 0x74]);
+    const buf = Buffer.concat([Buffer.from([0xFF, 0xFE]), utf16Bytes]);
+    const result = extractStrings(buf);
+    const texts = result.map(s => s.text);
+    expect(texts).toContain('Test');
+  });
+
+  it('deduplicates identical strings', () => {
+    const text = 'Repeated';
+    const chunk = Buffer.from(text, 'ascii');
+    const buf = Buffer.concat([chunk, Buffer.from([0x00, 0x00]), chunk]);
+    const result = extractStrings(buf);
+    const count = result.filter(s => s.text === 'Repeated').length;
+    expect(count).toBe(1);
+  });
+
+  it('returns results sorted by file offset', () => {
+    const buf = Buffer.from('AAABBB', 'ascii');
+    const result = extractStrings(buf);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i].offset).toBeGreaterThanOrEqual(result[i - 1].offset);
+    }
+  });
+});
+
+// ── readOneNoteSection() with real fixture files ──────────────────────────────
+
+describe('readOneNoteSection() — single-page fixture', () => {
+  const fixturePath = fixtureFile('single-page/Untitled Section.one');
+
+  it('fixture file exists', () => {
+    expect(fs.existsSync(fixturePath)).toBe(true);
+  });
+
+  it('returns a OneNoteSection with the correct sectionName', () => {
+    const section = readOneNoteSection(fixturePath);
+    expect(section.sectionName).toBe('Untitled Section');
+  });
+
+  it('reports filePath matching the input', () => {
+    const section = readOneNoteSection(fixturePath);
+    expect(section.filePath).toBe(fixturePath);
+  });
+
+  it('detects at least one page', () => {
+    const section = readOneNoteSection(fixturePath);
+    expect(section.pageCount).toBeGreaterThanOrEqual(1);
+    expect(section.pages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('extracts the word "test" from the note body', () => {
+    const section = readOneNoteSection(fixturePath);
+    const combined = section.textContent.toLowerCase();
+    expect(combined).toContain('test');
+  });
+
+  it('textContent is non-empty', () => {
+    const section = readOneNoteSection(fixturePath);
+    expect(section.textContent.trim().length).toBeGreaterThan(0);
+  });
+
+  it('each page has a pageIndex >= 1', () => {
+    const section = readOneNoteSection(fixturePath);
+    for (const page of section.pages) {
+      expect(page.pageIndex).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('readOneNoteSection() — onenote-2016 fixture', () => {
+  const fixturePath = fixtureFile('onenote-2016/OneWithFileData.one');
+
+  it('fixture file exists', () => {
+    expect(fs.existsSync(fixturePath)).toBe(true);
+  });
+
+  it('returns a OneNoteSection with string sectionName', () => {
+    const section = readOneNoteSection(fixturePath);
+    expect(typeof section.sectionName).toBe('string');
+    expect(section.sectionName.length).toBeGreaterThan(0);
+  });
+
+  it('detects at least one page', () => {
+    const section = readOneNoteSection(fixturePath);
+    expect(section.pageCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('textContent contains the attached filename', () => {
+    // The test file has a "testing.docx" attachment reference
+    const section = readOneNoteSection(fixturePath);
+    expect(section.textContent).toContain('testing.docx');
+  });
+});
+
+// ── readOneNoteSection() — edge cases ─────────────────────────────────────────
+
+describe('readOneNoteSection() — edge cases', () => {
+  it('throws if the file does not exist', () => {
+    expect(() => readOneNoteSection('/nonexistent/path/file.one')).toThrow();
+  });
+
+  it('handles an empty file gracefully (returns one page with empty content)', () => {
+    const tmp = path.join(os.tmpdir(), 'jarvis-test-empty.one');
+    fs.writeFileSync(tmp, Buffer.alloc(0));
+    try {
+      const section = readOneNoteSection(tmp);
+      expect(section.pageCount).toBeGreaterThanOrEqual(1);
+      expect(typeof section.textContent).toBe('string');
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+
+  it('handles a file containing only ASCII text (no page sentinels)', () => {
+    const tmp = path.join(os.tmpdir(), 'jarvis-test-ascii.one');
+    fs.writeFileSync(tmp, Buffer.from('Hello from a note with no structure'));
+    try {
+      const section = readOneNoteSection(tmp);
+      expect(section.textContent).toContain('Hello from a note with no structure');
+      expect(section.pageCount).toBe(1);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This is step 1 of building a local RAG index for OneNote files discovered via the OneDrive folder integration.

**What this PR adds:**
- A new `src/services/onenote-reader.ts` service that can read `.one` (MS-ONESTORE) binary files and extract all text content — **no OneNote installation required, no native parser, no cloud API**
- A new IPC handler `onedrive:read-onenote-file` to expose this to the renderer
- Types and preload wiring

## How it works

`.one` files store text in two ways depending on the format version:
- **UTF-16BE strings** (high byte first, zero-padded ASCII): used for metadata (page titles, dates, font names) and body text in newer-format files
- **ASCII strings**: used for body text in older-format files (pre-~2022)

The reader uses a **hybrid extraction strategy**:
1. Scan for runs of printable UTF-16BE codepoints → picks up page titles, dates, newer content
2. Scan for runs of printable ASCII bytes → picks up older-format body text
3. Locate `"PageTitle"` sentinels (always UTF-16BE) to count pages and split content per page
4. Filter a noise list (font names, GUIDs, XML fragments, OneNote property keys)

Each section file returns an `OneNoteSection` with:
- `sectionName` — derived from filename
- `pageCount` — detected via `"PageTitle"` sentinel occurrences
- `pages[]` — per-page `{ pageIndex, title, date, content }`
- `textContent` — full concatenated text (all pages), ready for RAG chunking

## Tested against
- `@joplin/onenote-converter` test fixtures (single-page, 2016-format with embedded file)
- Real `.one` files from user's OneDrive (Dutch and English content, 2017–2025 vintage)

## Next steps
- Step 2: Build the RAG chunk/embed pipeline using extracted `textContent`
- Step 3: Wire the RAG index into the chat context interface