### PR TITLE
feat: deduplicate local repos sharing the same remote

### DIFF
--- a/src/plugins/local-repos/LocalRepoCard.tsx
+++ b/src/plugins/local-repos/LocalRepoCard.tsx
@@ -4,14 +4,20 @@ import type { LocalRepo } from '../types';
 interface LocalRepoCardProps {
   repo: LocalRepo;
   notifCount?: number;
+  /** All local paths for this deduplicated repo group (only passed when 2+). */
+  allLocalPaths?: string[];
+  /** Called when the user opens a specific local path (only used when allLocalPaths is passed). */
+  onOpenPath?: (path: string) => void;
   onClick: () => void;
 }
 
-export function LocalRepoCard({ repo, notifCount, onClick }: LocalRepoCardProps) {
+export function LocalRepoCard({ repo, notifCount, allLocalPaths, onOpenPath, onClick }: LocalRepoCardProps) {
   // Collect unique GitHub full-names from all remotes
   const githubRemotes = repo.remotes
     .map((r) => ({ name: r.name, fullName: normalizeGitHubUrl(r.url) }))
     .filter((r): r is { name: string; fullName: string } => r.fullName !== null);
+
+  const isMultiPath = allLocalPaths != null && allLocalPaths.length > 1;
 
   return (
     <div class="repo-card" onClick={onClick}>
@@ -26,7 +32,32 @@ export function LocalRepoCard({ repo, notifCount, onClick }: LocalRepoCardProps)
           </span>
         )}
       </div>
-      <div class="repo-card-desc" style={{ color: '#8899aa', fontSize: '0.74rem' }}>{repo.localPath}</div>
+      {isMultiPath ? (
+        <div style={{ marginTop: '0.2rem' }}>
+          <span style={{ color: '#8899aa', fontSize: '0.74rem' }}>
+            {'\uD83D\uDCC1'} {allLocalPaths.length} local copies:
+          </span>
+          {allLocalPaths.map((p) => (
+            <div
+              key={p}
+              style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', marginTop: '0.12rem' }}
+            >
+              <span style={{ color: '#8899aa', fontSize: '0.74rem', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={p}>{p}</span>
+              {onOpenPath && (
+                <button
+                  title={`Open ${p}`}
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '0 0.2rem', color: '#8899aa', fontSize: '0.8rem' }}
+                  onClick={(e: Event) => { e.stopPropagation(); onOpenPath(p); }}
+                >
+                  {'\uD83D\uDCC2'}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div class="repo-card-desc" style={{ color: '#8899aa', fontSize: '0.74rem' }}>{repo.localPath}</div>
+      )}
       <div class="repo-card-meta">
         {repo.remotes.map((r) => (
           <span key={r.name} class="repo-card-badge" title={r.url}>{r.name}</span>

--- a/src/plugins/local-repos/LocalRepoPanelView.tsx
+++ b/src/plugins/local-repos/LocalRepoPanelView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 import { LocalRepoCard } from './LocalRepoCard';
-import { normalizeGitHubUrl } from '../shared/utils';
+import { deduplicateLocalRepos } from '../shared/utils';
 import type { LocalRepo, NotificationCounts } from '../types';
 
 type LocalSortKey = 'name' | 'scanned' | 'notifs';
@@ -19,38 +19,37 @@ interface LocalRepoPanelViewProps {
 export function LocalRepoPanelView({ title, repos, notifCounts, initialSortKey = 'name', onOpenRepoNotif, onClearNotif, onSortChange, onClose }: LocalRepoPanelViewProps) {
   const [sortKey, setSortKey] = useState<LocalSortKey>(initialSortKey);
 
-  /** Best GitHub full_name for a local repo — first linked remote wins. */
-  function getFullName(repo: LocalRepo): string | null {
-    for (const r of repo.remotes) {
-      const fn = normalizeGitHubUrl(r.url);
-      if (fn) return fn;
-    }
-    return null;
+  const deduped = deduplicateLocalRepos(repos);
+
+  function getNotifCount(githubFullName: string | null): number {
+    return githubFullName && notifCounts ? (notifCounts.perRepo[githubFullName] ?? 0) : 0;
   }
 
-  function getNotifCount(repo: LocalRepo): number {
-    const fn = getFullName(repo);
-    return fn && notifCounts ? (notifCounts.perRepo[fn] ?? 0) : 0;
-  }
-
-  const sorted = [...repos].sort((a, b) => {
-    if (sortKey === 'notifs') return getNotifCount(b) - getNotifCount(a) || a.name.localeCompare(b.name);
+  const sorted = [...deduped].sort((a, b) => {
+    if (sortKey === 'notifs') return getNotifCount(b.githubFullName) - getNotifCount(a.githubFullName) || a.primaryRepo.name.localeCompare(b.primaryRepo.name);
     if (sortKey === 'scanned') {
-      const ta = a.lastScanned ? new Date(a.lastScanned).getTime() : 0;
-      const tb = b.lastScanned ? new Date(b.lastScanned).getTime() : 0;
+      const ta = a.primaryRepo.lastScanned ? new Date(a.primaryRepo.lastScanned).getTime() : 0;
+      const tb = b.primaryRepo.lastScanned ? new Date(b.primaryRepo.lastScanned).getTime() : 0;
       return tb - ta;
     }
-    return a.name.localeCompare(b.name);
+    return a.primaryRepo.name.localeCompare(b.primaryRepo.name);
   });
 
-  const totalNotifs = repos.reduce((s, r) => s + getNotifCount(r), 0);
+  const totalNotifs = deduped.reduce((s, g) => s + getNotifCount(g.githubFullName), 0);
+  const totalLocalPaths = repos.length;
+  const hasDuplicates = deduped.some((g) => g.isDuplicate);
 
   return (
     <div class="repo-panel">
       <div class="repo-panel-header">
         <button class="repo-panel-close" title="Back" onClick={onClose}>&#8249;</button>
         <span class="repo-panel-title">{title}</span>
-        <span class="local-panel-count">{repos.length.toLocaleString()} repo{repos.length !== 1 ? 's' : ''}</span>
+        <span class="local-panel-count">
+          {deduped.length.toLocaleString()} repo{deduped.length !== 1 ? 's' : ''}
+          {hasDuplicates && (
+            <span title={`${totalLocalPaths} local copies across ${deduped.length} unique repo${deduped.length !== 1 ? 's' : ''}`}> ({totalLocalPaths} local copies)</span>
+          )}
+        </span>
         <span style={{ flex: 1 }} />
         {notifCounts && totalNotifs > 0 && (
           <span
@@ -80,17 +79,19 @@ export function LocalRepoPanelView({ title, repos, notifCounts, initialSortKey =
       {sorted.length === 0 ? (
         <div style={{ color: '#99a', fontSize: '0.85rem', padding: '0.5rem' }}>No repositories found</div>
       ) : (
-        sorted.map((repo) => {
-          const fullName = getFullName(repo);
-          const notifCount = getNotifCount(repo);
-          const handleClick = fullName && notifCount > 0
-            ? () => { onClearNotif(); onOpenRepoNotif(fullName); }
-            : () => { onClearNotif(); void window.jarvis.localOpenFolder(repo.localPath); };
+        sorted.map((group) => {
+          const { primaryRepo, githubFullName, allLocalPaths, isDuplicate } = group;
+          const notifCount = getNotifCount(githubFullName);
+          const handleClick = githubFullName && notifCount > 0
+            ? () => { onClearNotif(); onOpenRepoNotif(githubFullName); }
+            : () => { onClearNotif(); void window.jarvis.localOpenFolder(primaryRepo.localPath); };
           return (
             <LocalRepoCard
-              key={repo.localPath}
-              repo={repo}
+              key={primaryRepo.localPath}
+              repo={primaryRepo}
               notifCount={notifCount}
+              allLocalPaths={isDuplicate ? allLocalPaths : undefined}
+              onOpenPath={(p) => { onClearNotif(); void window.jarvis.localOpenFolder(p); }}
               onClick={handleClick}
             />
           );

--- a/src/plugins/shared/utils.ts
+++ b/src/plugins/shared/utils.ts
@@ -36,6 +36,95 @@ export function isDirect(reason: string): boolean {
 
 import type { LocalRepo } from '../types';
 
+// ── Deduplication ─────────────────────────────────────────────────────────────
+
+export interface DeduplicatedLocalRepo {
+  /** The canonical repo (most recently scanned clone, then most recently discovered, then path order). */
+  primaryRepo: LocalRepo;
+  /** All local paths sharing the same remote, primary first. */
+  allLocalPaths: string[];
+  /** Normalized GitHub full_name for the primary remote, or null. */
+  githubFullName: string | null;
+  /** True when 2 or more local clones share the same remote. */
+  isDuplicate: boolean;
+}
+
+/**
+ * Sort remotes deterministically: 'origin' first, then alphabetically by name.
+ */
+function sortedRemotes(repo: LocalRepo): LocalRepo['remotes'] {
+  return [...repo.remotes].sort((a, b) =>
+    a.name === 'origin' ? -1 : b.name === 'origin' ? 1 : a.name.localeCompare(b.name),
+  );
+}
+
+/**
+ * Compute a stable deduplication key for a local repo.
+ * Priority:
+ *   1. `repo.linkedGithubRepoId` — stable across renames
+ *   2. `remote.githubRepoId` (origin preferred) — stable across renames
+ *   3. Normalized GitHub remote URL (origin preferred)
+ *   4. Local path — unique, no grouping
+ */
+function getDedupeKey(repo: LocalRepo): string {
+  if (repo.linkedGithubRepoId != null) return `gid:${repo.linkedGithubRepoId}`;
+
+  const remotes = sortedRemotes(repo);
+  for (const remote of remotes) {
+    if (remote.githubRepoId != null) return `gid:${remote.githubRepoId}`;
+  }
+  for (const remote of remotes) {
+    const gh = normalizeGitHubUrl(remote.url);
+    if (gh) return `gh:${gh.toLowerCase()}`;
+  }
+  return `local:${repo.localPath}`;
+}
+
+/**
+ * Group repos that share the same remote into deduplicated entries.
+ * Repos with no shared remotes appear as individual entries.
+ * Insertion order of first-seen groups is preserved for stable rendering.
+ */
+export function deduplicateLocalRepos(repos: LocalRepo[]): DeduplicatedLocalRepo[] {
+  const groups = new Map<string, LocalRepo[]>();
+  const keyOrder: string[] = [];
+
+  for (const repo of repos) {
+    const key = getDedupeKey(repo);
+    if (!groups.has(key)) {
+      groups.set(key, []);
+      keyOrder.push(key);
+    }
+    groups.get(key)!.push(repo);
+  }
+
+  return keyOrder.map((key) => {
+    const group = groups.get(key)!;
+    // Primary = most recently scanned; break ties by discoveredAt then localPath
+    const sorted = [...group].sort((a, b) => {
+      const ta = a.lastScanned ? new Date(a.lastScanned).getTime() : 0;
+      const tb = b.lastScanned ? new Date(b.lastScanned).getTime() : 0;
+      if (tb !== ta) return tb - ta;
+      const da = a.discoveredAt ? new Date(a.discoveredAt).getTime() : 0;
+      const db = b.discoveredAt ? new Date(b.discoveredAt).getTime() : 0;
+      if (db !== da) return db - da;
+      return a.localPath.localeCompare(b.localPath);
+    });
+    const primaryRepo = sorted[0];
+    let githubFullName: string | null = null;
+    for (const remote of sortedRemotes(primaryRepo)) {
+      const fn = normalizeGitHubUrl(remote.url);
+      if (fn) { githubFullName = fn; break; }
+    }
+    return {
+      primaryRepo,
+      allLocalPaths: sorted.map((r) => r.localPath),
+      githubFullName,
+      isDuplicate: group.length > 1,
+    };
+  });
+}
+
 /** Returns all repos whose localPath is at or under the given parentPath. */
 export function getReposUnder(parentPath: string, repos: LocalRepo[]): LocalRepo[] {
   const norm = parentPath.replace(/[\\/]+$/, '');

--- a/tests/unit/shared-utils.test.ts
+++ b/tests/unit/shared-utils.test.ts
@@ -310,3 +310,144 @@ describe('normalizeGitHubUrl (renderer version)', () => {
     expect(normalizeGitHubUrl('')).toBeNull();
   });
 });
+
+// ── deduplicateLocalRepos ─────────────────────────────────────────────────────
+import { deduplicateLocalRepos } from '../../src/plugins/shared/utils';
+import type { LocalRemote } from '../../src/plugins/types';
+
+function makeFullRepo(
+  localPath: string,
+  remotes: { name: string; url: string; githubRepoId?: number | null }[] = [],
+  opts: { id?: number; linkedGithubRepoId?: number | null; lastScanned?: string | null; discoveredAt?: string } = {},
+): LocalRepo {
+  return {
+    id: opts.id ?? 0,
+    localPath,
+    name: localPath.split(/[\\/]/).filter(Boolean).pop() ?? localPath,
+    remotes: remotes as LocalRemote[],
+    discoveredAt: opts.discoveredAt ?? '2024-01-01T00:00:00Z',
+    lastScanned: opts.lastScanned !== undefined ? opts.lastScanned : null,
+    linkedGithubRepoId: opts.linkedGithubRepoId ?? null,
+  };
+}
+
+describe('deduplicateLocalRepos', () => {
+  it('groups two clones of the same GitHub remote URL', () => {
+    const repos = [
+      makeFullRepo('/repos/a/myrepo', [{ name: 'origin', url: 'https://github.com/org/myrepo.git' }]),
+      makeFullRepo('/repos/b/myrepo', [{ name: 'origin', url: 'https://github.com/org/myrepo.git' }]),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result).toHaveLength(1);
+    expect(result[0].allLocalPaths).toHaveLength(2);
+    expect(result[0].isDuplicate).toBe(true);
+    expect(result[0].githubFullName).toBe('org/myrepo');
+  });
+
+  it('groups by linkedGithubRepoId (handles remote renames)', () => {
+    const repos = [
+      makeFullRepo('/repos/old-name', [{ name: 'origin', url: 'https://github.com/org/old-name.git' }], { linkedGithubRepoId: 42 }),
+      makeFullRepo('/repos/new-name', [{ name: 'origin', url: 'https://github.com/org/new-name.git' }], { linkedGithubRepoId: 42 }),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result).toHaveLength(1);
+    expect(result[0].isDuplicate).toBe(true);
+    expect(result[0].allLocalPaths).toContain('/repos/old-name');
+    expect(result[0].allLocalPaths).toContain('/repos/new-name');
+  });
+
+  it('groups by remote.githubRepoId even when linkedGithubRepoId is null', () => {
+    const repos = [
+      makeFullRepo('/repos/clone1', [{ name: 'origin', url: 'https://github.com/org/repo.git', githubRepoId: 99 }]),
+      makeFullRepo('/repos/clone2', [{ name: 'origin', url: 'https://github.com/org/repo-renamed.git', githubRepoId: 99 }]),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result).toHaveLength(1);
+    expect(result[0].isDuplicate).toBe(true);
+  });
+
+  it('does not group repos with different remotes', () => {
+    const repos = [
+      makeFullRepo('/repos/a', [{ name: 'origin', url: 'https://github.com/org/repo-a.git' }]),
+      makeFullRepo('/repos/b', [{ name: 'origin', url: 'https://github.com/org/repo-b.git' }]),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result).toHaveLength(2);
+    expect(result.every((g) => !g.isDuplicate)).toBe(true);
+  });
+
+  it('treats repos with no remotes as unique entries', () => {
+    const repos = [
+      makeFullRepo('/repos/no-remote-a'),
+      makeFullRepo('/repos/no-remote-b'),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result).toHaveLength(2);
+  });
+
+  it('selects the most recently scanned clone as primary', () => {
+    const repos = [
+      makeFullRepo('/repos/old', [{ name: 'origin', url: 'https://github.com/org/repo.git' }], { lastScanned: '2024-01-01T00:00:00Z' }),
+      makeFullRepo('/repos/new', [{ name: 'origin', url: 'https://github.com/org/repo.git' }], { lastScanned: '2024-06-01T00:00:00Z' }),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result[0].primaryRepo.localPath).toBe('/repos/new');
+    expect(result[0].allLocalPaths[0]).toBe('/repos/new');
+  });
+
+  it('uses localPath as tiebreaker for repos with equal lastScanned', () => {
+    const scanned = '2024-01-01T00:00:00Z';
+    const repos = [
+      makeFullRepo('/repos/z-clone', [{ name: 'origin', url: 'https://github.com/org/repo.git' }], { lastScanned: scanned }),
+      makeFullRepo('/repos/a-clone', [{ name: 'origin', url: 'https://github.com/org/repo.git' }], { lastScanned: scanned }),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    // a-clone < z-clone lexicographically → a-clone is primary
+    expect(result[0].primaryRepo.localPath).toBe('/repos/a-clone');
+  });
+
+  it('handles null lastScanned gracefully', () => {
+    const repos = [
+      makeFullRepo('/repos/scanned', [{ name: 'origin', url: 'https://github.com/org/repo.git' }], { lastScanned: '2024-01-01T00:00:00Z' }),
+      makeFullRepo('/repos/unscanned', [{ name: 'origin', url: 'https://github.com/org/repo.git' }], { lastScanned: null }),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    // Scanned repo should be primary (null treated as oldest)
+    expect(result[0].primaryRepo.localPath).toBe('/repos/scanned');
+  });
+
+  it('prefers origin remote for githubFullName', () => {
+    const repos = [
+      makeFullRepo('/repos/myfork', [
+        { name: 'upstream', url: 'https://github.com/org/repo.git' },
+        { name: 'origin', url: 'https://github.com/user/myfork.git' },
+      ]),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result[0].githubFullName).toBe('user/myfork');
+  });
+
+  it('handles HTTPS and SSH variants of the same URL as identical', () => {
+    const repos = [
+      makeFullRepo('/repos/https', [{ name: 'origin', url: 'https://github.com/org/repo.git' }]),
+      makeFullRepo('/repos/ssh', [{ name: 'origin', url: 'git@github.com:org/repo.git' }]),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result).toHaveLength(1);
+    expect(result[0].isDuplicate).toBe(true);
+  });
+
+  it('returns single entries unchanged', () => {
+    const repos = [
+      makeFullRepo('/repos/solo', [{ name: 'origin', url: 'https://github.com/org/solo.git' }]),
+    ];
+    const result = deduplicateLocalRepos(repos);
+    expect(result).toHaveLength(1);
+    expect(result[0].isDuplicate).toBe(false);
+    expect(result[0].allLocalPaths).toEqual(['/repos/solo']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(deduplicateLocalRepos([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Repos cloned to multiple local paths showed up as separate entries in the list. This happened in two scenarios:
1. **Multiple local clones** of the same remote (e.g. cloned twice in different folders)
2. **Remotely renamed repos** — old and new clones appear as distinct entries

## Solution

Group local repos that share the same remote into a single display entry, while showing all local paths so the user can open any of them.

### Deduplication key priority

1. `linkedGithubRepoId` — stable across remote renames (GitHub repo IDs never change)
2. `remote.githubRepoId` — handles renames when linked at the remote level
3. Normalized GitHub remote URL — groups HTTPS and SSH variants of the same URL
4. Local path — fallback, no grouping (repos with no GitHub remote)

### UI changes

- **Count**: Shows `N repos (M local copies)` when duplicates are present
- **Card**: When a repo has multiple local clones, shows a `📁 N local copies:` list with each path and a per-path open button (clicks don't bubble to the card's main action)
- **Notifications**: No longer double-counted across clones of the same repo

## Files changed

| File | Change |
|------|--------|
| `src/plugins/shared/utils.ts` | New `DeduplicatedLocalRepo` type + `deduplicateLocalRepos()` |
| `src/plugins/local-repos/LocalRepoPanelView.tsx` | Apply dedup before rendering |
| `src/plugins/local-repos/LocalRepoCard.tsx` | Multi-path display with per-path open buttons |
| `tests/unit/shared-utils.test.ts` | 12 new tests covering all dedup scenarios |

All 555 tests pass.