### PR TITLE
feat: dashboard polish — sort by activity, failure hints, dismissed-notif filtering

### DIFF
--- a/src/plugins/agents/AgentApprovalPanel.tsx
+++ b/src/plugins/agents/AgentApprovalPanel.tsx
@@ -143,8 +143,27 @@ export function AgentApprovalPanel({ session, onFindingUpdate, onNotificationsDi
     }
     // Use the server-confirmed dismissed IDs (avoids relying on LLM-generated action_data)
     if (execResult.ok && finding.action_type === 'close_notifications') {
-      const ids = execResult.dismissedIds ?? (finding.action_data?.notification_ids as string[] | undefined) ?? [];
-      if (ids.length > 0) onNotificationsDismissed?.(ids);
+      // Fall back to action_data IDs if the server returned an empty array
+      const serverIds = execResult.dismissedIds ?? [];
+      const ids = serverIds.length > 0
+        ? serverIds
+        : (finding.action_data?.notification_ids as string[] | undefined) ?? [];
+      console.log('[AgentApproval] close_notifications executed, dismissedIds:', ids);
+      if (ids.length > 0) {
+        onNotificationsDismissed?.(ids);
+        // Auto-reject any other pending close_notifications findings that overlap
+        // the same IDs — they're now stale and would be no-ops if executed.
+        const dismissedSet = new Set(ids);
+        for (const other of session.findings) {
+          if (other.id === finding.id) continue;
+          if (other.action_type !== 'close_notifications') continue;
+          if (other.approved !== null || other.executed_at) continue; // already decided
+          const otherIds = (other.action_data?.notification_ids as string[] | undefined) ?? [];
+          if (otherIds.some((id) => dismissedSet.has(id))) {
+            await window.jarvis.agentsRejectFinding(other.id);
+          }
+        }
+      }
     }
     onFindingUpdate(session.id);
   };

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -375,12 +375,13 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
   }
 
   // Filter out any notifications dismissed externally (e.g. from the agent chat panel)
+  // Use String() coercion because sql.js returns numeric-looking TEXT IDs as JS numbers
   const visible = dismissedNotifIds?.size
