### PR TITLE
fix: group OAuth and PAT rate-limit badges into one panel with pipe separator

### DIFF
--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1131,7 +1131,7 @@ function BackgroundStatusBar({
         </>
       )}
       {hasAnyBadge && (
-        <div class="bg-status-rate-limits">
+        <div class={`bg-status-rate-limits${oauthBadge && patBadge ? ' bg-status-rate-limits--both' : ''}`}>
           {oauthBadge && (
             <span
               class="bg-status-rate-limit"
@@ -1144,6 +1144,9 @@ function BackgroundStatusBar({
                 ? '⚡ OAuth –'
                 : `⚡ OAuth ${oauthBadge.resource.remaining.toLocaleString()}/${oauthBadge.resource.limit.toLocaleString()}`}
             </span>
+          )}
+          {oauthBadge && patBadge && (
+            <span class="bg-status-rate-sep" aria-hidden="true">|</span>
           )}
           {patBadge && (
             <span

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -3207,6 +3207,25 @@ h5.ec-heading { font-size: 0.85rem; }
   pointer-events: auto;
 }
 
+.bg-status-rate-limits--both {
+  gap: 0;
+  padding: 0.1rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.bg-status-rate-limits--both .bg-status-rate-limit {
+  padding: 0 0.4rem;
+}
+
+.bg-status-rate-sep {
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.25);
+  user-select: none;
+  flex-shrink: 0;
+}
+
 .bg-status-rate-limit {
   font-size: 0.72rem;
   font-weight: 600;


### PR DESCRIPTION
## Problem

When both OAuth and PAT rate-limit badges were visible, they appeared as two disconnected floating items in the status bar.

## Fix

When both OAuth and PAT are configured, they're now rendered inside a single visually-grouped panel:
- A subtle border + background visually groups the two badges
- A dim \|\ pipe separator sits between them
- Per-badge padding so the pipe reads as a natural divider

When only one badge is present, the original plain style is preserved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>