### PR TITLE
feat: auto-dismiss issue notifications closed by current user

### DIFF
--- a/src/plugins/notifications/OrgNotifPanel.tsx
+++ b/src/plugins/notifications/OrgNotifPanel.tsx
@@ -40,6 +40,8 @@ interface OrgNotifPanelProps {
 
 export function OrgNotifPanel({ title, notifications, loading, onClose, onRefresh, refreshing, onDismiss }: OrgNotifPanelProps) {
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; notifId: string } | null>(null);
+  const [closedByMeIds, setClosedByMeIds] = useState<string[]>([]);
+  const [dismissingClosed, setDismissingClosed] = useState(false);
 
   useEffect(() => {
     if (!ctxMenu) return;
@@ -48,10 +50,64 @@ export function OrgNotifPanel({ title, notifications, loading, onClose, onRefres
     return () => window.removeEventListener('mousedown', close);
   }, [ctxMenu]);
 
+  // Check which issue notifications are for issues closed by the current user
+  useEffect(() => {
+    if (loading) return;
+    const issueNotifs = notifications.filter((n) => n.subject_type === 'Issue' && n.subject_url);
+    if (issueNotifs.length === 0) { setClosedByMeIds([]); return; }
+
+    let cancelled = false;
+    setClosedByMeIds([]);
+
+    const run = async () => {
+      const ids: string[] = [];
+      const byUrl = new Map<string, typeof issueNotifs>();
+      for (const n of issueNotifs) {
+        if (!n.subject_url) continue;
+        if (!byUrl.has(n.subject_url)) byUrl.set(n.subject_url, []);
+        byUrl.get(n.subject_url)!.push(n);
+      }
+
+      const entries = [...byUrl.entries()];
+      const CONCURRENCY = 6;
+      let next = 0;
+      const worker = async () => {
+        while (next < entries.length) {
+          const idx = next++;
+          const [url, notifs] = entries[idx];
+          try {
+            const result = await window.jarvis.githubGetIssueState(url);
+            if (cancelled) return;
+            if (result?.state === 'closed' && result.closedByMe) {
+              ids.push(...notifs.map((n) => n.id));
+            }
+          } catch { /* skip individual issue */ }
+        }
+      };
+      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, entries.length) }, worker));
+      if (!cancelled) setClosedByMeIds(ids);
+    };
+
+    void run();
+    return () => { cancelled = true; };
+  }, [notifications, loading]);
+
   const handleDismiss = async (id: string) => {
     setCtxMenu(null);
     await window.jarvis.dismissNotification(id);
     onDismiss?.(id);
+  };
+
+  const handleDismissClosedByMe = async () => {
+    setDismissingClosed(true);
+    for (const id of closedByMeIds) {
+      try {
+        await window.jarvis.dismissNotification(id);
+        onDismiss?.(id);
+      } catch { /* skip */ }
+    }
+    setClosedByMeIds([]);
+    setDismissingClosed(false);
   };
 
   // Group by repo
@@ -87,6 +143,27 @@ export function OrgNotifPanel({ title, notifications, loading, onClose, onRefres
       )}
       {!loading && notifications.length === 0 && (
         <div style={{ color: '#99a', fontSize: '0.85rem', padding: '0.5rem' }}>No unread notifications</div>
+      )}
+
+      {!loading && closedByMeIds.length > 0 && (
+        <div class="dash-recoverable-banner">
+          <span class="dash-recoverable-icon">{'✓'}</span>
+          <div class="dash-recoverable-body">
+            <span class="dash-recoverable-title">Issues you closed</span>
+            <span class="dash-recoverable-detail">
+              {`${closedByMeIds.length} notification${closedByMeIds.length !== 1 ? 's' : ''} for issues closed by you`}
+            </span>
+          </div>
+          <button
+            class={`dash-recoverable-btn${dismissingClosed ? ' dash-recoverable-btn--busy' : ''}`}
+            disabled={dismissingClosed}
+            onClick={() => void handleDismissClosedByMe()}
+          >
+            {dismissingClosed
+              ? <span class="dismiss-spinner" />
+              : `Dismiss ${closedByMeIds.length}`}
+          </button>
+        </div>
       )}
 
       {!loading && Array.from(groups.entries()).map(([repoFullName, items]) => (


### PR DESCRIPTION
## Summary

When the **People First Notifications** (OrgNotifPanel) loads, it now automatically checks in the background whether any Issue notifications belong to issues that were already closed by the current authenticated user.

If any are found, a **"Issues you closed"** banner appears at the top of the panel with a one-click **Dismiss** button to clear them all.

## How it works

1. After notifications finish loading, all `Issue`-type entries with a `subject_url` are collected.
2. Unique issue URLs are deduplicated and checked via the existing `githubGetIssueState` IPC (which calls the GitHub API and inspects the `closed` event actor).
3. Any notification whose issue is `closed` **and** whose `closedByMe` flag is `true` is collected.
4. The banner shows the total count and dismisses each notification (marking it read on GitHub and removing it locally) when clicked.
5. Checks run with up to 6 concurrent requests to keep the operation fast.

## Files changed

- `src/plugins/notifications/OrgNotifPanel.tsx` — added closed-by-me check logic and dismissal banner