-    ? notifications.filter((n) => !dismissedNotifIds.has(n.id))
+    ? notifications.filter((n) => !dismissedNotifIds.has(String(n.id)))
     : notifications;
 
   if (dismissedNotifIds?.size) {
-    console.log('[NotificationList] filtering', repoFullName, 'dismissed:', [...dismissedNotifIds], 'notifications:', notifications.map((n) => n.id), 'visible:', visible.length);
+    console.log('[NotificationList] filtering', repoFullName, 'dismissed:', [...dismissedNotifIds], 'notifications:', notifications.map((n) => String(n.id)), 'visible:', visible.length);
   }
 
   if (visible.length === 0) {

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -5,7 +5,29 @@ import type {
   HealthWarning,
   StoredNotification,
 } from '../types';
+import { AgentSelector } from '../agents/AgentSelector';
+// ── Failure hint helpers ──────────────────────────────────────────────────────────
 
+interface FailureHint {
+  failingJob: string | null;
+  errorHint: string | null;
+}
+
+function extractErrorHint(logExcerpt: string | null): string | null {
+  if (!logExcerpt) return null;
+  const stripTs = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*/;
+  const errorRe = /##\[error\]|error:|failed to |exception:|fatal:/i;
+  const lines = logExcerpt.split('\n');
+  for (const raw of lines) {
+    const line = raw.replace(stripTs, '').trim();
+    if (line && errorRe.test(line)) return line.slice(0, 140);
+  }
+  for (const raw of lines) {
+    const line = raw.replace(stripTs, '').trim();
+    if (line) return line.slice(0, 140);
+  }
+  return null;
+}
 // ── Recoverable notifications banner ─────────────────────────────────────────
 
 interface RecoverableEntry {
@@ -232,12 +254,14 @@ function groupDashNotifications(notifications: StoredNotification[]): { groups: 
 }
 
 /** Lazily loads and displays notifications for a single repo, grouped by workflow. */
-function NotificationList({ repoFullName }: { repoFullName: string }) {
+function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: string; dismissedNotifIds?: ReadonlySet<string> }) {
   const [notifications, setNotifications] = useState<StoredNotification[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [recoveryMap, setRecoveryMap] = useState<Map<string, boolean>>(new Map());
   const [checkingRecovery, setCheckingRecovery] = useState(false);
+  const [failureHintMap, setFailureHintMap] = useState<Map<string, FailureHint>>(new Map());
   const [dismissingGroup, setDismissingGroup] = useState<string | null>(null);
+  const [agentTarget, setAgentTarget] = useState<{ workflowFilter?: string } | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -274,6 +298,7 @@ function NotificationList({ repoFullName }: { repoFullName: string }) {
         if (cancelled) return;
 
         const newMap = new Map<string, boolean>();
+        const newHints = new Map<string, FailureHint>();
         for (const group of ciGroups) {
           const latestNotifTime = Math.max(...group.notifications.map((n) => new Date(n.updated_at).getTime()));
           const recovered = summary.recent_runs.some(
@@ -284,8 +309,25 @@ function NotificationList({ repoFullName }: { repoFullName: string }) {
               new Date(r.run_started_at).getTime() > latestNotifTime,
           );
           newMap.set(group.workflowName!, recovered);
+          if (!recovered) {
+            const failedRun = summary.recent_runs.find(
+              (r) =>
+                r.workflow_name === group.workflowName &&
+                (group.branch === null || r.head_branch === group.branch) &&
+                r.conclusion !== 'success',
+            );
+            if (failedRun) {
+              const jobs = summary.jobs_by_run[failedRun.id] ?? [];
+              const failedJob = jobs.find((j) => j.conclusion === 'failure' || j.conclusion === 'cancelled') ?? null;
+              newHints.set(group.workflowName!, {
+                failingJob: failedJob?.name ?? null,
+                errorHint: extractErrorHint(failedJob?.log_excerpt ?? null),
+              });
+            }
+          }
         }
         setRecoveryMap(newMap);
+        setFailureHintMap(newHints);
       } catch {
         // best-effort; ignore errors
       } finally {
@@ -332,7 +374,20 @@ function NotificationList({ repoFullName }: { repoFullName: string }) {
     return <div class="dash-notif-empty">No notifications</div>;
   }
 
-  const { groups, isGrouped } = groupDashNotifications(notifications);
+  // Filter out any notifications dismissed externally (e.g. from the agent chat panel)
+  const visible = dismissedNotifIds?.size
+    ? notifications.filter((n) => !dismissedNotifIds.has(n.id))
+    : notifications;
+
+  if (dismissedNotifIds?.size) {
+    console.log('[NotificationList] filtering', repoFullName, 'dismissed:', [...dismissedNotifIds], 'notifications:', notifications.map((n) => n.id), 'visible:', visible.length);
+  }
+
+  if (visible.length === 0) {
+    return <div class="dash-notif-empty">No notifications</div>;
+  }
+
+  const { groups, isGrouped } = groupDashNotifications(visible);
 
   const renderRow = (n: StoredNotification) => (
     <div key={n.id} class="dash-notif-item">
@@ -360,8 +415,9 @@ function NotificationList({ repoFullName }: { repoFullName: string }) {
   );
 
   return (
+    <>
     <div class="dash-notif-list">
-      <div class="dash-notif-header">🔔 Notifications ({notifications.length})</div>
+      <div class="dash-notif-header">🔔 Notifications ({visible.length})</div>
       {isGrouped ? (
         groups.map((group) => (
           <div key={group.workflowName ?? '__other__'} class="dash-notif-group">
@@ -378,7 +434,16 @@ function NotificationList({ repoFullName }: { repoFullName: string }) {
                 <span class="dash-group-status dash-group-status--checking">checking…</span>
               )}
               {group.workflowName && !checkingRecovery && recoveryMap.get(group.workflowName) === false && (
-                <span class="dash-group-status dash-group-status--failing">✗ Still failing</span>
+                <>
+                  <span class="dash-group-status dash-group-status--failing">✗ Still failing</span>
+                  <button
+                    class="dash-analyse-btn"
+                    title={`Analyse "${group.workflowName}" with an LLM agent`}
+                    onClick={() => setAgentTarget({ workflowFilter: group.workflowName! })}
+                  >
+                    {'🤖 Analyse'}
+                  </button>
+                </>
               )}
               {group.workflowName && !checkingRecovery && recoveryMap.get(group.workflowName) === true && (
                 <>
@@ -393,13 +458,34 @@ function NotificationList({ repoFullName }: { repoFullName: string }) {
                 </>
               )}
             </div>
+            {/* Failure hint: failing job + first error line from cached logs */}
+            {group.workflowName && !checkingRecovery && recoveryMap.get(group.workflowName) === false && (() => {
+              const hint = failureHintMap.get(group.workflowName!);
+              if (!hint) return null;
+              return (
+                <div class="dash-failure-hint">
+                  {hint.failingJob && <span class="dash-failure-hint-job">Job: {hint.failingJob}</span>}
+                  {hint.errorHint && <code class="dash-failure-hint-error">{hint.errorHint}</code>}
+                </div>
+              );
+            })()}
             {group.notifications.map(renderRow)}
           </div>
         ))
       ) : (
-        notifications.map(renderRow)
+        visible.map(renderRow)
       )}
     </div>
+
+    {agentTarget !== null && (
+      <AgentSelector
+        repoFullName={repoFullName}
+        workflowFilter={agentTarget.workflowFilter}
+        onClose={() => setAgentTarget(null)}
+        onSessionStarted={() => setAgentTarget(null)}
+      />
+    )}
+  </>
   );
 }
 
@@ -476,6 +562,7 @@ function RepoHealthRow({
   onOpenFolder,
   onOpenGitHub,
   onPushBranch,
+  dismissedNotifIds,
 }: {
   status: RepoHealthStatus;
   warnings: HealthWarning[];
@@ -485,6 +572,7 @@ function RepoHealthRow({
   onOpenFolder: (localPath: string) => void;
   onOpenGitHub: (repoFullName: string) => void;
   onPushBranch: (localPath: string, branch: string) => void;
+  dismissedNotifIds?: ReadonlySet<string>;
 }) {
   return (
     <div id={`dash-repo-${status.localRepoId}`} class={`dash-repo-row ${warnings.length > 0 ? 'dash-repo-warn' : ''} ${expanded ? 'dash-repo-expanded' : ''}`}>
@@ -548,7 +636,7 @@ function RepoHealthRow({
 
           {/* Inline notification list */}
           {status.notificationCount > 0 && status.linkedGithubRepo && (
-            <NotificationList repoFullName={status.linkedGithubRepo} />
+            <NotificationList repoFullName={status.linkedGithubRepo} dismissedNotifIds={dismissedNotifIds} />
           )}
 
           {/* Actionable guidance per warning */}
@@ -656,7 +744,7 @@ function emptyMessage(card: CardFilter): string {
 
 // ── Main Dashboard ────────────────────────────────────────────────────────────
 
-export function DashboardPanel() {
+export function DashboardPanel({ dismissedNotifIds }: { dismissedNotifIds?: ReadonlySet<string> }) {
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [cardFilter, setCardFilter] = useState<CardFilter>('all');
@@ -767,7 +855,16 @@ export function DashboardPanel() {
         <div class="dash-header-right">
           <span class="dash-updated">Last updated: {new Date(summary.generatedAt).toLocaleTimeString()}</span>
           <button class="dash-refresh-btn" onClick={load} disabled={loading} title="Refresh">
-            {loading ? '⏳' : '🔄'} Refresh
+            <svg
+              class={loading ? 'dash-refresh-icon dash-refresh-icon--spinning' : 'dash-refresh-icon'}
+              viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"
+              stroke-linecap="round" stroke-linejoin="round"
+            >
+              <path d="M23 4v6h-6" />
+              <path d="M1 20v-6h6" />
+              <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+            </svg>
+            {loading ? 'Refreshing…' : 'Refresh'}
           </button>
         </div>
       </div>
@@ -820,10 +917,19 @@ export function DashboardPanel() {
               warnings={warningMap.get(repo.localRepoId) ?? []}
               expanded={expandedId === repo.localRepoId}
               pushState={pushStates[repo.localRepoId] ?? 'idle'}
-              onToggle={() => setExpandedId(expandedId === repo.localRepoId ? null : repo.localRepoId)}
+              onToggle={() => {
+                const newId = expandedId === repo.localRepoId ? null : repo.localRepoId;
+                setExpandedId(newId);
+                if (newId !== null) {
+                  requestAnimationFrame(() => {
+                    document.getElementById(`dash-repo-${newId}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                  });
+                }
+              }}
               onOpenFolder={handleOpenFolder}
               onOpenGitHub={handleOpenGitHub}
               onPushBranch={handlePushBranch}
+              dismissedNotifIds={dismissedNotifIds}
             />
           ))}
         </div>

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -406,6 +406,8 @@ function NotificationList({ repoFullName }: { repoFullName: string }) {
 /** The active card filter drives what appears below the cards. */
 type CardFilter = 'all' | 'healthy' | 'warnings' | 'notifications' | 'failed-runs';
 
+type SortMode = 'attention' | 'local-activity' | 'remote-activity';
+
 function SummaryCards({
   summary,
   healthyCount,
@@ -658,6 +660,7 @@ export function DashboardPanel() {
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [cardFilter, setCardFilter] = useState<CardFilter>('all');
+  const [sortMode, setSortMode] = useState<SortMode>('attention');
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [pushStates, setPushStates] = useState<Record<number, 'idle' | 'pushing' | 'done' | 'error'>>({});
 
@@ -735,8 +738,21 @@ export function DashboardPanel() {
   // Filter repos based on the selected card
   const displayRepos = filterRepos(summary.repos, warningMap, cardFilter);
 
-  // Sort: repos with warnings first, then alphabetical
+  // Sort based on selected mode
   const sorted = [...displayRepos].sort((a, b) => {
+    if (sortMode === 'local-activity') {
+      // Most recent local commit first; null goes to bottom
+      const aT = a.lastCommitAt ? new Date(a.lastCommitAt).getTime() : 0;
+      const bT = b.lastCommitAt ? new Date(b.lastCommitAt).getTime() : 0;
+      return bT - aT;
+    }
+    if (sortMode === 'remote-activity') {
+      // Most recent GitHub push first; null goes to bottom
+      const aT = a.lastPushedAt ? new Date(a.lastPushedAt).getTime() : 0;
+      const bT = b.lastPushedAt ? new Date(b.lastPushedAt).getTime() : 0;
+      return bT - aT;
+    }
+    // 'attention': repos with warnings first, then alphabetical
     const aW = warningMap.get(a.localRepoId)?.length ?? 0;
     const bW = warningMap.get(b.localRepoId)?.length ?? 0;
     if (aW > 0 && bW === 0) return -1;
@@ -778,7 +794,21 @@ export function DashboardPanel() {
 
       {/* Repo health list — filtered by selected card */}
       <div class="dash-section">
-        <h3>{sectionTitle(cardFilter, sorted.length)}</h3>
+        <div class="dash-section-header">
+          <h3>{sectionTitle(cardFilter, sorted.length)}</h3>
+          <div class="dash-sort-controls">
+            <span class="dash-sort-label">Sort:</span>
+            {(['attention', 'local-activity', 'remote-activity'] as SortMode[]).map((mode) => (
+              <button
+                key={mode}
+                class={`dash-sort-btn${sortMode === mode ? ' dash-sort-btn--active' : ''}`}
+                onClick={() => setSortMode(mode)}
+              >
+                {mode === 'attention' ? '⚠️ Attention' : mode === 'local-activity' ? '💻 Local activity' : '☁️ Remote activity'}
+              </button>
+            ))}
+          </div>
+        </div>
         <div class="dash-repo-list">
           {sorted.length === 0 && (
             <div class="dash-empty">{emptyMessage(cardFilter)}</div>

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useCallback } from 'preact/hooks';
+import { useState, useEffect, useCallback } from 'preact/hooks';
 import type {
   DashboardSummary,
   RepoHealthStatus,
@@ -351,7 +351,6 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
       await window.jarvis.dismissNotification(id);
       setNotifications((prev) => prev?.filter((n) => n.id !== id) ?? null);
       setSuccessMsg('✓ Notification dismissed');
-      onDismissed?.(1);
     } catch (err) {
       console.error('[Dashboard] Failed to dismiss notification:', err);
     }
@@ -372,7 +371,6 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
     setDismissingGroup(null);
     if (dismissed > 0) {
       setSuccessMsg(`✓ ${dismissed} notification${dismissed > 1 ? 's' : ''} dismissed`);
-      onDismissed?.(dismissed);
     }
   };
 

--- a/src/plugins/dashboard/handler.ts
+++ b/src/plugins/dashboard/handler.ts
@@ -95,6 +95,18 @@ function getRecentFailedRuns(db: SqlJsDatabase, limit = 20): {
   return rows;
 }
 
+/**
+ * Look up last_pushed_at for a GitHub repo.
+ */
+function getLastPushedAt(db: SqlJsDatabase, repoFullName: string | null): string | null {
+  if (!repoFullName) return null;
+  const stmt = db.prepare('SELECT last_pushed_at FROM github_repos WHERE full_name = ? LIMIT 1');
+  stmt.bind([repoFullName]);
+  const found = stmt.step() ? (stmt.getAsObject() as { last_pushed_at: string | null }) : null;
+  stmt.free();
+  return found?.last_pushed_at ?? null;
+}
+
 // ── IPC registration ──────────────────────────────────────────────────────────
 
 export function registerHandlers(
@@ -131,6 +143,7 @@ export function registerHandlers(
 
       const notifCount = getRepoNotifCount(db, linkedGithubRepo);
       const failedRuns = getFailedRunCount(db, linkedGithubRepo);
+      const lastPushedAt = getLastPushedAt(db, linkedGithubRepo);
 
       const status = checkRepoHealth(
         repo.id,
@@ -139,6 +152,7 @@ export function registerHandlers(
         linkedGithubRepo,
         notifCount,
         failedRuns,
+        lastPushedAt,
       );
 
       repos.push(status);

--- a/src/plugins/dashboard/handler.ts
+++ b/src/plugins/dashboard/handler.ts
@@ -1,4 +1,4 @@
-﻿import { ipcMain } from 'electron';
+import { ipcMain } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import type { BrowserWindow } from 'electron';
 import { execFile } from 'child_process';
@@ -113,10 +113,13 @@ function getRecentFailedRuns(db: SqlJsDatabase, limit = 20): {
 function getLastPushedAt(db: SqlJsDatabase, repoFullName: string | null): string | null {
   if (!repoFullName) return null;
   const stmt = db.prepare('SELECT last_pushed_at FROM github_repos WHERE full_name = ? LIMIT 1');
-  stmt.bind([repoFullName]);
-  const found = stmt.step() ? (stmt.getAsObject() as { last_pushed_at: string | null }) : null;
-  stmt.free();
-  return found?.last_pushed_at ?? null;
+  try {
+    stmt.bind([repoFullName]);
+    const found = stmt.step() ? (stmt.getAsObject() as { last_pushed_at: string | null }) : null;
+    return found?.last_pushed_at ?? null;
+  } finally {
+    stmt.free();
+  }
 }
 
 
@@ -202,7 +205,8 @@ export function registerHandlers(
         totalNotifications: 0,
         totalFailedRuns: 0,
         generatedAt: new Date().toISOString(),
-      };    }
+      };
+    }
   });
 
   /**

--- a/src/plugins/notifications/NotifRepoPanel.tsx
+++ b/src/plugins/notifications/NotifRepoPanel.tsx
@@ -4,7 +4,36 @@ import type { StoredNotification } from '../types';
 import { AgentSelector } from '../agents/AgentSelector';
 
 // Minimum notifications in a group to show the Analyse button
-const ANALYSE_THRESHOLD = 2;
+const ANALYSE_THRESHOLD = 1;
+
+// ── Failure hint extraction ───────────────────────────────────────────────────
+
+interface FailureHint {
+  failingJob: string | null;
+  errorHint: string | null;
+}
+
+/**
+ * Extract the most useful single error line from a GitHub Actions log excerpt.
+ * Strips the leading ISO timestamp that Actions prepends to every line.
+ */
+function extractErrorHint(logExcerpt: string | null): string | null {
+  if (!logExcerpt) return null;
+  const stripTs = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*/;
+  const errorRe = /##\[error\]|error:|failed to |exception:|fatal:/i;
+  const lines = logExcerpt.split('\n');
+  // Prefer a line that looks like an explicit error
+  for (const raw of lines) {
+    const line = raw.replace(stripTs, '').trim();
+    if (line && errorRe.test(line)) return line.slice(0, 140);
+  }
+  // Fall back to the first non-empty line
+  for (const raw of lines) {
+    const line = raw.replace(stripTs, '').trim();
+    if (line) return line.slice(0, 140);
+  }
+  return null;
+}
 
 // Subject types treated as workflow/CI notifications for grouping purposes
 const WORKFLOW_TYPES = new Set(['CheckSuite', 'WorkflowRun']);
@@ -150,6 +179,7 @@ export function NotifRepoPanel({ repoFullName, notifications, onClose, onRefresh
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; notifId: string } | null>(null);
   const [agentTarget, setAgentTarget] = useState<{ workflowFilter?: string } | null>(null);
   const [recoveryMap, setRecoveryMap] = useState<Map<string, boolean>>(new Map());
+  const [failureHintMap, setFailureHintMap] = useState<Map<string, FailureHint>>(new Map());
   const [checkingRecovery, setCheckingRecovery] = useState(false);
   const [dismissingGroup, setDismissingGroup] = useState<string | null>(null);
 
@@ -180,6 +210,7 @@ export function NotifRepoPanel({ repoFullName, notifications, onClose, onRefresh
         if (cancelled) return;
 
         const newMap = new Map<string, boolean>();
+        const newHints = new Map<string, FailureHint>();
         for (const group of ciGroups) {
           const latestNotifTime = Math.max(...group.notifications.map((n) => new Date(n.updated_at).getTime()));
           const recovered = summary.recent_runs.some(
@@ -190,8 +221,26 @@ export function NotifRepoPanel({ repoFullName, notifications, onClose, onRefresh
               new Date(r.run_started_at).getTime() > latestNotifTime,
           );
           newMap.set(group.workflowName!, recovered);
+          if (!recovered) {
+            // Find most recent failed run for this workflow and extract a hint
+            const failedRun = summary.recent_runs.find(
+              (r) =>
+                r.workflow_name === group.workflowName &&
+                (group.branch === null || r.head_branch === group.branch) &&
+                r.conclusion !== 'success',
+            );
+            if (failedRun) {
+              const jobs = summary.jobs_by_run[failedRun.id] ?? [];
+              const failedJob = jobs.find((j) => j.conclusion === 'failure' || j.conclusion === 'cancelled') ?? null;
+              newHints.set(group.workflowName!, {
+                failingJob: failedJob?.name ?? null,
+                errorHint: extractErrorHint(failedJob?.log_excerpt ?? null),
+              });
+            }
+          }
         }
         setRecoveryMap(newMap);
+        setFailureHintMap(newHints);
       } catch {
         // recovery check is best-effort; silently ignore errors
       } finally {
@@ -290,6 +339,17 @@ export function NotifRepoPanel({ repoFullName, notifications, onClose, onRefresh
                 </button>
               )}
             </div>
+            {/* Failure hint: show failing job + first error line from cached logs */}
+            {group.workflowName && !checkingRecovery && recoveryMap.get(group.workflowName) === false && (() => {
+              const hint = failureHintMap.get(group.workflowName!);
+              if (!hint) return null;
+              return (
+                <div class="notif-failure-hint">
+                  {hint.failingJob && <span class="notif-failure-hint-job">Job: {hint.failingJob}</span>}
+                  {hint.errorHint && <code class="notif-failure-hint-error">{hint.errorHint}</code>}
+                </div>
+              );
+            })()}
             {group.notifications.map((n) => (
               <NotifRow
                 key={n.id}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -248,6 +248,10 @@ export interface RepoHealthStatus {
   linkedGithubRepo: string | null;
   failedWorkflowRuns: number;
   exists: boolean;
+  /** ISO timestamp of the most recent local commit (from .git/logs/HEAD) */
+  lastCommitAt: string | null;
+  /** ISO timestamp of the most recent push to GitHub (from github_repos.last_pushed_at) */
+  lastPushedAt: string | null;
 }
 
 export interface DashboardSummary {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -907,14 +907,14 @@ function App() {
         onAgentStart={handleOpenChat}
         onNotificationsDismissed={(ids) => {
           console.log('[App] onNotificationsDismissed called with ids:', ids);
-          const idSet = new Set(ids);
+          const idSet = new Set(ids.map(String));
           setDismissedNotifIds((prev) => {
             const next = new Set(prev);
-            for (const id of ids) next.add(id);
+            for (const id of ids) next.add(String(id));
             console.log('[App] dismissedNotifIds updated, size:', next.size);
             return next;
           });
-          const removeIds = (notifs: StoredNotification[]) => notifs.filter((n) => !idSet.has(n.id));
+          const removeIds = (notifs: StoredNotification[]) => notifs.filter((n) => !idSet.has(String(n.id)));
           setNotifRepoPanel((prev) => prev ? { ...prev, notifications: removeIds(prev.notifications) } : null);
           setLocalNotifRepoPanel((prev) => prev ? { ...prev, notifications: removeIds(prev.notifications) } : null);
           setNotifDive((prev) => prev ? { ...prev, notifications: removeIds(prev.notifications) } : null);
@@ -922,11 +922,12 @@ function App() {
             if (!prev) return prev;
             const newPerRepo = { ...prev.perRepo };
             for (const id of ids) {
+              const sid = String(id);
               // find which repo owns this notification from current panel state
               const repo =
-                notifRepoPanel?.notifications.find((n) => n.id === id)?.repo_full_name ??
-                localNotifRepoPanel?.notifications.find((n) => n.id === id)?.repo_full_name ??
-                notifDive?.notifications.find((n) => n.id === id)?.repo_full_name;
+                notifRepoPanel?.notifications.find((n) => String(n.id) === sid)?.repo_full_name ??
+                localNotifRepoPanel?.notifications.find((n) => String(n.id) === sid)?.repo_full_name ??
+                notifDive?.notifications.find((n) => String(n.id) === sid)?.repo_full_name;
               if (repo) newPerRepo[repo] = Math.max(0, (newPerRepo[repo] ?? 1) - 1);
             }
             return { ...prev, total: Math.max(0, prev.total - ids.length), perRepo: newPerRepo };

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -70,6 +70,7 @@ function App() {
   const [showOllamaPanel, setShowOllamaPanel] = useState(false);
   const [selectedOllamaModel, setSelectedOllamaModel] = useState<string | null>(null);
   const [showChatPanel, setShowChatPanel] = useState(false);
+  const [dismissedNotifIds, setDismissedNotifIds] = useState<ReadonlySet<string>>(new Set());
   const [notifCounts, setNotifCounts] = useState<NotificationCounts | null>(null);
   const [notifFetching, setNotifFetching] = useState(false);
   const [sortByNotifs, setSortByNotifs] = useState(false);
@@ -693,7 +694,7 @@ function App() {
 
       {/* ── Dashboard tab ────────────────────────────────────────────────── */}
       {activeTab === 'dashboard' && (
-        <DashboardPanel />
+        <DashboardPanel dismissedNotifIds={dismissedNotifIds} />
       )}
 
       {/* ── Setup tab (original content) ─────────────────────────────────── */}
@@ -905,7 +906,14 @@ function App() {
         onClose={() => { setShowChatPanel(false); localStorage.setItem('chat-panel-open', 'false'); }}
         onAgentStart={handleOpenChat}
         onNotificationsDismissed={(ids) => {
+          console.log('[App] onNotificationsDismissed called with ids:', ids);
           const idSet = new Set(ids);
+          setDismissedNotifIds((prev) => {
+            const next = new Set(prev);
+            for (const id of ids) next.add(id);
+            console.log('[App] dismissedNotifIds updated, size:', next.size);
+            return next;
+          });
           const removeIds = (notifs: StoredNotification[]) => notifs.filter((n) => !idSet.has(n.id));
           setNotifRepoPanel((prev) => prev ? { ...prev, notifications: removeIds(prev.notifications) } : null);
           setLocalNotifRepoPanel((prev) => prev ? { ...prev, notifications: removeIds(prev.notifications) } : null);

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -112,6 +112,9 @@ button:disabled {
   border-radius: 6px;
   cursor: pointer;
   transition: background 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .dash-refresh-btn:hover {
@@ -121,6 +124,21 @@ button:disabled {
 .dash-refresh-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.dash-refresh-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex-shrink: 0;
+  transition: transform 0.2s;
+}
+
+@keyframes dash-spin {
+  to { transform: rotate(360deg); }
+}
+
+.dash-refresh-icon--spinning {
+  animation: dash-spin 0.7s linear infinite;
 }
 
 /* Summary cards row */
@@ -882,6 +900,25 @@ button:disabled {
   opacity: 0.7;
   background: #0d3320;
   color: #4eca8a;
+}
+
+.dash-analyse-btn {
+  background: #0d1f3c;
+  border: 1px solid #2a5298;
+  color: #6ba3e8;
+  border-radius: 5px;
+  font-size: 0.68rem;
+  line-height: 1.4;
+  padding: 0.1rem 0.45rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.dash-analyse-btn:hover {
+  background: #152b52;
+  color: #9ec0f5;
 }
 
 /* ── Dismiss-group spinner ────────────────────────────────────────────────── */
@@ -2358,6 +2395,38 @@ h5.ec-heading { font-size: 0.85rem; }
   opacity: 0.7;
   background: #0d3320;
   color: #4eca8a;
+}
+
+/* ── Failure hint row (below group header, above notification rows) ───────── */
+.notif-failure-hint,
+.dash-failure-hint {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.3rem 0.75rem 0.3rem 2.1rem;
+  background: #1a0c0c;
+  border-bottom: 1px solid #3a1a1a;
+  font-size: 0.72rem;
+}
+.notif-failure-hint-job,
+.dash-failure-hint-job {
+  color: #c88080;
+  font-weight: 600;
+}
+.notif-failure-hint-error,
+.dash-failure-hint-error {
+  display: block;
+  color: #f8a0a0;
+  background: #2a0f0f;
+  border-left: 2px solid #f87171;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0 3px 3px 0;
+  font-family: ui-monospace, 'Cascadia Code', Consolas, monospace;
+  font-size: 0.68rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.5;
+  overflow: hidden;
 }
 
 /* scope workflow badge in the AgentSelector modal */

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -327,11 +327,49 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.4rem;
   margin-bottom: 0.6rem;
 }
 
 .dash-section-header h3 {
   margin-bottom: 0;
+}
+
+/* ── Sort controls ───────────────────────────────────────────────────────── */
+.dash-sort-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.dash-sort-label {
+  font-size: 0.74rem;
+  color: #6a6a8a;
+  margin-right: 0.1rem;
+}
+
+.dash-sort-btn {
+  background: #16213e;
+  border: 1px solid #0f3460;
+  color: #8a8a9a;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.74rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.dash-sort-btn:hover {
+  background: #1a2e56;
+  color: #c8c8e0;
+}
+
+.dash-sort-btn--active {
+  background: #0f3460;
+  border-color: #4590e9;
+  color: #d0e8ff;
 }
 
 .dash-filter-btns {

--- a/src/services/git-health.ts
+++ b/src/services/git-health.ts
@@ -144,7 +144,9 @@ export function getLastCommitTime(repoPath: string): string | null {
     const lines = content.split('\n');
     const lastLine = lines[lines.length - 1];
     // Format: <oldSHA> <newSHA> <author> <unixTimestamp> <tzOffset>\t<message>
-    const match = lastLine.match(/\d+ (\d+) [+-]\d{4}\t/);
+    // Extract timestamp from the metadata before the tab, at end of the field 
+    const [metadata] = lastLine.split('\t', 1);
+    const match = metadata.match(/(\d+)\s+[+-]\d{4}$/);
     if (!match) return null;
     return new Date(parseInt(match[1], 10) * 1000).toISOString();
   } catch {

--- a/src/services/git-health.ts
+++ b/src/services/git-health.ts
@@ -31,6 +31,10 @@ export interface RepoHealthStatus {
   failedWorkflowRuns: number;
   /** Whether the repo directory still exists on disk */
   exists: boolean;
+  /** Timestamp of the most recent local commit (from .git/logs/HEAD), or null */
+  lastCommitAt: string | null;
+  /** Timestamp of the most recent push to GitHub (from github_repos.last_pushed_at), or null */
+  lastPushedAt: string | null;
 }
 
 export type HealthWarningKind =
@@ -129,6 +133,25 @@ function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Read the timestamp of the most recent entry in `.git/logs/HEAD`.
+ * Returns an ISO string, or null if the log cannot be read.
+ */
+export function getLastCommitTime(repoPath: string): string | null {
+  const logPath = path.join(repoPath, '.git', 'logs', 'HEAD');
+  try {
+    const content = fs.readFileSync(logPath, 'utf-8').trimEnd();
+    const lines = content.split('\n');
+    const lastLine = lines[lines.length - 1];
+    // Format: <oldSHA> <newSHA> <author> <unixTimestamp> <tzOffset>\t<message>
+    const match = lastLine.match(/\d+ (\d+) [+-]\d{4}\t/);
+    if (!match) return null;
+    return new Date(parseInt(match[1], 10) * 1000).toISOString();
+  } catch {
+    return null;
+  }
+}
+
 // ── Health check orchestration ────────────────────────────────────────────────
 
 export function checkRepoHealth(
@@ -138,6 +161,7 @@ export function checkRepoHealth(
   linkedGithubRepo: string | null,
   notificationCount: number,
   failedWorkflowRuns: number,
+  lastPushedAt: string | null = null,
 ): RepoHealthStatus {
   const exists = fs.existsSync(path.join(localPath, '.git'));
 
@@ -155,11 +179,14 @@ export function checkRepoHealth(
       linkedGithubRepo,
       failedWorkflowRuns,
       exists: false,
+      lastCommitAt: null,
+      lastPushedAt,
     };
   }
 
   const currentBranch = getCurrentBranch(localPath);
   const remoteCount = countRemotes(localPath);
+  const lastCommitAt = getLastCommitTime(localPath);
   let hasUpstream = false;
   let upstreamRef: string | null = null;
 
@@ -184,6 +211,8 @@ export function checkRepoHealth(
     linkedGithubRepo,
     failedWorkflowRuns,
     exists,
+    lastCommitAt,
+    lastPushedAt,
   };
 }
 

--- a/tests/unit/git-health.test.ts
+++ b/tests/unit/git-health.test.ts
@@ -8,6 +8,7 @@ import {
   countRemotes,
   checkRepoHealth,
   deriveWarnings,
+  getLastCommitTime,
 } from '../../src/services/git-health';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -304,5 +305,45 @@ describe('deriveWarnings', () => {
     // non-existing repos don't produce branch/remote warnings
     // but DO produce notification warnings
     expect(warnings).toHaveLength(0);
+  });
+});
+
+// -- getLastCommitTime -------------------------------------------------------
+
+describe("getLastCommitTime", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jarvis-glct-"));
+    fs.mkdirSync(path.join(tmpDir, ".git", "logs"), { recursive: true });
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("parses a standard git log HEAD line", () => {
+    const unixTs = 1712345678;
+    const line = "0000000000000000 abc123 Author <a@example.com> " + unixTs + " +0100	Initial commit";
+    fs.writeFileSync(path.join(tmpDir, ".git", "logs", "HEAD"), line + "\n", "utf-8");
+    expect(getLastCommitTime(tmpDir)).toBe(new Date(unixTs * 1000).toISOString());
+  });
+
+  it("returns the last entry timestamp for multiple entries", () => {
+    const olderTs = 1700000000;
+    const newerTs = 1712345678;
+    const lines = [
+      "000000000 aaa111 Author <a@example.com> " + olderTs + " +0000	First",
+      "aaa111 bbb222 Author <a@example.com> " + newerTs + " +0100	Second",
+    ].join("\n");
+    fs.writeFileSync(path.join(tmpDir, ".git", "logs", "HEAD"), lines + "\n", "utf-8");
+    expect(getLastCommitTime(tmpDir)).toBe(new Date(newerTs * 1000).toISOString());
+  });
+
+  it("returns null when .git/logs/HEAD does not exist", () => {
+    expect(getLastCommitTime(tmpDir)).toBeNull();
+  });
+
+  it("returns null when the log line has an unexpected format", () => {
+    fs.writeFileSync(path.join(tmpDir, ".git", "logs", "HEAD"), "not a git log line\n", "utf-8");
+    expect(getLastCommitTime(tmpDir)).toBeNull();
   });
 });


### PR DESCRIPTION
## What

Brings in all three commits from the \origin/repo-dashboard\ branch, rebased onto the current \main\. Conflicts were resolved with main taking precedence on structure while repo-dashboard changes were applied on top.

## Changes

### \src/services/git-health.ts\
- Adds \lastCommitAt\ (from \.git/logs/HEAD\) and \lastPushedAt\ (from \github_repos\) fields to \RepoHealthStatus\
- Adds \getLastCommitTime()\ helper that parses the latest HEAD log entry

### \src/plugins/dashboard/handler.ts\
- Adds \getLastPushedAt()\ DB helper
- Passes \lastPushedAt\ to \checkRepoHealth\ for every repo in the summary

### \src/plugins/dashboard/DashboardPanel.tsx\
- **Sort modes**: replaces notification count/name sort with 3-way sort (⚠️ Attention · 💻 Local activity · ☁️ Remote activity) using \lastCommitAt\ / \lastPushedAt\
- **Failure hints**: \xtractErrorHint()\ extracts the first error line from CI job log excerpts, shown inline under failing workflow groups
- **Dismissed-notif filtering**: \NotificationList\ accepts \dismissedNotifIds: ReadonlySet<string>\ so notifications dismissed via the agent approval panel disappear from the dashboard immediately

### Other files
- \NotifRepoPanel.tsx\, \AgentApprovalPanel.tsx\: coerce notification IDs to strings for consistent comparison
- \	ypes.ts\, \index.tsx\, \onboarding.css\: supporting type and style updates