### PR TITLE
feat: rate limit protection for PAT/OAuth

### DIFF
--- a/src/plugins/notifications/handler.ts
+++ b/src/plugins/notifications/handler.ts
@@ -22,6 +22,58 @@ import { loadGitHubAuth } from '../../services/github-oauth';
 import { saveDatabase } from '../../storage/database';
 import { fetchAndStoreWorkflowData } from '../../services/github-workflows';
 
+// ── Boot workflow check constants ─────────────────────────────────────────────
+
+/** Workflow cache is considered fresh if fetched within this window. */
+const WORKFLOW_CACHE_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
+
+/** When rate limit remaining is below this value, check estimated call count. */
+const BOOT_CHECK_RATE_LIMIT_THRESHOLD = 1000;
+
+/** Skip boot pre-warm if estimated API calls exceed this when rate limit is low. */
+const BOOT_CHECK_MAX_ESTIMATED_CALLS = 50;
+
+/** Conservative per-repo estimate: 1 runs page + up to 5 failing-run details. */
+const BOOT_CHECK_ESTIMATED_CALLS_PER_REPO = 10;
+
+/**
+ * Returns true if workflow run data for the given repo was fetched recently
+ * (within WORKFLOW_CACHE_MAX_AGE_MS). Avoids redundant API calls on rapid
+ * restarts (e.g. during agentic dev sessions with hot reload).
+ */
+export function isWorkflowDataFresh(db: SqlJsDatabase, repoFullName: string): boolean {
+  const result = db.exec(
+    `SELECT MAX(fetched_at) FROM github_workflow_runs WHERE repo_full_name = ?`,
+    [repoFullName],
+  );
+  const raw = result[0]?.values[0]?.[0] as string | null | undefined;
+  if (!raw) return false;
+  // SQLite datetime('now') stores UTC without 'Z' suffix — append it before parsing.
+  const fetchedAt = new Date(raw.includes('T') ? raw : raw + 'Z');
+  return Date.now() - fetchedAt.getTime() < WORKFLOW_CACHE_MAX_AGE_MS;
+}
+
+/**
+ * Fetches the core rate-limit remaining count for the given token.
+ * Returns null if the request fails (caller should treat null as "unknown / proceed").
+ */
+async function fetchTokenRateLimitRemaining(token: string): Promise<number | null> {
+  try {
+    const res = await fetch('https://api.github.com/rate_limit', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { resources: { core: { remaining: number } } };
+    return data.resources.core.remaining;
+  } catch {
+    return null;
+  }
+}
+
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('github:fetch-notifications', async () => {
     const auth = loadGitHubAuth(db);
@@ -134,15 +186,38 @@ export async function runBootWorkflowCheck(
      WHERE subject_type IN ('CheckSuite', 'WorkflowRun')`,
   );
 
-  const repos: string[] = result[0]?.values.map((row) => row[0] as string) ?? [];
-  if (repos.length === 0) return;
+  const allRepos: string[] = result[0]?.values.map((row) => row[0] as string) ?? [];
+  if (allRepos.length === 0) return;
+
+  // Feature 2: skip repos whose workflow data is already fresh (avoids burning rate
+  // limit on rapid restarts, e.g. during agentic dev sessions with hot reload).
+  const staleRepos = allRepos.filter((repo) => !isWorkflowDataFresh(db, repo));
+  if (staleRepos.length === 0) {
+    console.log('[Boot] Workflow cache is fresh for all CI repos — skipping pre-warm');
+    return;
+  }
+
+  // Feature 1: when estimated API calls exceed the threshold AND the rate-limit
+  // budget is below BOOT_CHECK_RATE_LIMIT_THRESHOLD, skip the pre-warm entirely.
+  const estimatedCalls = staleRepos.length * BOOT_CHECK_ESTIMATED_CALLS_PER_REPO;
+  if (estimatedCalls > BOOT_CHECK_MAX_ESTIMATED_CALLS) {
+    const remaining = await fetchTokenRateLimitRemaining(auth.accessToken);
+    if (remaining !== null && remaining < BOOT_CHECK_RATE_LIMIT_THRESHOLD) {
+      console.log(
+        `[Boot] Skipping workflow pre-warm: rate limit low (${remaining} remaining, ` +
+        `threshold ${BOOT_CHECK_RATE_LIMIT_THRESHOLD}) and ~${estimatedCalls} calls needed ` +
+        `for ${staleRepos.length} repo(s)`,
+      );
+      return;
+    }
+  }
 
   const sendStatus = (msg: string) => getWindow()?.webContents.send('app:background-status', msg);
 
-  console.log(`[Boot] Pre-warming workflow cache for ${repos.length} repo(s) with CI notifications…`);
-  sendStatus(`Caching workflow data for ${repos.length} repo${repos.length !== 1 ? 's' : ''}…`);
+  console.log(`[Boot] Pre-warming workflow cache for ${staleRepos.length} stale repo(s)…`);
+  sendStatus(`Caching workflow data for ${staleRepos.length} repo${staleRepos.length !== 1 ? 's' : ''}…`);
 
-  for (const repo of repos) {
+  for (const repo of staleRepos) {
     try {
       sendStatus(`Loading workflow runs: ${repo.split('/')[1]}…`);
       const { runsStored } = await fetchAndStoreWorkflowData(db, auth.accessToken, repo);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1125,6 +1125,17 @@ function BackgroundStatusBar({
     return '#4caf50';                            // green
   }
 
+  // Helper: human-readable time until rate limit reset
+  function formatResetIn(resetUnixSec: number): string {
+    const msLeft = resetUnixSec * 1000 - Date.now();
+    if (msLeft <= 0) return 'resets soon';
+    const totalMins = Math.ceil(msLeft / 60_000);
+    if (totalMins < 60) return `resets in ${totalMins}m`;
+    const hours = Math.floor(totalMins / 60);
+    const mins = totalMins % 60;
+    return mins > 0 ? `resets in ${hours}h ${mins}m` : `resets in ${hours}h`;
+  }
+
   // Build badges for OAuth and PAT sources (only when configured)
   const oauthBadge = rateLimit?.oauth.configured ? rateLimit.oauth : null;
   const patBadge = rateLimit?.pat.configured ? rateLimit.pat : null;
@@ -1152,7 +1163,7 @@ function BackgroundStatusBar({
             >
               {oauthBadge.error || !oauthBadge.resource
                 ? '⚡ OAuth –'
-                : `⚡ OAuth ${oauthBadge.resource.remaining.toLocaleString()}/${oauthBadge.resource.limit.toLocaleString()}`}
+                : `⚡ OAuth ${oauthBadge.resource.remaining.toLocaleString()}/${oauthBadge.resource.limit.toLocaleString()}${oauthBadge.resource.remaining < 500 ? ` · ${formatResetIn(oauthBadge.resource.reset)}` : ''}`}
             </span>
           )}
           {oauthBadge && patBadge && (
@@ -1168,7 +1179,7 @@ function BackgroundStatusBar({
             >
               {patBadge.error || !patBadge.resource
                 ? '⚡ PAT –'
-                : `⚡ PAT ${patBadge.resource.remaining.toLocaleString()}/${patBadge.resource.limit.toLocaleString()}`}
+                : `⚡ PAT ${patBadge.resource.remaining.toLocaleString()}/${patBadge.resource.limit.toLocaleString()}${patBadge.resource.remaining < 500 ? ` · ${formatResetIn(patBadge.resource.reset)}` : ''}`}
             </span>
           )}
         </div>

--- a/tests/unit/boot-workflow-check.test.ts
+++ b/tests/unit/boot-workflow-check.test.ts
@@ -1,0 +1,82 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import { getSchema } from '../../src/storage/schema';
+import { isWorkflowDataFresh } from '../../src/plugins/notifications/handler';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function insertWorkflowRun(
+  db: SqlJsDatabase,
+  repoFullName: string,
+  fetchedAt: string,
+): void {
+  db.run(
+    `INSERT INTO github_workflow_runs
+       (id, repo_full_name, workflow_name, workflow_id, head_branch, head_sha,
+        event, status, conclusion, run_number, run_started_at, updated_at, html_url, fetched_at)
+     VALUES (?, ?, 'CI', '1', 'main', 'abc', 'push', 'completed', 'success', 1,
+             datetime('now'), datetime('now'), 'https://github.com/x/y/actions', ?)`,
+    [Math.random().toString(), repoFullName, fetchedAt],
+  );
+}
+
+// ── Tests: isWorkflowDataFresh ────────────────────────────────────────────────
+
+describe('isWorkflowDataFresh', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+  });
+
+  afterEach(() => db.close());
+
+  it('returns false when no workflow runs exist for the repo', () => {
+    expect(isWorkflowDataFresh(db, 'owner/repo')).toBe(false);
+  });
+
+  it('returns false when workflow runs exist for a different repo only', () => {
+    insertWorkflowRun(db, 'other/repo', new Date().toISOString().replace('T', ' ').slice(0, 19));
+    expect(isWorkflowDataFresh(db, 'owner/repo')).toBe(false);
+  });
+
+  it('returns true when data was fetched just now', () => {
+    const nowUtc = new Date().toISOString().replace('T', ' ').slice(0, 19);
+    insertWorkflowRun(db, 'owner/repo', nowUtc);
+    expect(isWorkflowDataFresh(db, 'owner/repo')).toBe(true);
+  });
+
+  it('returns true when data was fetched 10 minutes ago', () => {
+    const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000)
+      .toISOString().replace('T', ' ').slice(0, 19);
+    insertWorkflowRun(db, 'owner/repo', tenMinAgo);
+    expect(isWorkflowDataFresh(db, 'owner/repo')).toBe(true);
+  });
+
+  it('returns false when data was fetched 31 minutes ago', () => {
+    const thirtyOneMinAgo = new Date(Date.now() - 31 * 60 * 1000)
+      .toISOString().replace('T', ' ').slice(0, 19);
+    insertWorkflowRun(db, 'owner/repo', thirtyOneMinAgo);
+    expect(isWorkflowDataFresh(db, 'owner/repo')).toBe(false);
+  });
+
+  it('returns false when data was fetched 2 hours ago', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+      .toISOString().replace('T', ' ').slice(0, 19);
+    insertWorkflowRun(db, 'owner/repo', twoHoursAgo);
+    expect(isWorkflowDataFresh(db, 'owner/repo')).toBe(false);
+  });
+
+  it('uses MAX(fetched_at) — returns true if any run was fetched recently', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+      .toISOString().replace('T', ' ').slice(0, 19);
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000)
+      .toISOString().replace('T', ' ').slice(0, 19);
+    insertWorkflowRun(db, 'owner/repo', twoHoursAgo);
+    insertWorkflowRun(db, 'owner/repo', fiveMinAgo);
+    expect(isWorkflowDataFresh(db, 'owner/repo')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Three rate-limit protection features to prevent exhausting GitHub API quotas:

### 1. Boot pre-warm guard (rate limit < 1000 + >50 calls → skip)
- Before running the boot workflow cache pre-warm, estimates the number of API calls needed (\epos × 10\)
- If the estimate exceeds 50 calls **and** the OAuth rate limit is below 1,000 remaining, the entire pre-warm is skipped
- The rate-limit probe (1 API call) is only made when the estimate is already >50, so it's nearly free on normal startups

### 2. Cache freshness check on startup
- Each repo's workflow run data is checked for freshness before fetching — data less than **30 minutes old** is considered fresh and skipped
- If all CI repos are already fresh, the pre-warm returns immediately without any API calls
- Prevents rapid restarts (e.g. agentic dev sessions with hot reload) from burning the rate limit on redundant fetches

### 3. Show reset time in status bar when remaining < 500
- The rate-limit badge in the status bar now shows a human-readable reset countdown inline when remaining drops below 500
- Format: \⚡ PAT 450/5000 · resets in 12m\ (or \esets in 1h 5m\ for longer waits)
- Reset time was previously only visible as a tooltip

## Tests
Added \	ests/unit/boot-workflow-check.test.ts\ with 6 tests for \isWorkflowDataFresh\:
- No data → false
- Data for different repo → false  
- Fetched just now → true
- Fetched 10 min ago → true
- Fetched 31 min ago → false
- Multiple runs, uses MAX(fetched_at) → true if any recent