### PR TITLE
docs: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: "Bug Report"
+about: "Report a bug in Jarvis"
+labels: "bug"
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include any error messages or stack traces.
+
+## Environment
+
+- **OS**: (e.g. Windows 11 22H2)
+- **Electron version**: (e.g. 34.0.0)
+- **Ollama version**: (e.g. 0.6.0)
+- **Node version**: (e.g. 20.x)
+
+## Screenshots / Logs
+
+If applicable, add screenshots or paste relevant log output to help explain the problem.
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: "Feature Request"
+about: "Suggest a new feature or improvement"
+labels: "enhancement"
+---
+
+## Is Your Feature Request Related to a Problem?
+
+A clear and concise description of what the problem is. (e.g. "I find it frustrating when...")
+
+## Describe the Solution You'd Like
+
+A clear and concise description of what you want to happen.
+
+## Describe Alternatives You've Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, screenshots, or examples about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary of Changes
+
+<!-- Describe what this PR does and why. -->
+
+## Related Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor
+- [ ] Tests
+
+## How to Test
+
+<!-- Steps to verify the change works correctly. -->
+
+1.
+2.
+3.
+
+## Checklist
+
+- [ ] Tests pass (`npm test`)
+- [ ] Documentation updated (if applicable)
+- [ ] No secrets or sensitive data committed


### PR DESCRIPTION
Add GitHub issue templates and a pull request template to standardize contributions.

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md` — bug report template with environment details, steps to reproduce, expected vs actual behavior, and optional screenshots/logs
- `.github/ISSUE_TEMPLATE/feature_request.md` — feature request template with problem statement, desired solution, and alternatives considered
- `.github/pull_request_template.md` — PR template with summary, related issue, type of change checkboxes, how to test, and a pre-merge checklist

Closes #84
Part of #72

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>