### PR TITLE
Keep OAuth and PAT rate limit badges together

### DIFF
--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1130,31 +1130,35 @@ function BackgroundStatusBar({
           <span class="bg-status-text">{message}</span>
         </>
       )}
-      {oauthBadge && (
-        <span
-          class="bg-status-rate-limit"
-          title={oauthBadge.error
-            ? `OAuth rate limit error: ${oauthBadge.error}`
-            : `OAuth: ${oauthBadge.resource!.remaining}/${oauthBadge.resource!.limit} calls remaining (resets ${new Date(oauthBadge.resource!.reset * 1000).toLocaleTimeString()})`}
-          style={{ color: oauthBadge.error ? '#888' : (oauthBadge.resource ? rateLimitColor(oauthBadge.resource.remaining) : '#888') }}
-        >
-          {oauthBadge.error || !oauthBadge.resource
-            ? '⚡ OAuth –'
-            : `⚡ OAuth ${oauthBadge.resource.remaining.toLocaleString()}/${oauthBadge.resource.limit.toLocaleString()}`}
-        </span>
-      )}
-      {patBadge && (
-        <span
-          class="bg-status-rate-limit"
-          title={patBadge.error
-            ? `PAT rate limit error: ${patBadge.error}`
-            : `PAT: ${patBadge.resource!.remaining}/${patBadge.resource!.limit} calls remaining (resets ${new Date(patBadge.resource!.reset * 1000).toLocaleTimeString()})`}
-          style={{ color: patBadge.error ? '#888' : (patBadge.resource ? rateLimitColor(patBadge.resource.remaining) : '#888') }}
-        >
-          {patBadge.error || !patBadge.resource
-            ? '⚡ PAT –'
-            : `⚡ PAT ${patBadge.resource.remaining.toLocaleString()}/${patBadge.resource.limit.toLocaleString()}`}
-        </span>
+      {hasAnyBadge && (
+        <div class="bg-status-rate-limits">
+          {oauthBadge && (
+            <span
+              class="bg-status-rate-limit"
+              title={oauthBadge.error
+                ? `OAuth rate limit error: ${oauthBadge.error}`
+                : `OAuth: ${oauthBadge.resource!.remaining}/${oauthBadge.resource!.limit} calls remaining (resets ${new Date(oauthBadge.resource!.reset * 1000).toLocaleTimeString()})`}
+              style={{ color: oauthBadge.error ? '#888' : (oauthBadge.resource ? rateLimitColor(oauthBadge.resource.remaining) : '#888') }}
+            >
+              {oauthBadge.error || !oauthBadge.resource
+                ? '⚡ OAuth –'
+                : `⚡ OAuth ${oauthBadge.resource.remaining.toLocaleString()}/${oauthBadge.resource.limit.toLocaleString()}`}
+            </span>
+          )}
+          {patBadge && (
+            <span
+              class="bg-status-rate-limit"
+              title={patBadge.error
+                ? `PAT rate limit error: ${patBadge.error}`
+                : `PAT: ${patBadge.resource!.remaining}/${patBadge.resource!.limit} calls remaining (resets ${new Date(patBadge.resource!.reset * 1000).toLocaleTimeString()})`}
+              style={{ color: patBadge.error ? '#888' : (patBadge.resource ? rateLimitColor(patBadge.resource.remaining) : '#888') }}
+            >
+              {patBadge.error || !patBadge.resource
+                ? '⚡ PAT –'
+                : `⚡ PAT ${patBadge.resource.remaining.toLocaleString()}/${patBadge.resource.limit.toLocaleString()}`}
+            </span>
+          )}
+        </div>
       )}
     </div>
   );
@@ -1165,4 +1169,3 @@ function BackgroundStatusBar({
 document.body.classList.add('onboarding');
 const root = document.getElementById('app')!;
 render(<App />, root);
-

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -3198,13 +3198,20 @@ h5.ec-heading { font-size: 0.85rem; }
   text-overflow: ellipsis;
 }
 
-.bg-status-rate-limit {
+.bg-status-rate-limits {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  pointer-events: auto;
+}
+
+.bg-status-rate-limit {
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   white-space: nowrap;
   flex-shrink: 0;
-  pointer-events: auto;
   cursor: default;
 }


### PR DESCRIPTION
## Summary of Changes

This fixes the background status bar layout so the OAuth and PAT rate limit badges stay adjacent instead of being pushed apart across the full footer width.

The badges now render inside a shared right-aligned flex container, which keeps the group anchored to the right while preserving a normal gap between the two values.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. Run `npm test`.
2. Run `npm run build`.
3. Open the app with both OAuth and PAT configured and confirm the two rate limit badges appear next to each other in the bottom status bar.

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed