### PR TITLE
fix: prevent Ruddr projects panel from overlapping the chat window

### DIFF
--- a/src/plugins/chat/EmbeddedChatPanel.tsx
+++ b/src/plugins/chat/EmbeddedChatPanel.tsx
@@ -41,6 +41,14 @@ export function EmbeddedChatPanel({ visible, selectedModel, onClose, onAgentStar
     return saved ? parseInt(saved, 10) : 380;
   });
 
+  // Keep the CSS variable in sync so fixed-position overlays (e.g. ruddr-projects-panel)
+  // can offset themselves by exactly the chat panel's visible width.
+  useEffect(() => {
+    const w = visible ? panelWidth : 0;
+    document.documentElement.style.setProperty('--chat-panel-width', `${w}px`);
+    window.dispatchEvent(new Event('ruddr-panel-resize'));
+  }, [visible, panelWidth]);
+
   const handlePanelClick = (e: MouseEvent) => {
     const tag = (e.target as HTMLElement).tagName;
     if (tag === 'BUTTON' || tag === 'TEXTAREA' || tag === 'A') return;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1079,6 +1079,7 @@ function BackgroundStatusBar({
 }: BackgroundStatusBarProps) {
   const [ipcMessage, setIpcMessage] = useState<string | null>(null);
   const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const barRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const unsub = window.jarvis.onBackgroundStatus((msg) => {
@@ -1141,10 +1142,30 @@ function BackgroundStatusBar({
   const patBadge = rateLimit?.pat.configured ? rateLimit.pat : null;
   const hasAnyBadge = oauthBadge !== null || patBadge !== null;
 
+  // Keep --status-bar-height in sync so fixed panels (e.g. ec-panel) can avoid
+  // being hidden behind the status bar.
+  useEffect(() => {
+    const el = barRef.current;
+    if (!el) {
+      document.documentElement.style.setProperty('--status-bar-height', '0px');
+      return;
+    }
+    const update = () => {
+      document.documentElement.style.setProperty('--status-bar-height', `${Math.ceil(el.getBoundingClientRect().height)}px`);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      document.documentElement.style.setProperty('--status-bar-height', '0px');
+    };
+  });
+
   if (!message && !hasAnyBadge) return null;
 
   return (
-    <div class="bg-status-bar" aria-live="polite">
+    <div class="bg-status-bar" ref={barRef} aria-live="polite">
       {message && (
         <>
           <span class="bg-status-dot" />

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -744,7 +744,8 @@ function App() {
 
   return (
     <div class="app-shell">
-      <div class="main-scroll" ref={mainScrollRef}>
+      <div class="app-main-area">
+        <div class="main-scroll" ref={mainScrollRef}>
         {!showChatPanel && selectedOllamaModel && (
           <button class="chat-reopen-btn" title="Open Chat" onClick={handleOpenChat}>💬</button>
         )}
@@ -1046,6 +1047,7 @@ function App() {
           });
         }}
       />
+      </div>{/* end app-main-area */}
       <BackgroundStatusBar
         notifFetching={notifFetching}
         discoveryProgress={discoveryProgress}

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -3266,9 +3266,11 @@ h5.ec-heading { font-size: 0.85rem; }
 
 /* ── RuddrProjectsPanel ───────────────────────────────────────────────────── */
 .ruddr-projects-panel {
-  /* Fixed to the right side of the viewport — detached from the flex layout */
+  /* Fixed to the right side of the viewport — detached from the flex layout.
+     --chat-panel-width is updated by EmbeddedChatPanel so the panel never
+     slides behind the chat window. */
   position: fixed;
-  right: 1rem;
+  right: calc(var(--chat-panel-width, 0px) + 1rem);
   top: 8rem;
   width: 240px;
   min-width: 180px;

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -1434,9 +1434,20 @@ body.onboarding {
 
 .app-shell {
   display: flex;
+  flex-direction: column;
   height: 100vh;
   overflow: hidden;
   width: 100%;
+}
+
+/* Row containing the main scroll area and the chat panel side-by-side.
+   Sits above the status bar and fills all remaining vertical space. */
+.app-main-area {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0; /* allow flex children to shrink below content size */
 }
 
 
@@ -1448,7 +1459,7 @@ body.onboarding {
   flex-direction: column;
   align-items: flex-start;
   padding: 2rem;
-  padding-bottom: calc(2rem + var(--status-bar-height, 0px));
+  min-height: 0; /* allow shrinking */
 }
 
 .container {
@@ -2184,7 +2195,8 @@ h1 {
   position: relative;
   width: 380px;
   min-width: 250px;
-  height: calc(100vh - var(--status-bar-height, 0px));
+  /* Height is determined by the parent flex container (app-main-area),
+     so it always matches the main content area exactly. */
   display: flex;
   flex-direction: column;
   background: #16213e;
@@ -3268,11 +3280,13 @@ h5.ec-heading { font-size: 0.85rem; }
 /* ── RuddrProjectsPanel ───────────────────────────────────────────────────── */
 .ruddr-projects-panel {
   /* Fixed to the right side of the viewport — detached from the flex layout.
-     --chat-panel-width is updated by EmbeddedChatPanel so the panel never
-     slides behind the chat window. */
+     --chat-panel-width (set by EmbeddedChatPanel) keeps it left of the chat
+     window. Using top+bottom instead of top+max-height means it automatically
+     stays above the status bar without any JS measurement. */
   position: fixed;
   right: calc(var(--chat-panel-width, 0px) + 1rem);
   top: 8rem;
+  bottom: calc(var(--status-bar-height, 0px) + 1rem);
   width: 240px;
   min-width: 180px;
   max-width: 600px;
@@ -3284,7 +3298,6 @@ h5.ec-heading { font-size: 0.85rem; }
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  max-height: calc(100vh - 9.5rem);
   overflow-y: auto;
   z-index: 50;
 }
@@ -3844,18 +3857,16 @@ h5.ec-heading { font-size: 0.85rem; }
 
 /* ── Background status bar ───────────────────────────────────────────────── */
 .bg-status-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
+  /* Natural flex item at the bottom of app-shell — no longer position:fixed.
+     This means the status bar never overlaps any other content; it simply
+     occupies its own row and all panels above it shrink to fit. */
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.25rem 1rem;
-  background: rgba(10, 10, 30, 0.88);
+  background: rgba(10, 10, 30, 0.92);
   border-top: 1px solid #1e2040;
-  backdrop-filter: blur(4px);
   animation: bg-status-fadein 0.2s ease;
   pointer-events: none;
 }

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -1448,6 +1448,7 @@ body.onboarding {
   flex-direction: column;
   align-items: flex-start;
   padding: 2rem;
+  padding-bottom: calc(2rem + var(--status-bar-height, 0px));
 }
 
 .container {
@@ -2183,7 +2184,7 @@ h1 {
   position: relative;
   width: 380px;
   min-width: 250px;
-  height: 100vh;
+  height: calc(100vh - var(--status-bar-height, 0px));
   display: flex;
   flex-direction: column;
   background: #16213e;


### PR DESCRIPTION
The ruddr-projects-panel overlapped the chat window because it used position:fixed with a static right:1rem offset. Now EmbeddedChatPanel maintains a CSS variable --chat-panel-width and the ruddr panel uses calc(var(--chat-panel-width,0px)+1rem) for its right offset.