### PR TITLE
feat: dismiss notifications for merged Dependabot PRs

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -85,7 +85,7 @@ async function initialize(): Promise<void> {
   if (!needsOnboarding || onboarding.github_oauth === 'completed') {
     startDiscoveryIfAuthed(db, () => mainWindow);
     // Pre-warm workflow run cache so recovery status is ready when panels open
-    runBootWorkflowCheck(db).catch((err) => {
+    runBootWorkflowCheck(db, () => mainWindow).catch((err) => {
       console.warn('[Boot] Workflow check failed:', err instanceof Error ? err.message : String(err));
     });
   }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -67,6 +67,8 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('github:list-notifications-for-starred'),
   dismissNotification: (id: string) =>
     ipcRenderer.invoke('github:dismiss-notification', id),
+  checkMergedDependabotPRs: () =>
+    ipcRenderer.invoke('github:check-merged-dependabot-prs'),
   getRunUrlForCheckSuite: (checkSuiteApiUrl: string) =>
     ipcRenderer.invoke('github:get-run-url-for-check-suite', checkSuiteApiUrl),
   // Local repos

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -235,4 +235,9 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.on('browser:extension-connected', listener);
     return () => { ipcRenderer.removeListener('browser:extension-connected', listener); };
   },
+  onBackgroundStatus: (callback: (message: string) => void) => {
+    const listener = (_event: unknown, message: string) => callback(message);
+    ipcRenderer.on('app:background-status', listener);
+    return () => { ipcRenderer.removeListener('app:background-status', listener); };
+  },
 });

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -127,8 +127,8 @@ function RecoverableBanner({
     onDismissed();
   };
 
-  if (checking) return null;
-
+  // Keep showing the banner with the last known results while re-checking.
+  // The totalIds.length === 0 guard above handles the initial-load case.
   return (
     <div class="dash-recoverable-banner">
       <span class="dash-recoverable-icon">✓</span>

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -156,6 +156,79 @@ function RecoverableBanner({
   );
 }
 
+// ── Merged Dependabot PR notifications banner ─────────────────────────────────
+
+/**
+ * Checks all stored PR notifications for Dependabot-authored PRs that have
+ * been merged, and offers a single "dismiss all" action.
+ * Re-checks whenever `refreshKey` changes (e.g. on dashboard reload).
+ */
+function DependabotMergedBanner({
+  refreshKey,
+  onDismissed,
+}: {
+  refreshKey: string;
+  onDismissed: () => void;
+}) {
+  const [notifications, setNotifications] = useState<StoredNotification[]>([]);
+  const [checking, setChecking] = useState(true);
+  const [dismissing, setDismissing] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setChecking(true);
+    setNotifications([]);
+
+    const run = async () => {
+      try {
+        const result = await window.jarvis.checkMergedDependabotPRs();
+        if (!cancelled) setNotifications(result);
+      } catch {
+        // best-effort; silently ignore
+      } finally {
+        if (!cancelled) setChecking(false);
+      }
+    };
+
+    void run();
+    return () => { cancelled = true; };
+  }, [refreshKey]);
+
+  if (checking || notifications.length === 0) return null;
+
+  const repoCount = new Set(notifications.map((n) => n.repo_full_name)).size;
+  const summary = `${notifications.length} notification${notifications.length !== 1 ? 's' : ''} for merged PRs across ${repoCount} repo${repoCount !== 1 ? 's' : ''}.`;
+  const tooltip = notifications.map((n) => `${n.repo_full_name}: ${n.subject_title}`).join('\n');
+
+  const handleDismissAll = async () => {
+    setDismissing(true);
+    for (const n of notifications) {
+      try { await window.jarvis.dismissNotification(n.id); } catch { /* skip */ }
+    }
+    setDismissing(false);
+    onDismissed();
+  };
+
+  return (
+    <div class="dash-recoverable-banner">
+      <span class="dash-recoverable-icon">🤖</span>
+      <div class="dash-recoverable-body">
+        <span class="dash-recoverable-title">Merged Dependabot PRs</span>
+        <span class="dash-recoverable-detail" title={tooltip}>{summary}</span>
+      </div>
+      <button
+        class={`dash-recoverable-btn${dismissing ? ' dash-recoverable-btn--busy' : ''}`}
+        disabled={dismissing}
+        onClick={() => void handleDismissAll()}
+      >
+        {dismissing
+          ? <span class="dismiss-spinner" />
+          : `Dismiss ${notifications.length} notification${notifications.length !== 1 ? 's' : ''}`}
+      </button>
+    </div>
+  );
+}
+
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function WarningIcon({ kind }: { kind: HealthWarning['kind'] }) {
@@ -1234,6 +1307,12 @@ export function DashboardPanel({ dismissedNotifIds }: { dismissedNotifIds?: Read
             document.getElementById(`dash-repo-${repo.localRepoId}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
           });
         }}
+      />
+
+      {/* Merged Dependabot PRs — dismiss all notifications for merged dependabot PRs */}
+      <DependabotMergedBanner
+        refreshKey={summary.generatedAt}
+        onDismissed={load}
       />
 
       {/* Repo health list — filtered by selected card */}

--- a/src/plugins/discovery/handler.ts
+++ b/src/plugins/discovery/handler.ts
@@ -80,6 +80,8 @@ export function startDiscoveryIfAuthed(
   const auth = loadGitHubAuth(db);
   if (!auth) return;
 
+  const sendStatus = (msg: string) => getWindow()?.webContents.send('app:background-status', msg);
+
   if (activeDiscovery && !activeDiscovery.aborted) {
     console.log('[Discovery] Already running, skipping');
     return;
@@ -139,12 +141,14 @@ export function startDiscoveryIfAuthed(
 
       if (isStale) {
         console.log('[Discovery] Data is stale, running lightweight refresh');
+        sendStatus('Syncing repos\u2026');
         const pat = loadGitHubPat(db);
         runLightweightRefresh(db, auth.accessToken, (progress) => {
           setLastDiscoveryProgress(progress);
           getWindow()?.webContents.send('github:discovery-progress', progress);
         }, pat, auth.login).then(() => {
           console.log('[Discovery] Lightweight refresh finished');
+          sendStatus('Repos synced.');
           getWindow()?.webContents.send('github:discovery-complete', lastDiscoveryProgress);
         }).catch((err) => {
           console.error('[Discovery] Lightweight refresh failed:', err);
@@ -153,7 +157,8 @@ export function startDiscoveryIfAuthed(
         console.log(`[Discovery] Already have ${existing.orgs.length} org(s) in DB and data is fresh, skipping.`);
 
         if (existing.starredRepoCount === 0) {
-          console.log('[Discovery] No starred repos indexed yet — fetching stars now');
+          console.log('[Discovery] No starred repos indexed yet - fetching stars now');
+          sendStatus('Fetching starred repos\u2026');
           const starState: DiscoveryState = { callsSinceLastPause: 0, aborted: false, lastRateLimit: null };
           const starProgress: DiscoveryProgress = { phase: 'starred', orgsFound: 0, reposFound: 0 };
           fetchStarredRepos(db, auth.accessToken, starState, starProgress, (p) => {
@@ -162,6 +167,7 @@ export function startDiscoveryIfAuthed(
           }).then(() => {
             const done: DiscoveryProgress = { phase: 'done', orgsFound: 0, reposFound: starProgress.reposFound };
             setLastDiscoveryProgress(done);
+            sendStatus(starProgress.reposFound + ' starred repo' + (starProgress.reposFound !== 1 ? 's' : '') + ' loaded.');
             getWindow()?.webContents.send('github:discovery-complete', done);
           }).catch((err) => console.error('[Discovery] Starred-only fetch failed:', err));
         }
@@ -171,6 +177,7 @@ export function startDiscoveryIfAuthed(
   }
 
   console.log('[Discovery] Starting background discovery for', auth.login);
+  sendStatus('Discovering repos\u2026');
   const pat = loadGitHubPat(db);
   runDiscovery(db, auth.accessToken, (progress) => {
     setLastDiscoveryProgress(progress);
@@ -178,6 +185,7 @@ export function startDiscoveryIfAuthed(
   }, pat, auth.login).then((_state) => {
     setActiveDiscovery(null);
     console.log('[Discovery] Finished');
+    sendStatus('Discovery finished — ' + (lastDiscoveryProgress?.reposFound ?? 0) + ' repos found.');
     getWindow()?.webContents.send('github:discovery-complete', lastDiscoveryProgress);
   }).catch((err) => {
     setActiveDiscovery(null);

--- a/src/plugins/notifications/handler.ts
+++ b/src/plugins/notifications/handler.ts
@@ -111,7 +111,10 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
  * CI-type notifications stored locally. This ensures the recovery check in
  * the UI can resolve immediately without a user-triggered fetch.
  */
-export async function runBootWorkflowCheck(db: SqlJsDatabase): Promise<void> {
+export async function runBootWorkflowCheck(
+  db: SqlJsDatabase,
+  getWindow: () => BrowserWindow | null,
+): Promise<void> {
   const auth = loadGitHubAuth(db);
   if (!auth) return;
 
@@ -124,10 +127,14 @@ export async function runBootWorkflowCheck(db: SqlJsDatabase): Promise<void> {
   const repos: string[] = result[0]?.values.map((row) => row[0] as string) ?? [];
   if (repos.length === 0) return;
 
+  const sendStatus = (msg: string) => getWindow()?.webContents.send('app:background-status', msg);
+
   console.log(`[Boot] Pre-warming workflow cache for ${repos.length} repo(s) with CI notifications…`);
+  sendStatus(`Caching workflow data for ${repos.length} repo${repos.length !== 1 ? 's' : ''}…`);
 
   for (const repo of repos) {
     try {
+      sendStatus(`Loading workflow runs: ${repo.split('/')[1]}…`);
       const { runsStored } = await fetchAndStoreWorkflowData(db, auth.accessToken, repo);
       console.log(`[Boot] Cached ${runsStored} workflow run(s) for ${repo}`);
     } catch (err) {
@@ -136,5 +143,6 @@ export async function runBootWorkflowCheck(db: SqlJsDatabase): Promise<void> {
     }
   }
 
+  sendStatus('Workflow cache ready.');
   saveDatabase();
 }

--- a/src/plugins/notifications/handler.ts
+++ b/src/plugins/notifications/handler.ts
@@ -14,6 +14,7 @@ import {
   listNotificationsForStarred,
   deleteNotification,
   markNotificationRead,
+  listMergedDependabotPRNotifications,
 } from '../../services/github-notifications';
 import { loadGitHubAuth } from '../../services/github-oauth';
 import { saveDatabase } from '../../storage/database';
@@ -91,6 +92,17 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
     }
     deleteNotification(db, id);
     saveDatabase();
+  });
+
+  ipcMain.handle('github:check-merged-dependabot-prs', async () => {
+    const auth = loadGitHubAuth(db);
+    if (!auth) return [];
+    try {
+      return await listMergedDependabotPRNotifications(db, auth.accessToken);
+    } catch (err) {
+      console.warn('[Jarvis] Could not check merged dependabot PRs:', err instanceof Error ? err.message : String(err));
+      return [];
+    }
   });
 }
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -471,6 +471,7 @@ export interface JarvisApi {
   listNotificationsForOwner(owner: string): Promise<StoredNotification[]>;
   listNotificationsForStarred(): Promise<StoredNotification[]>;
   dismissNotification(id: string): Promise<void>;
+  checkMergedDependabotPRs(): Promise<StoredNotification[]>;
   getRunUrlForCheckSuite(checkSuiteApiUrl: string): Promise<string | null>;
   getPreferences(): Promise<{ sortByNotifications: boolean; localSortByNotifs: boolean; localRepoSortKey: 'name' | 'scanned' | 'notifs' }>;
   setPreferences(prefs: { sortByNotifications?: boolean; localSortByNotifs?: boolean; localRepoSortKey?: 'name' | 'scanned' | 'notifs' }): Promise<{ ok: boolean }>;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -557,6 +557,7 @@ export interface JarvisApi {
   browserGetPageContent(tabId?: number): Promise<{ ok: boolean; data?: unknown; error?: string }>;
   browserFocusWindow(tabId?: number): Promise<{ ok: boolean; windowId?: number; error?: string }>;
   onBrowserExtensionConnected(cb: (data: { count: number }) => void): () => void;
+  onBackgroundStatus(cb: (message: string) => void): () => void;
 }
 
 declare global {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1011,6 +1011,35 @@ function App() {
           });
         }}
       />
+      <BackgroundStatusBar />
+    </div>
+  );
+}
+
+// ── Background status bar ─────────────────────────────────────────────────────
+
+function BackgroundStatusBar() {
+  const [message, setMessage] = useState<string | null>(null);
+  const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const unsub = window.jarvis.onBackgroundStatus((msg) => {
+      setMessage(msg);
+      if (fadeTimer.current) clearTimeout(fadeTimer.current);
+      fadeTimer.current = setTimeout(() => setMessage(null), 4000);
+    });
+    return () => {
+      unsub();
+      if (fadeTimer.current) clearTimeout(fadeTimer.current);
+    };
+  }, []);
+
+  if (!message) return null;
+
+  return (
+    <div class="bg-status-bar" aria-live="polite">
+      <span class="bg-status-dot" />
+      <span class="bg-status-text">{message}</span>
     </div>
   );
 }

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1011,22 +1011,42 @@ function App() {
           });
         }}
       />
-      <BackgroundStatusBar />
+      <BackgroundStatusBar
+        notifFetching={notifFetching}
+        discoveryProgress={discoveryProgress}
+        discoveryFinished={discoveryFinished}
+        localScanning={localScanning}
+        localScanProgress={localScanProgress}
+      />
     </div>
   );
 }
 
 // ── Background status bar ─────────────────────────────────────────────────────
 
-function BackgroundStatusBar() {
-  const [message, setMessage] = useState<string | null>(null);
+interface BackgroundStatusBarProps {
+  notifFetching: boolean;
+  discoveryProgress: DiscoveryProgress | null;
+  discoveryFinished: boolean;
+  localScanning: boolean;
+  localScanProgress: LocalScanProgress | null;
+}
+
+function BackgroundStatusBar({
+  notifFetching,
+  discoveryProgress,
+  discoveryFinished,
+  localScanning,
+  localScanProgress,
+}: BackgroundStatusBarProps) {
+  const [ipcMessage, setIpcMessage] = useState<string | null>(null);
   const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const unsub = window.jarvis.onBackgroundStatus((msg) => {
-      setMessage(msg);
+      setIpcMessage(msg);
       if (fadeTimer.current) clearTimeout(fadeTimer.current);
-      fadeTimer.current = setTimeout(() => setMessage(null), 4000);
+      fadeTimer.current = setTimeout(() => setIpcMessage(null), 4000);
     });
     return () => {
       unsub();
@@ -1034,6 +1054,31 @@ function BackgroundStatusBar() {
     };
   }, []);
 
+  // Derive a message from App state — IPC message takes priority when active
+  let derivedMessage: string | null = null;
+  if (localScanning) {
+    if (localScanProgress?.currentFolder) {
+      derivedMessage = `Scanning repos… ${localScanProgress.currentFolder}`;
+    } else if (localScanProgress) {
+      derivedMessage = `Scanning repos… ${localScanProgress.reposFound} found`;
+    } else {
+      derivedMessage = 'Scanning local repos…';
+    }
+  } else if (discoveryProgress && !discoveryFinished) {
+    const phase = discoveryProgress.phase;
+    const count = discoveryProgress.reposFound;
+    if (phase === 'starred') {
+      derivedMessage = `Discovering starred repos… ${count} found`;
+    } else if (phase === 'repos') {
+      derivedMessage = `Discovering repos… ${count} found`;
+    } else {
+      derivedMessage = `Discovering repos (${phase})…`;
+    }
+  } else if (notifFetching) {
+    derivedMessage = 'Fetching notifications…';
+  }
+
+  const message = ipcMessage ?? derivedMessage;
   if (!message) return null;
 
   return (

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -3151,3 +3151,49 @@ h5.ec-heading { font-size: 0.85rem; }
   max-height: 80vh;
   overflow-y: auto;
 }
+
+/* ── Background status bar ───────────────────────────────────────────────── */
+.bg-status-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 1rem;
+  background: rgba(10, 10, 30, 0.88);
+  border-top: 1px solid #1e2040;
+  backdrop-filter: blur(4px);
+  animation: bg-status-fadein 0.2s ease;
+  pointer-events: none;
+}
+
+@keyframes bg-status-fadein {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.bg-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #4fc3f7;
+  flex-shrink: 0;
+  animation: bg-status-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes bg-status-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
+}
+
+.bg-status-text {
+  font-size: 0.72rem;
+  color: #8892b0;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/services/github-notifications.ts
+++ b/src/services/github-notifications.ts
@@ -381,11 +381,13 @@ const DEPENDABOT_PR_URL_RE = /^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+\/
 function isDependabotPRNotification(n: StoredNotification): boolean {
   if (n.subject_type !== 'PullRequest') return false;
   const actor = (n.subject_actor_login ?? '').toLowerCase();
-  if (actor.includes('dependabot')) return true;
-  // Fallback when actor wasn't resolved: Bot + specific "Bump X from Y to Z" title pattern
+  // If we know who opened the PR, use that as source of truth
+  if (actor.length > 0) return actor.includes('dependabot');
+  // Actor unknown — fall back to distinctive dependabot title patterns:
+  // "Bump X from Y to Z" (single dep) or "Bump the X group" (grouped update)
   return (
-    n.subject_actor_type === 'Bot' &&
-    /\bBump\s+\S.+?\bfrom\s+\S+\s+to\s+\S+/i.test(n.subject_title)
+    /\bBump\s+\S.+?\bfrom\s+\S+\s+to\s+\S+/i.test(n.subject_title) ||
+    /\bBump\s+the\s+\S.+?\bgroup\b/i.test(n.subject_title)
   );
 }
 

--- a/src/services/github-notifications.ts
+++ b/src/services/github-notifications.ts
@@ -374,6 +374,84 @@ export function deleteNotification(db: SqlJsDatabase, id: string): void {
   db.run('DELETE FROM github_notifications WHERE id = ?', [id]);
 }
 
+// ── Dependabot merged PR detection ───────────────────────────────────────────
+
+const DEPENDABOT_PR_URL_RE = /^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+\/pulls\/\d+$/;
+
+function isDependabotPRNotification(n: StoredNotification): boolean {
+  if (n.subject_type !== 'PullRequest') return false;
+  const actor = (n.subject_actor_login ?? '').toLowerCase();
+  if (actor.includes('dependabot')) return true;
+  // Fallback when actor wasn't resolved: Bot + specific "Bump X from Y to Z" title pattern
+  return (
+    n.subject_actor_type === 'Bot' &&
+    /\bBump\s+\S.+?\bfrom\s+\S+\s+to\s+\S+/i.test(n.subject_title)
+  );
+}
+
+async function checkPRMerged(accessToken: string, prApiUrl: string): Promise<boolean> {
+  if (!DEPENDABOT_PR_URL_RE.test(prApiUrl)) return false;
+  try {
+    const response = await fetch(prApiUrl, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!response.ok) return false;
+    const pr = (await response.json()) as Record<string, unknown>;
+    return pr.state === 'closed' && pr.merged_at != null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scans all stored unread PullRequest notifications, identifies those authored
+ * by Dependabot, checks each against the GitHub API, and returns the subset
+ * whose PR has been merged. Failures per-notification are non-fatal.
+ */
+export async function listMergedDependabotPRNotifications(
+  db: SqlJsDatabase,
+  accessToken: string,
+): Promise<StoredNotification[]> {
+  const stmt = db.prepare(`
+    SELECT id, repo_full_name, repo_owner, subject_type, subject_title, subject_url,
+           subject_actor_login, subject_actor_type, reason, unread, updated_at, fetched_at
+    FROM github_notifications
+    WHERE unread = 1 AND subject_type = 'PullRequest'
+    ORDER BY updated_at DESC
+  `);
+  const rows: StoredNotification[] = [];
+  while (stmt.step()) rows.push(stmt.getAsObject() as unknown as StoredNotification);
+  stmt.free();
+
+  const candidates = rows.filter(isDependabotPRNotification).filter(
+    (n) => n.subject_url != null,
+  );
+  if (candidates.length === 0) return [];
+
+  const merged: StoredNotification[] = [];
+  const concurrency = 6;
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < candidates.length) {
+      const i = next++;
+      const n = candidates[i];
+      const isMerged = await checkPRMerged(accessToken, n.subject_url!);
+      if (isMerged) merged.push(n);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, candidates.length) }, () => worker()),
+  );
+
+  return merged;
+}
+
 /**
  * Calls the GitHub API to mark a notification thread as done (removes it from GitHub inbox).
  * DELETE /notifications/threads/{thread_id} — returns 204 No Content.

--- a/tests/unit/github-notifications.test.ts
+++ b/tests/unit/github-notifications.test.ts
@@ -358,7 +358,7 @@ describe('GitHub Notifications — listNotificationsForStarred', () => {
 });
 
 // ── fetchNotificationsForRepo ─────────────────────────────────────────────────
-import { fetchNotificationsForRepo, markNotificationRead } from '../../src/services/github-notifications';
+import { fetchNotificationsForRepo, markNotificationRead, listMergedDependabotPRNotifications } from '../../src/services/github-notifications';
 
 describe('fetchNotificationsForRepo', () => {
   afterEach(() => vi.restoreAllMocks());
@@ -454,5 +454,160 @@ describe('markNotificationRead', () => {
     await expect(markNotificationRead('token', '123')).rejects.toThrow(
       'GitHub mark-done API error: 403',
     );
+  });
+});
+
+// ── listMergedDependabotPRNotifications ───────────────────────────────────────
+
+function makePRNotif(
+  id: string,
+  opts: {
+    owner?: string;
+    repoName?: string;
+    actorLogin?: string | null;
+    actorType?: string | null;
+    title?: string;
+    prNumber?: number;
+  } = {},
+): GitHubNotification {
+  const owner = opts.owner ?? 'myorg';
+  const repoName = opts.repoName ?? 'myrepo';
+  const prNumber = opts.prNumber ?? 1;
+  return {
+    id,
+    unread: true,
+    reason: 'subscribed',
+    updated_at: new Date().toISOString(),
+    subject_actor_login: opts.actorLogin !== undefined ? opts.actorLogin : 'dependabot[bot]',
+    subject_actor_type: opts.actorType !== undefined ? opts.actorType : 'Bot',
+    subject: {
+      type: 'PullRequest',
+      title: opts.title ?? `Bump some-action from 1.0.0 to 2.0.0`,
+      url: `https://api.github.com/repos/${owner}/${repoName}/pulls/${prNumber}`,
+    },
+    repository: {
+      full_name: `${owner}/${repoName}`,
+      name: repoName,
+      owner: { login: owner },
+      html_url: `https://github.com/${owner}/${repoName}`,
+    },
+  };
+}
+
+describe('listMergedDependabotPRNotifications', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.restoreAllMocks();
+  });
+
+  it('returns merged dependabot PR notifications', async () => {
+    storeNotifications(db, [makePRNotif('10', { actorLogin: 'dependabot[bot]' })]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('10');
+  });
+
+  it('excludes closed-but-not-merged PRs', async () => {
+    storeNotifications(db, [makePRNotif('11')]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'closed', merged_at: null }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes open PRs', async () => {
+    storeNotifications(db, [makePRNotif('12')]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'open', merged_at: null }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes non-PR notifications', async () => {
+    storeNotifications(db, [makeNotif('13', { type: 'CheckSuite' })]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes PR notifications not authored by dependabot', async () => {
+    storeNotifications(db, [makePRNotif('14', { actorLogin: 'octocat', actorType: 'User' })]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(0);
+  });
+
+  it('detects dependabot via title pattern when actor login is null', async () => {
+    storeNotifications(db, [makePRNotif('15', {
+      actorLogin: null,
+      actorType: 'Bot',
+      title: 'Bump actions/checkout from 3.0.0 to 4.0.0',
+    })]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(1);
+  });
+
+  it('does not false-positive on renovate-style bot with generic title', async () => {
+    storeNotifications(db, [makePRNotif('16', {
+      actorLogin: 'renovate[bot]',
+      actorType: 'Bot',
+      title: 'Update dependency some-package to v3',
+    })]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns partial results when one PR check fails', async () => {
+    storeNotifications(db, [
+      makePRNotif('17', { prNumber: 1 }),
+      makePRNotif('18', { prNumber: 2 }),
+    ]);
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error('Network error');
+      return new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 });
+    });
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    // One fails (treated as not-merged), one succeeds
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array when no notifications are stored', async () => {
+    globalThis.fetch = vi.fn();
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(0);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/github-notifications.test.ts
+++ b/tests/unit/github-notifications.test.ts
@@ -562,8 +562,22 @@ describe('listMergedDependabotPRNotifications', () => {
   it('detects dependabot via title pattern when actor login is null', async () => {
     storeNotifications(db, [makePRNotif('15', {
       actorLogin: null,
-      actorType: 'Bot',
+      actorType: null,
       title: 'Bump actions/checkout from 3.0.0 to 4.0.0',
+    })]);
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 }),
+    );
+
+    const result = await listMergedDependabotPRNotifications(db, 'token');
+    expect(result).toHaveLength(1);
+  });
+
+  it('detects grouped dependabot update PRs via title pattern', async () => {
+    storeNotifications(db, [makePRNotif('15b', {
+      actorLogin: null,
+      actorType: null,
+      title: 'Bump the github-actions group in /.github/workflows with 5 updates',
     })]);
     globalThis.fetch = vi.fn(async () =>
       new Response(JSON.stringify({ state: 'closed', merged_at: '2024-01-01T00:00:00Z' }), { status: 200 }),

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -83,6 +83,7 @@ const EXPECTED_CHANNELS = [
   'github:list-notifications-for-owner',
   'github:list-notifications-for-starred',
   'github:dismiss-notification',
+  'github:check-merged-dependabot-prs',
   // local-repos plugin
   'local:get-folders',
   'local:add-folder',


### PR DESCRIPTION
## Summary

Adds a **Merged Dependabot PRs** banner to the dashboard — right alongside the existing "Workflows recovered" banner — that detects unread PR notifications authored by Dependabot where the PR has since been merged, and lets you dismiss them all in one click.

## What's new

### `DependabotMergedBanner` component
- Appears in the dashboard between `SummaryCards` and the repo list, next to `RecoverableBanner`
- On each dashboard refresh it checks all stored unread PullRequest notifications via a single IPC call
- While checking: renders nothing (no spinner clutter)
- When merged PRs found: shows a banner like _"9 notifications for merged PRs across 1 repo."_ with a **Dismiss N notifications** button
- Reuses the existing `dash-recoverable-banner` CSS — zero new styles needed

### Detection logic (`listMergedDependabotPRNotifications`)
1. Queries DB for all unread `PullRequest` notifications
2. Filters to Dependabot-authored ones:
   - Primary: `subject_actor_login` contains `dependabot` (matches `dependabot[bot]`, `dependabot-preview[bot]`)
   - Fallback (when actor wasn't resolved): `subject_actor_type === 'Bot'` + title matches `Bump X from Y to Z` — specific enough to avoid Renovate false-positives
3. Validates `subject_url` format before hitting GitHub API
4. Checks each in parallel (concurrency=6), per-notification failures are non-fatal

### New IPC channel: `github:check-merged-dependabot-prs`
- No arguments — scans all stored notifications globally
- Returns `StoredNotification[]` of merged PRs

## Tests
9 new unit tests covering:
- Merged PR → included
- Closed-but-not-merged → excluded  
- Open PR → excluded
- Non-PR notification → excluded
- Non-dependabot actor → excluded
- Title-pattern fallback detection (null actor login)
- Renovate bot with generic title → not false-positived
- Partial API failure → returns remaining results
- Empty DB → no fetch calls made