### PR TITLE
docs: add SECURITY.md with responsible disclosure process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version on the `main` branch of this repository is actively supported with security updates.
+
+| Branch | Supported |
+| ------ | --------- |
+| `main` | ✅ Yes    |
+| Others | ❌ No     |
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for security vulnerabilities.**
+
+Report security vulnerabilities via GitHub's private security advisory feature:
+
+1. Go to the [rajbos/Jarvis Security Advisories](https://github.com/rajbos/Jarvis/security/advisories) page
+2. Click **"New draft security advisory"**
+3. Describe the vulnerability, steps to reproduce, and potential impact
+
+This keeps the disclosure private until a fix is in place.
+
+## Response Timeline
+
+| Stage        | Target      |
+| ------------ | ----------- |
+| Acknowledge  | Within 7 days  |
+| Triage       | Within 14 days |
+| Patch/fix    | Within 90 days (for verified vulnerabilities) |
+
+## Scope
+
+Jarvis handles sensitive data that warrants careful security consideration:
+
+- **GitHub OAuth tokens** — used to authenticate with the GitHub API
+- **Personal Access Tokens (PATs)** — stored locally for repository access
+- **Encrypted local secrets** — stored in a SQLite database using DPAPI-backed encryption via Electron's `safeStorage`
+
+Vulnerabilities affecting the confidentiality, integrity, or availability of any of the above are in scope.
+
+## Out of Scope
+
+The following are **not** considered in-scope vulnerabilities:
+
+- Issues in third-party services or dependencies (report those upstream)
+- Vulnerabilities that require physical access to the user's machine
+- Issues in Ollama or other locally-hosted services Jarvis connects to
+- Social engineering attacks
+
+## Acknowledgements
+
+We appreciate responsible disclosure and will acknowledge reporters in the release notes for patches addressing their findings (unless they prefer to remain anonymous).


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` to the repository root, establishing a clear responsible disclosure policy for Jarvis.

### What's included

- **Supported Versions** — only `main` branch is actively supported
- **Reporting** — directs reporters to GitHub's private Security Advisories (no public issues, no email)
- **Response Timeline** — 7-day acknowledgement, 14-day triage, 90-day patch target
- **Scope** — explicitly calls out GitHub OAuth tokens, PATs, and DPAPI-encrypted SQLite secrets
- **Out of Scope** — third-party services, physical access attacks, Ollama/local service issues

Closes #81
Part of #72