### PR TITLE
fix: add try/catch to unguarded IPC handlers

### DIFF
--- a/src/plugins/config/handler.ts
+++ b/src/plugins/config/handler.ts
@@ -7,18 +7,30 @@ import { loadConfig, saveConfig } from '../../agent/config';
 
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('onboarding:status', () => {
-    return getOnboardingStatus(db);
+    try {
+      return getOnboardingStatus(db);
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   ipcMain.handle('app:get-preferences', () => {
-    return loadConfig().preferences;
+    try {
+      return loadConfig().preferences;
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   ipcMain.handle('app:set-preferences', (_event, prefs: Partial<{ sortByNotifications: boolean; localSortByNotifs: boolean; localRepoSortKey: 'name' | 'scanned' | 'notifs' }>) => {
     if (typeof prefs !== 'object' || prefs === null || Array.isArray(prefs)) return { ok: false, error: 'Invalid preferences' };
-    const config = loadConfig();
-    config.preferences = { ...config.preferences, ...prefs };
-    saveConfig(config);
-    return { ok: true };
+    try {
+      const config = loadConfig();
+      config.preferences = { ...config.preferences, ...prefs };
+      saveConfig(config);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 }

--- a/src/plugins/local-repos/handler.ts
+++ b/src/plugins/local-repos/handler.ts
@@ -18,58 +18,93 @@ let lastLocalScanProgress: ScanProgress | null = null;
 
 export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('local:get-folders', () => {
-    return getScanFolders(db);
+    try {
+      return getScanFolders(db);
+    } catch (err) {
+      console.error('[IPC] local:get-folders failed:', err);
+      return [];
+    }
   });
 
   ipcMain.handle('local:add-folder', async (_event, folderPath?: string) => {
-    let chosenPath = folderPath;
-    if (!chosenPath) {
-      const win = getWindow();
-      const result = await dialog.showOpenDialog(win ?? new BrowserWindow({ show: false }), {
-        properties: ['openDirectory'],
-        title: 'Select a folder to scan for Git repositories',
-      });
-      if (result.canceled || result.filePaths.length === 0) {
-        return { canceled: true };
+    try {
+      let chosenPath = folderPath;
+      if (!chosenPath) {
+        const win = getWindow();
+        const result = await dialog.showOpenDialog(win ?? new BrowserWindow({ show: false }), {
+          properties: ['openDirectory'],
+          title: 'Select a folder to scan for Git repositories',
+        });
+        if (result.canceled || result.filePaths.length === 0) {
+          return { canceled: true };
+        }
+        chosenPath = result.filePaths[0];
       }
-      chosenPath = result.filePaths[0];
+      addScanFolder(db, chosenPath);
+      saveDatabase();
+      return { ok: true, path: chosenPath };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
-    addScanFolder(db, chosenPath);
-    saveDatabase();
-    return { ok: true, path: chosenPath };
   });
 
   ipcMain.handle('local:remove-folder', (_event, folderPath: string) => {
     if (typeof folderPath !== 'string' || folderPath.length === 0) return { ok: false, error: 'Invalid folderPath' };
-    removeScanFolder(db, folderPath);
-    saveDatabase();
-    return { ok: true };
+    try {
+      removeScanFolder(db, folderPath);
+      saveDatabase();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   ipcMain.handle('local:get-scan-status', () => {
-    return { running: localScanRunning, progress: lastLocalScanProgress };
+    try {
+      return { running: localScanRunning, progress: lastLocalScanProgress };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   ipcMain.handle('local:start-scan', () => {
-    startLocalScanIfNeeded(db, getWindow, true);
-    return { started: true };
+    try {
+      startLocalScanIfNeeded(db, getWindow, true);
+      return { started: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   ipcMain.handle('local:list-repos', () => {
-    return listLocalRepos(db);
+    try {
+      return listLocalRepos(db);
+    } catch (err) {
+      console.error('[IPC] local:list-repos failed:', err);
+      return [];
+    }
   });
 
   ipcMain.handle('local:list-repos-for-folder', (_event, folderPath: string) => {
     if (typeof folderPath !== 'string' || folderPath.length === 0) return [];
-    return listLocalReposForFolder(db, folderPath);
+    try {
+      return listLocalReposForFolder(db, folderPath);
+    } catch (err) {
+      console.error('[IPC] local:list-repos-for-folder failed:', err);
+      return [];
+    }
   });
 
   ipcMain.handle('local:link-repo', (_event, localRepoId: number, githubRepoId: number | null) => {
     if (typeof localRepoId !== 'number') return { ok: false, error: 'Invalid localRepoId' };
     if (githubRepoId !== null && typeof githubRepoId !== 'number') return { ok: false, error: 'Invalid githubRepoId' };
-    linkLocalRepo(db, localRepoId, githubRepoId);
-    saveDatabase();
-    return { ok: true };
+    try {
+      linkLocalRepo(db, localRepoId, githubRepoId);
+      saveDatabase();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   ipcMain.handle('local:open-folder', (_event, folderPath: string) => {

--- a/src/plugins/orgs/handler.ts
+++ b/src/plugins/orgs/handler.ts
@@ -7,14 +7,23 @@ import { saveDatabase } from '../../storage/database';
 
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('github:list-orgs', () => {
-    return listOrgs(db);
+    try {
+      return listOrgs(db);
+    } catch (err) {
+      console.error('[IPC] github:list-orgs failed:', err);
+      return [];
+    }
   });
 
   ipcMain.handle('github:set-org-enabled', (_event, orgLogin: string, enabled: boolean) => {
     if (typeof orgLogin !== 'string' || orgLogin.length === 0) return { ok: false, error: 'Invalid orgLogin' };
     if (typeof enabled !== 'boolean') return { ok: false, error: 'Invalid enabled value' };
-    setOrgDiscoveryEnabled(db, orgLogin, enabled);
-    saveDatabase();
-    return { ok: true };
+    try {
+      setOrgDiscoveryEnabled(db, orgLogin, enabled);
+      saveDatabase();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 }

--- a/src/plugins/secrets/handler.ts
+++ b/src/plugins/secrets/handler.ts
@@ -32,27 +32,50 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
 
   ipcMain.handle('secrets:list-for-repo', (_event, repoFullName: string) => {
     if (typeof repoFullName !== 'string' || repoFullName.length === 0) return { ok: false, error: 'Invalid repoFullName' };
-    return listSecretsForRepo(db, repoFullName);
+    try {
+      return listSecretsForRepo(db, repoFullName);
+    } catch (err) {
+      console.error('[IPC] secrets:list-for-repo failed:', err);
+      return [];
+    }
   });
 
   ipcMain.handle('secrets:list-all', () => {
-    return searchSecrets(db, '');
+    try {
+      return searchSecrets(db, '');
+    } catch (err) {
+      console.error('[IPC] secrets:list-all failed:', err);
+      return [];
+    }
   });
 
   ipcMain.handle('secrets:list-favorites', () => {
-    return listSecretFavorites(db);
+    try {
+      return listSecretFavorites(db);
+    } catch (err) {
+      console.error('[IPC] secrets:list-favorites failed:', err);
+      return [];
+    }
   });
 
   ipcMain.handle('secrets:add-favorite', (_event, targetType: 'org' | 'repo', targetName: string) => {
     if (targetType !== 'org' && targetType !== 'repo') return { ok: false, error: 'Invalid targetType' };
     if (typeof targetName !== 'string' || targetName.length === 0) return { ok: false, error: 'Invalid targetName' };
-    addSecretFavorite(db, targetType, targetName);
-    return { ok: true };
+    try {
+      addSecretFavorite(db, targetType, targetName);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   ipcMain.handle('secrets:remove-favorite', (_event, targetName: string) => {
     if (typeof targetName !== 'string' || targetName.length === 0) return { ok: false, error: 'Invalid targetName' };
-    removeSecretFavorite(db, targetName);
-    return { ok: true };
+    try {
+      removeSecretFavorite(db, targetName);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 }


### PR DESCRIPTION
## Summary

Wraps all unguarded IPC handler bodies in `try/catch` blocks so unexpected errors surface as structured responses rather than crashing or silently failing.

### Changes

- **`src/plugins/config/handler.ts`** — `onboarding:status`, `app:get-preferences`, and the DB/file operations in `app:set-preferences` are now guarded.
- **`src/plugins/orgs/handler.ts`** — `github:list-orgs` (returns `[]` on error) and the success path of `github:set-org-enabled` are now guarded.
- **`src/plugins/local-repos/handler.ts`** — `local:get-folders`, `local:add-folder`, `local:remove-folder`, `local:get-scan-status`, `local:start-scan`, `local:list-repos`, `local:list-repos-for-folder`, `local:link-repo` are now guarded. `local:open-folder` is unchanged (fire-and-forget).
- **`src/plugins/secrets/handler.ts`** — `secrets:list-for-repo`, `secrets:list-all`, `secrets:list-favorites`, `secrets:add-favorite`, `secrets:remove-favorite` are now guarded. `secrets:scan` was already guarded.

List-style handlers return `[]` on error; mutation handlers return `{ ok: false, error: <message> }`.

Closes #80
Part of #72