### PR TITLE
feat: OneNote page content caching, LLM search tool, and cache browser

### DIFF
--- a/scripts/read-onenote-section.ps1
+++ b/scripts/read-onenote-section.ps1
@@ -59,13 +59,15 @@ try {
 
   foreach ($pageNode in $pageNodes) {
     $pageIndex++
-    $pageId       = $pageNode.GetAttribute('ID')
-    $pageName     = $pageNode.GetAttribute('name')
-    $pageDateTime = $pageNode.GetAttribute('dateTime')
-  $pageLevelStr = $pageNode.GetAttribute('pageLevel')
-  if ($null -eq $pageName)     { $pageName = '' }
-  if ($null -eq $pageDateTime) { $pageDateTime = '' }
-  [int]$pageLevel = if (-not [string]::IsNullOrEmpty($pageLevelStr)) { [int]$pageLevelStr } else { 1 }
+    $pageId            = $pageNode.GetAttribute('ID')
+    $pageName          = $pageNode.GetAttribute('name')
+    $pageDateTime      = $pageNode.GetAttribute('dateTime')
+    $pageLastModified  = $pageNode.GetAttribute('lastModifiedTime')
+    $pageLevelStr      = $pageNode.GetAttribute('pageLevel')
+    if ($null -eq $pageName)         { $pageName = '' }
+    if ($null -eq $pageDateTime)     { $pageDateTime = '' }
+    if ($null -eq $pageLastModified) { $pageLastModified = '' }
+    [int]$pageLevel = if (-not [string]::IsNullOrEmpty($pageLevelStr)) { [int]$pageLevelStr } else { 1 }
 
     # GetPageContent - PageDetail.pdBasic = 0
     $contentXml = [string]''
@@ -97,11 +99,12 @@ try {
     }
 
     $pages.Add(@{
-      pageIndex = $pageIndex
-      pageLevel = $pageLevel
-      title     = $pageName
-      date      = $pageDateTime
-      content   = $textContent
+      pageIndex    = $pageIndex
+      pageLevel    = $pageLevel
+      title        = $pageName
+      date         = $pageDateTime
+      lastModified = $pageLastModified
+      content      = $textContent
     })
   }
 

--- a/scripts/read-onenote-section.ps1
+++ b/scripts/read-onenote-section.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+  Read a OneNote .one section file via COM and output page content as JSON.
+.PARAMETER FilePath
+  Absolute path to the .one section file.
+.OUTPUTS
+  JSON written to stdout: { ok: true, pages: [{ pageIndex, title, date, content }] }
+  On failure:           { ok: false, error: "<message>" }
+#>
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$FilePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-SafeJson([object]$value) {
+  return $value | ConvertTo-Json -Depth 5 -Compress
+}
+
+try {
+  if (-not (Test-Path -LiteralPath $FilePath)) {
+    Write-Output (ConvertTo-SafeJson @{ ok = $false; error = "File not found: $FilePath" })
+    exit 1
+  }
+
+  $onenote = New-Object -ComObject OneNote.Application
+
+  # Derive section name from file path
+  $sectionName = [System.IO.Path]::GetFileNameWithoutExtension($FilePath)
+
+  # OpenHierarchy - CreateFileType.cftNone = 0
+  $sectionId = [string]''
+  $onenote.OpenHierarchy($FilePath, [string]'', [ref]$sectionId, 0)
+
+  if ([string]::IsNullOrEmpty($sectionId)) {
+    Write-Output (ConvertTo-SafeJson @{ ok = $false; error = "Failed to resolve section ID for: $FilePath" })
+    exit 1
+  }
+
+  # GetHierarchy - HierarchyScope.hsPages = 4
+  $hierXml = [string]''
+  $onenote.GetHierarchy($sectionId, 4, [ref]$hierXml)
+
+  [xml]$hier = $hierXml
+
+  # Detect namespace from document root; fall back to 2013 schema
+  $rootNs = $hier.DocumentElement.NamespaceURI
+  if ([string]::IsNullOrEmpty($rootNs)) {
+    $rootNs = 'http://schemas.microsoft.com/office/onenote/2013/onenote'
+  }
+  $nsMgr = New-Object System.Xml.XmlNamespaceManager($hier.NameTable)
+  $nsMgr.AddNamespace('one', $rootNs)
+
+  $pageNodes = $hier.SelectNodes('//one:Page', $nsMgr)
+
+  $pages = [System.Collections.Generic.List[hashtable]]::new()
+  $pageIndex = 0
+
+  foreach ($pageNode in $pageNodes) {
+    $pageIndex++
+    $pageId       = $pageNode.GetAttribute('ID')
+    $pageName     = $pageNode.GetAttribute('name')
+    $pageDateTime = $pageNode.GetAttribute('dateTime')
+  $pageLevelStr = $pageNode.GetAttribute('pageLevel')
+  if ($null -eq $pageName)     { $pageName = '' }
+  if ($null -eq $pageDateTime) { $pageDateTime = '' }
+  [int]$pageLevel = if (-not [string]::IsNullOrEmpty($pageLevelStr)) { [int]$pageLevelStr } else { 1 }
+
+    # GetPageContent - PageDetail.pdBasic = 0
+    $contentXml = [string]''
+    try {
+      $onenote.GetPageContent($pageId, [ref]$contentXml, 0)
+    } catch {
+      # Non-fatal: page content unreadable; continue with empty text
+    }
+
+    $textContent = ''
+    if (-not [string]::IsNullOrEmpty($contentXml)) {
+      try {
+        [xml]$content = $contentXml
+        $cNs = $content.DocumentElement.NamespaceURI
+        if ([string]::IsNullOrEmpty($cNs)) { $cNs = $rootNs }
+        $cMgr = New-Object System.Xml.XmlNamespaceManager($content.NameTable)
+        $cMgr.AddNamespace('one', $cNs)
+
+        $tNodes = $content.SelectNodes('//one:T', $cMgr)
+        $parts  = [System.Collections.Generic.List[string]]::new()
+        foreach ($t in $tNodes) {
+          $inner = $t.InnerText.Trim()
+          if ($inner.Length -gt 0) { $parts.Add($inner) }
+        }
+        $textContent = $parts -join ' '
+      } catch {
+        $textContent = ''
+      }
+    }
+
+    $pages.Add(@{
+      pageIndex = $pageIndex
+      pageLevel = $pageLevel
+      title     = $pageName
+      date      = $pageDateTime
+      content   = $textContent
+    })
+  }
+
+  Write-Output (ConvertTo-SafeJson @{ ok = $true; sectionName = $sectionName; pages = $pages.ToArray() })
+  exit 0
+
+} catch {
+  Write-Output (ConvertTo-SafeJson @{ ok = $false; error = $_.Exception.Message })
+  exit 1
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -251,6 +251,8 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('onedrive:cache-onenote-files-for-group', groupId),
   onedriveGetOneNoteCache: (folderId: number, relativePath: string) =>
     ipcRenderer.invoke('onedrive:get-onenote-cache', folderId, relativePath),
+  onedriveGetOneNoteCacheForGroup: (groupId: number) =>
+    ipcRenderer.invoke('onedrive:get-onenote-cache-for-group', groupId),
   shellOpenUrl: (url: string) =>
     ipcRenderer.invoke('shell:open-url', url),
   // Browser Companion

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -247,6 +247,10 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('onedrive:read-onenote-file', filePath),
   onedriveReadUrlShortcut: (filePath: string) =>
     ipcRenderer.invoke('onedrive:read-url-shortcut', filePath),
+  onedriveCacheOneNoteFilesForGroup: (groupId: number) =>
+    ipcRenderer.invoke('onedrive:cache-onenote-files-for-group', groupId),
+  onedriveGetOneNoteCache: (folderId: number, relativePath: string) =>
+    ipcRenderer.invoke('onedrive:get-onenote-cache', folderId, relativePath),
   shellOpenUrl: (url: string) =>
     ipcRenderer.invoke('shell:open-url', url),
   // Browser Companion

--- a/src/plugins/chat/db-helpers.ts
+++ b/src/plugins/chat/db-helpers.ts
@@ -10,6 +10,7 @@ import { listOrgs } from '../../services/github-discovery';
 export function buildSystemContext(db: SqlJsDatabase): string {
   const lines: string[] = [
     'You are Jarvis, a personal GitHub repository assistant.',
+    `Today's date: ${new Date().toISOString().slice(0, 10)}.`,
     'You have access to the user\'s GitHub data that has been indexed into a local database (snapshot shown below).',
     'Help the user find repos, understand their codebase, and answer questions about their repositories.',
     'Be concise and helpful. When listing repos, use the full_name format (org/repo).',
@@ -252,7 +253,7 @@ const ONENOTE_SNIPPET_LENGTH = 400;
  * Returns up to 10 pages with a short content snippet around the first match.
  * Optionally filter to a specific group name.
  */
-export function searchOneNoteForChat(db: SqlJsDatabase, query: string, groupName?: string): string {
+export function searchOneNoteForChat(db: SqlJsDatabase, query: string, groupName?: string, since?: string): string {
   const words = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
   if (words.length === 0) return 'No search terms provided.';
 
@@ -265,26 +266,31 @@ export function searchOneNoteForChat(db: SqlJsDatabase, query: string, groupName
   const groupFilter = groupName ? 'AND LOWER(g.name) LIKE LOWER(?)' : '';
   const groupParams = groupName ? [`%${groupName}%`] : [];
 
+  const sinceFilter = since ? 'AND c.page_last_modified >= ?' : '';
+  const sinceParams = since ? [since] : [];
+
   const sql = `
     SELECT g.name AS group_name,
            c.section_name,
            c.page_level,
            c.page_title,
            c.page_date,
+           c.page_last_modified,
            SUBSTR(c.page_content, 1, ${ONENOTE_SNIPPET_LENGTH * 3}) AS raw_content
     FROM onedrive_onenote_cache c
     JOIN onedrive_customer_folders cf ON cf.id = c.folder_id
     JOIN groups g ON g.id = cf.group_id
     WHERE ${wordConditions}
     ${groupFilter}
-    ORDER BY g.name, c.section_name, c.page_index
+    ${sinceFilter}
+    ORDER BY c.page_last_modified DESC, g.name, c.section_name, c.page_index
     LIMIT 10`;
 
   const stmt = db.prepare(sql);
-  type Row = { group_name: string; section_name: string | null; page_level: number; page_title: string | null; page_date: string | null; raw_content: string | null };
+  type Row = { group_name: string; section_name: string | null; page_level: number; page_title: string | null; page_date: string | null; page_last_modified: string | null; raw_content: string | null };
   const rows: Row[] = [];
   try {
-    stmt.bind([...wordParams, ...groupParams]);
+    stmt.bind([...wordParams, ...groupParams, ...sinceParams]);
     while (stmt.step()) rows.push(stmt.getAsObject() as unknown as Row);
   } finally {
     stmt.free();
@@ -292,7 +298,8 @@ export function searchOneNoteForChat(db: SqlJsDatabase, query: string, groupName
 
   if (rows.length === 0) {
     const hint = groupName ? ` in group "${groupName}"` : '';
-    return `No OneNote pages found matching "${query}"${hint}. Try broader terms or check that files have been cached via the OneDrive panel.`;
+    const dateHint = since ? ` since ${since}` : '';
+    return `No OneNote pages found matching "${query}"${hint}${dateHint}. Try broader terms or check that files have been cached via the OneDrive panel.`;
   }
 
   const lines = [`Found ${rows.length} OneNote page(s) matching "${query}":`];
@@ -300,8 +307,9 @@ export function searchOneNoteForChat(db: SqlJsDatabase, query: string, groupName
     const levelPrefix = r.page_level > 1 ? `${'  '.repeat(r.page_level - 1)}↳ ` : '';
     const section = r.section_name ? ` › ${r.section_name}` : '';
     const title = r.page_title || '(untitled)';
+    const modified = r.page_last_modified ? ` [modified: ${r.page_last_modified.slice(0, 10)}]` : '';
     const date = r.page_date ? ` (${r.page_date})` : '';
-    lines.push(`\n[${r.group_name}${section}] ${levelPrefix}${title}${date}`);
+    lines.push(`\n[${r.group_name}${section}] ${levelPrefix}${title}${date}${modified}`);
 
     // Extract a short snippet around the first matching word
     const content = r.raw_content ?? '';

--- a/src/plugins/chat/db-helpers.ts
+++ b/src/plugins/chat/db-helpers.ts
@@ -117,6 +117,31 @@ export function buildSystemContext(db: SqlJsDatabase): string {
     }
   }
 
+  // OneNote cache summary — tell the LLM this data exists and is searchable
+  try {
+    const onStmt = db.prepare(
+      `SELECT COUNT(*) as page_count,
+              COUNT(DISTINCT c.folder_id || '|' || c.relative_path) as section_count,
+              COUNT(DISTINCT cf.group_id) as group_count
+       FROM onedrive_onenote_cache c
+       JOIN onedrive_customer_folders cf ON cf.id = c.folder_id`,
+    );
+    if (onStmt.step()) {
+      const r = onStmt.getAsObject() as { page_count: number; section_count: number; group_count: number };
+      if (r.page_count > 0) {
+        lines.push('');
+        lines.push(
+          `OneNote pages cached: ${r.page_count} pages across ${r.section_count} section(s) in ${r.group_count} group(s). ` +
+          'Use the search_onenote tool to find relevant notes when the user asks about project-specific information, ' +
+          'meeting notes, decisions, or any topic that may be documented in OneNote.',
+        );
+      }
+    }
+    onStmt.free();
+  } catch {
+    // table not yet created in older DB; skip
+  }
+
   return lines.join('\n');
 }
 
@@ -217,3 +242,85 @@ export function searchSecretsForChat(db: SqlJsDatabase, pattern: string): string
   }
   return lines.join('\n');
 }
+
+// ── OneNote search ────────────────────────────────────────────────────────────
+
+const ONENOTE_SNIPPET_LENGTH = 400;
+
+/**
+ * Search cached OneNote pages for content matching all words in `query`.
+ * Returns up to 10 pages with a short content snippet around the first match.
+ * Optionally filter to a specific group name.
+ */
+export function searchOneNoteForChat(db: SqlJsDatabase, query: string, groupName?: string): string {
+  const words = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return 'No search terms provided.';
+
+  // Build WHERE clauses: every word must appear in title OR content
+  const wordConditions = words.map(() =>
+    `(LOWER(COALESCE(c.page_title,'')) LIKE ? OR LOWER(COALESCE(c.page_content,'')) LIKE ?)`,
+  ).join(' AND ');
+  const wordParams = words.flatMap(w => [`%${w}%`, `%${w}%`]);
+
+  const groupFilter = groupName ? 'AND LOWER(g.name) LIKE LOWER(?)' : '';
+  const groupParams = groupName ? [`%${groupName}%`] : [];
+
+  const sql = `
+    SELECT g.name AS group_name,
+           c.section_name,
+           c.page_level,
+           c.page_title,
+           c.page_date,
+           SUBSTR(c.page_content, 1, ${ONENOTE_SNIPPET_LENGTH * 3}) AS raw_content
+    FROM onedrive_onenote_cache c
+    JOIN onedrive_customer_folders cf ON cf.id = c.folder_id
+    JOIN groups g ON g.id = cf.group_id
+    WHERE ${wordConditions}
+    ${groupFilter}
+    ORDER BY g.name, c.section_name, c.page_index
+    LIMIT 10`;
+
+  const stmt = db.prepare(sql);
+  type Row = { group_name: string; section_name: string | null; page_level: number; page_title: string | null; page_date: string | null; raw_content: string | null };
+  const rows: Row[] = [];
+  try {
+    stmt.bind([...wordParams, ...groupParams]);
+    while (stmt.step()) rows.push(stmt.getAsObject() as unknown as Row);
+  } finally {
+    stmt.free();
+  }
+
+  if (rows.length === 0) {
+    const hint = groupName ? ` in group "${groupName}"` : '';
+    return `No OneNote pages found matching "${query}"${hint}. Try broader terms or check that files have been cached via the OneDrive panel.`;
+  }
+
+  const lines = [`Found ${rows.length} OneNote page(s) matching "${query}":`];
+  for (const r of rows) {
+    const levelPrefix = r.page_level > 1 ? `${'  '.repeat(r.page_level - 1)}↳ ` : '';
+    const section = r.section_name ? ` › ${r.section_name}` : '';
+    const title = r.page_title || '(untitled)';
+    const date = r.page_date ? ` (${r.page_date})` : '';
+    lines.push(`\n[${r.group_name}${section}] ${levelPrefix}${title}${date}`);
+
+    // Extract a short snippet around the first matching word
+    const content = r.raw_content ?? '';
+    const lower = content.toLowerCase();
+    let snippetStart = 0;
+    for (const w of words) {
+      const idx = lower.indexOf(w);
+      if (idx !== -1) {
+        snippetStart = Math.max(0, idx - 60);
+        break;
+      }
+    }
+    const snippet = content.slice(snippetStart, snippetStart + ONENOTE_SNIPPET_LENGTH).trim();
+    if (snippet) {
+      const prefix = snippetStart > 0 ? '…' : '';
+      const suffix = snippetStart + ONENOTE_SNIPPET_LENGTH < content.length ? '…' : '';
+      lines.push(`  ${prefix}${snippet}${suffix}`);
+    }
+  }
+  return lines.join('\n');
+}
+

--- a/src/plugins/chat/handler.ts
+++ b/src/plugins/chat/handler.ts
@@ -10,7 +10,7 @@ import {
   type OllamaToolCall,
 } from '../../services/ollama';
 import { getConfigValue } from '../../storage/database';
-import { buildSystemContext, searchReposForChat, searchSecretsForChat } from './db-helpers';
+import { buildSystemContext, searchReposForChat, searchSecretsForChat, searchOneNoteForChat } from './db-helpers';
 
 const activeChatAborts = new Map<number, AbortController>();
 
@@ -58,6 +58,32 @@ const CHAT_TOOLS: OllamaTool[] = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'search_onenote',
+      description:
+        'Search the locally cached OneNote pages for content matching a query. ' +
+        'Use this when the user asks about project-specific topics, meeting notes, decisions, ' +
+        'requirements, or any information that may be documented in OneNote sections linked to a group. ' +
+        'Supports partial matching: all words in the query must appear in the page title or content. ' +
+        'Optionally filter results to a specific group by name.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'One or more search terms (space-separated). All terms must match somewhere in the page.',
+          },
+          group: {
+            type: 'string',
+            description: 'Optional group name to restrict the search (partial match). Omit to search all groups.',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
 ];
 
 function dispatchToolCall(db: SqlJsDatabase, call: OllamaToolCall): string {
@@ -68,6 +94,11 @@ function dispatchToolCall(db: SqlJsDatabase, call: OllamaToolCall): string {
   if (call.function.name === 'search_secrets') {
     const pattern = String(call.function.arguments['pattern'] ?? '');
     return searchSecretsForChat(db, pattern);
+  }
+  if (call.function.name === 'search_onenote') {
+    const query = String(call.function.arguments['query'] ?? '');
+    const group = call.function.arguments['group'] != null ? String(call.function.arguments['group']) : undefined;
+    return searchOneNoteForChat(db, query, group);
   }
   return `Unknown tool: ${call.function.name}`;
 }

--- a/src/plugins/chat/handler.ts
+++ b/src/plugins/chat/handler.ts
@@ -79,6 +79,10 @@ const CHAT_TOOLS: OllamaTool[] = [
             type: 'string',
             description: 'Optional group name to restrict the search (partial match). Omit to search all groups.',
           },
+          since: {
+            type: 'string',
+            description: 'Optional ISO date string (YYYY-MM-DD). When provided, only pages last modified on or after this date are returned. Use this to answer questions like "notes from this week" by computing the date from today.',
+          },
         },
         required: ['query'],
       },
@@ -98,7 +102,8 @@ function dispatchToolCall(db: SqlJsDatabase, call: OllamaToolCall): string {
   if (call.function.name === 'search_onenote') {
     const query = String(call.function.arguments['query'] ?? '');
     const group = call.function.arguments['group'] != null ? String(call.function.arguments['group']) : undefined;
-    return searchOneNoteForChat(db, query, group);
+    const since = call.function.arguments['since'] != null ? String(call.function.arguments['since']) : undefined;
+    return searchOneNoteForChat(db, query, group, since);
   }
   return `Unknown tool: ${call.function.name}`;
 }

--- a/src/plugins/groups/GroupsPanel.tsx
+++ b/src/plugins/groups/GroupsPanel.tsx
@@ -8,9 +8,10 @@ import type { Group, GroupDetail, LocalRepo, OnedriveFolderInfo, OnedriveFile, U
 interface GroupsPanelProps {
   onClose: () => void;
   onOpenOneNote?: (filePath: string) => void;
+  onOpenOneNoteCache?: (groupId: number, groupName: string) => void;
 }
 
-export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
+export function GroupsPanel({ onClose, onOpenOneNote, onOpenOneNoteCache }: GroupsPanelProps) {
   const [groups, setGroups] = useState<Group[]>([]);
   const [selectedGroup, setSelectedGroup] = useState<GroupDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -389,14 +390,26 @@ export function GroupsPanel({ onClose, onOpenOneNote }: GroupsPanelProps) {
                   <div style={{ fontSize: '0.8rem', color: '#99a', fontWeight: 600 }}>
                     Customer Data (OneDrive)
                   </div>
-                  <button
-                    class="btn-save"
-                    style={{ padding: '0.15rem 0.5rem', fontSize: '0.75rem' }}
-                    onClick={() => void handleOnedriveDiscover()}
-                    disabled={onedriveDiscovering}
-                  >
-                    {onedriveDiscovering ? 'Scanning…' : '🔍 Discover'}
-                  </button>
+                  <div style={{ display: 'flex', gap: '0.25rem' }}>
+                    <button
+                      class="btn-save"
+                      style={{ padding: '0.15rem 0.5rem', fontSize: '0.75rem' }}
+                      onClick={() => void handleOnedriveDiscover()}
+                      disabled={onedriveDiscovering}
+                    >
+                      {onedriveDiscovering ? 'Scanning…' : '🔍 Discover'}
+                    </button>
+                    {onOpenOneNoteCache && selectedGroup.onedriveFolders.some(f => f.status === 'found') && (
+                      <button
+                        class="btn-secondary"
+                        style={{ padding: '0.15rem 0.5rem', fontSize: '0.75rem' }}
+                        title="View cached OneNote pages for this group"
+                        onClick={() => onOpenOneNoteCache(selectedGroup.id, selectedGroup.name)}
+                      >
+                        📋
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 {selectedGroup.onedriveFolders.length === 0 && (

--- a/src/plugins/groups/OneNoteCachePanel.tsx
+++ b/src/plugins/groups/OneNoteCachePanel.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from 'preact/hooks';
+import type { OneNoteGroupCachePage } from '../types';
+
+// ── OneNoteCachePanel ─────────────────────────────────────────────────────────
+// Sanity-check view of all cached OneNote pages for a group.
+// Shows section name, page hierarchy, title, and last-modified date.
+// Opens as a sub-panel to the right of GroupsPanel.
+
+interface Props {
+  groupId: number;
+  groupName: string;
+  onClose: () => void;
+}
+
+export function OneNoteCachePanel({ groupId, groupName, onClose }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [pages, setPages] = useState<OneNoteGroupCachePage[]>([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    setPages([]);
+    window.jarvis.onedriveGetOneNoteCacheForGroup(groupId)
+      .then(r => { setPages(r.pages); })
+      .catch((err: unknown) => { setError(String(err)); })
+      .finally(() => { setLoading(false); });
+  }, [groupId]);
+
+  // Group pages by section file
+  const sections = groupBySectionFile(pages);
+
+  const totalPages = pages.length;
+  const withDate = pages.filter(p => p.pageLastModified).length;
+  const comPages = pages.filter(p => p.readSource === 'com').length;
+
+  return (
+    <div class="org-panel onenote-cache-panel">
+      <div class="org-panel-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span>📋 OneNote cache — {groupName}</span>
+        <button class="repo-panel-close" title="Close" onClick={onClose}>&times;</button>
+      </div>
+
+      {loading && (
+        <div style={{ color: '#99a', fontSize: '0.82rem', padding: '0.5rem 0' }}>Loading…</div>
+      )}
+
+      {!loading && error && (
+        <div style={{ color: '#f88', fontSize: '0.82rem', padding: '0.5rem 0', wordBreak: 'break-word' }}>{error}</div>
+      )}
+
+      {!loading && !error && totalPages === 0 && (
+        <div style={{ fontSize: '0.8rem', color: '#667', fontStyle: 'italic' }}>
+          No pages cached yet. Use "Cache OneNote files" in the group panel first.
+        </div>
+      )}
+
+      {!loading && totalPages > 0 && (
+        <>
+          {/* Summary bar */}
+          <div style={{ fontSize: '0.73rem', color: '#778', marginBottom: '0.65rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <span>{totalPages} page{totalPages !== 1 ? 's' : ''}</span>
+            <span>{sections.length} section{sections.length !== 1 ? 's' : ''}</span>
+            <span style={{ color: withDate < totalPages ? '#fa8' : '#6a9' }}>
+              {withDate}/{totalPages} with date
+            </span>
+            {comPages > 0 && (
+              <span style={{ color: '#88d' }}>
+                {comPages} via COM
+              </span>
+            )}
+          </div>
+
+          {sections.map(section => (
+            <SectionBlock key={section.relativePath} section={section} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── SectionBlock ──────────────────────────────────────────────────────────────
+
+interface SectionGroup {
+  relativePath: string;
+  sectionName: string;
+  pages: OneNoteGroupCachePage[];
+  cachedAt: string;
+}
+
+function groupBySectionFile(pages: OneNoteGroupCachePage[]): SectionGroup[] {
+  const map = new Map<string, SectionGroup>();
+  for (const p of pages) {
+    let g = map.get(p.relativePath);
+    if (!g) {
+      g = { relativePath: p.relativePath, sectionName: p.sectionName || p.relativePath, pages: [], cachedAt: p.cachedAt };
+      map.set(p.relativePath, g);
+    }
+    g.pages.push(p);
+  }
+  return [...map.values()];
+}
+
+function SectionBlock({ section }: { section: SectionGroup }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const cachedDate = section.cachedAt ? new Date(section.cachedAt).toLocaleDateString() : '—';
+
+  return (
+    <div style={{ marginBottom: '0.55rem', borderRadius: '5px', background: '#1a1a26', border: '1px solid #232340', overflow: 'hidden' }}>
+      {/* Section header row */}
+      <div
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0.3rem 0.5rem', cursor: 'pointer', userSelect: 'none' }}
+        onClick={() => setCollapsed(c => !c)}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', minWidth: 0 }}>
+          <span style={{ fontSize: '0.78rem' }}>📓</span>
+          <span style={{ fontSize: '0.82rem', color: '#ccd', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {section.sectionName}
+          </span>
+          <span style={{ fontSize: '0.7rem', color: '#556', flexShrink: 0 }}>
+            {section.pages.length}p
+          </span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexShrink: 0 }}>
+          <span style={{ fontSize: '0.68rem', color: '#556' }}>cached {cachedDate}</span>
+          <span style={{ fontSize: '0.7rem', color: '#556' }}>{collapsed ? '▶' : '▼'}</span>
+        </div>
+      </div>
+
+      {!collapsed && (
+        <div style={{ borderTop: '1px solid #1e1e2e' }}>
+          {section.pages.map(p => (
+            <PageRow key={p.pageIndex} page={p} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── PageRow ───────────────────────────────────────────────────────────────────
+
+function PageRow({ page }: { page: OneNoteGroupCachePage }) {
+  const indent = (page.pageLevel - 1) * 14;
+  const hasDate = !!page.pageLastModified;
+  const displayDate = hasDate ? page.pageLastModified.slice(0, 10) : null;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0.18rem 0.5rem',
+        borderBottom: '1px solid #1a1a28',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', minWidth: 0, paddingLeft: `${indent}px` }}>
+        {page.pageLevel > 1 && (
+          <span style={{ color: '#445', fontSize: '0.72rem', flexShrink: 0 }}>↳</span>
+        )}
+        <span
+          style={{
+            fontSize: '0.78rem',
+            color: page.pageTitle ? '#bbd' : '#556',
+            fontStyle: page.pageTitle ? 'normal' : 'italic',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={page.pageTitle || undefined}
+        >
+          {page.pageTitle || '(untitled)'}
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', flexShrink: 0, paddingLeft: '0.5rem' }}>
+        {displayDate ? (
+          <span style={{ fontSize: '0.7rem', color: '#6a9', fontFamily: 'monospace' }}>{displayDate}</span>
+        ) : (
+          <span style={{ fontSize: '0.68rem', color: '#fa8', fontFamily: 'monospace' }} title="No last-modified date available">no date</span>
+        )}
+        <span
+          style={{
+            fontSize: '0.62rem',
+            color: page.readSource === 'com' ? '#88d' : '#667',
+            background: page.readSource === 'com' ? '#1a1a35' : '#1a1a1a',
+            padding: '0.05rem 0.25rem',
+            borderRadius: '3px',
+          }}
+        >
+          {page.readSource}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/onedrive/handler.ts
+++ b/src/plugins/onedrive/handler.ts
@@ -1,6 +1,6 @@
-// ── OneDrive IPC handlers ─────────────────────────────────────────────────────
-import { ipcMain, dialog, BrowserWindow, shell } from 'electron';
+import { ipcMain, dialog, BrowserWindow, shell, app } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
+import path from 'path';
 import { saveDatabase } from '../../storage/database';
 import {
   listOnedriveRoots,
@@ -12,10 +12,18 @@ import {
   listFilesForFolder,
 } from '../../services/onedrive';
 import { readOneNoteSection } from '../../services/onenote-reader';
+import {
+  cacheOneNoteFilesForGroup,
+  getCachedPages,
+} from '../../services/onedrive-onenote-cache';
 import { readUrlShortcut } from '../../services/url-shortcut';
 import { getGroup } from '../../services/groups';
 
 export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
+  // Resolve PS1 script path relative to the compiled main JS, or resourcesPath when packaged.
+  const scriptPath = app.isPackaged
+    ? path.join(process.resourcesPath, 'scripts', 'read-onenote-section.ps1')
+    : path.join(__dirname, '..', '..', '..', 'scripts', 'read-onenote-section.ps1');
   ipcMain.handle('onedrive:list-roots', () => {
     return listOnedriveRoots(db);
   });
@@ -153,6 +161,26 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
       const msg = err instanceof Error ? err.message : String(err);
       return { ok: false, error: msg };
     }
+  });
+
+  ipcMain.handle('onedrive:cache-onenote-files-for-group', async (_event, groupId: number) => {
+    if (typeof groupId !== 'number') return { ok: false, error: 'Invalid groupId' };
+    try {
+      const result = await cacheOneNoteFilesForGroup(db, groupId, scriptPath);
+      saveDatabase();
+      return { ok: true, ...result };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle('onedrive:get-onenote-cache', (_event, folderId: number, relativePath: string) => {
+    if (typeof folderId !== 'number' || typeof relativePath !== 'string') {
+      return { pages: [] };
+    }
+    const pages = getCachedPages(db, folderId, relativePath);
+    return { pages };
   });
 
   ipcMain.handle('shell:open-url', (_event, url: string) => {

--- a/src/plugins/onedrive/handler.ts
+++ b/src/plugins/onedrive/handler.ts
@@ -15,6 +15,7 @@ import { readOneNoteSection } from '../../services/onenote-reader';
 import {
   cacheOneNoteFilesForGroup,
   getCachedPages,
+  getOneNoteCacheForGroup,
 } from '../../services/onedrive-onenote-cache';
 import { readUrlShortcut } from '../../services/url-shortcut';
 import { getGroup } from '../../services/groups';
@@ -180,6 +181,12 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
       return { pages: [] };
     }
     const pages = getCachedPages(db, folderId, relativePath);
+    return { pages };
+  });
+
+  ipcMain.handle('onedrive:get-onenote-cache-for-group', (_event, groupId: number) => {
+    if (typeof groupId !== 'number') return { pages: [] };
+    const pages = getOneNoteCacheForGroup(db, groupId);
     return { pages };
   });
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1366,6 +1366,14 @@ export interface OneNotePageContent {
 
 
 
+  /** ISO 8601 last-modified, or YYYY-MM-DD from title. Empty if unknown. */
+
+
+
+  lastModified: string;
+
+
+
   /** All body text found in this page, joined with spaces. */
 
 
@@ -1445,6 +1453,8 @@ export interface OneNoteCachedPage {
   pageTitle: string;
   /** Page date string (e.g. ISO datetime from OneNote metadata). */
   pageDate: string;
+  /** ISO 8601 last-modified timestamp, or YYYY-MM-DD from title prefix. Empty if unknown. */
+  pageLastModified: string;
   /** Full text content of the page. */
   pageContent: string;
   /** last_modified of the source file at time of caching. */

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1476,6 +1476,19 @@ export interface OneNoteCacheGroupResult {
   errors: Array<{ relativePath: string; error: string }>;
 }
 
+export interface OneNoteGroupCachePage {
+  relativePath: string;
+  sectionName: string;
+  pageIndex: number;
+  pageLevel: number;
+  pageTitle: string;
+  /** ISO 8601 last-modified from OneNote, or YYYY-MM-DD from title. Empty if unknown. */
+  pageLastModified: string;
+  pageDate: string;
+  readSource: 'com' | 'binary';
+  cachedAt: string;
+}
+
 // ── URL shortcut types ────────────────────────────────────────────────────────
 
 
@@ -2489,6 +2502,10 @@ export interface JarvisApi {
 
 
   onedriveGetOneNoteCache(folderId: number, relativePath: string): Promise<{ pages: OneNoteCachedPage[] }>;
+
+
+
+  onedriveGetOneNoteCacheForGroup(groupId: number): Promise<{ pages: OneNoteGroupCachePage[] }>;
 
 
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1342,6 +1342,14 @@ export interface OneNotePageContent {
 
 
 
+  /** Sub-page depth: 1 = top-level, 2 = sub-page, 3 = sub-sub-page. */
+
+
+
+  pageLevel: number;
+
+
+
   /** Best-effort page title (may be empty for untitled pages). */
 
 
@@ -1426,12 +1434,39 @@ export interface OneNoteSectionContent {
 
 
 
+// ── OneNote cache types ───────────────────────────────────────────────────────
+
+export interface OneNoteCachedPage {
+  /** 1-based page index within the section file. */
+  pageIndex: number;
+  /** Sub-page depth: 1 = top-level, 2 = sub-page, 3 = sub-sub-page. */
+  pageLevel: number;
+  /** Page title extracted from OneNote. */
+  pageTitle: string;
+  /** Page date string (e.g. ISO datetime from OneNote metadata). */
+  pageDate: string;
+  /** Full text content of the page. */
+  pageContent: string;
+  /** last_modified of the source file at time of caching. */
+  fileLastModified: string | null;
+  /** Whether content was read via OneNote COM or binary extraction. */
+  readSource: 'com' | 'binary';
+  /** When this page was cached. */
+  cachedAt: string;
+}
+
+export interface OneNoteCacheGroupResult {
+  /** Number of files that were re-read and cached (stale or new). */
+  filesProcessed: number;
+  /** Total pages written to cache. */
+  pagesCached: number;
+  /** Files skipped because the cache was already up-to-date. */
+  filesSkipped: number;
+  /** Per-file errors (non-fatal — other files continue). */
+  errors: Array<{ relativePath: string; error: string }>;
+}
+
 // ── URL shortcut types ────────────────────────────────────────────────────────
-
-
-
-
-
 
 
 export interface UrlShortcutInfo {
@@ -2436,6 +2471,14 @@ export interface JarvisApi {
 
 
   onedriveReadUrlShortcut(filePath: string): Promise<{ ok: boolean; url?: string; isOneNote?: boolean; isSharePoint?: boolean; error?: string }>;
+
+
+
+  onedriveCacheOneNoteFilesForGroup(groupId: number): Promise<OneNoteCacheGroupResult>;
+
+
+
+  onedriveGetOneNoteCache(folderId: number, relativePath: string): Promise<{ pages: OneNoteCachedPage[] }>;
 
 
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -28,6 +28,7 @@ import { BrowserCompanionPanel } from '../plugins/browser-companion/BrowserCompa
 import { GroupsStep } from '../plugins/groups/GroupsStep';
 import { GroupsPanel } from '../plugins/groups/GroupsPanel';
 import { OneNoteSectionPanel } from '../plugins/groups/OneNoteSectionPanel';
+import { OneNoteCachePanel } from '../plugins/groups/OneNoteCachePanel';
 import { GroupsDashboardPanel } from '../plugins/groups/GroupsDashboardPanel';
 
 // ── Types (imported from single source of truth in plugins/types.ts) ─────────
@@ -124,6 +125,7 @@ function App() {
   const [groups, setGroups] = useState<Group[]>([]);
   const [showGroupsPanel, setShowGroupsPanel] = useState(false);
   const [oneNoteFilePath, setOneNoteFilePath] = useState<string | null>(null);
+  const [oneNoteCacheGroup, setOneNoteCacheGroup] = useState<{ groupId: number; groupName: string } | null>(null);
 
   // GitHub rate limit
   const [rateLimit, setRateLimit] = useState<GitHubRateLimit | null>(null);
@@ -503,6 +505,7 @@ function App() {
     // Groups
     setShowGroupsPanel(false);
     setOneNoteFilePath(null);
+    setOneNoteCacheGroup(null);
     // Ollama + Chat sub-panel
     setShowOllamaPanel(false);
     setShowChatPanel(false);
@@ -707,6 +710,7 @@ function App() {
   const handleGroupsClose = async () => {
     setShowGroupsPanel(false);
     setOneNoteFilePath(null);
+    setOneNoteCacheGroup(null);
     // Refresh group list so the step badge stays current
     try {
       const list = await window.jarvis.groupsList();
@@ -983,7 +987,8 @@ function App() {
         {showGroupsPanel && (
           <GroupsPanel
             onClose={() => void handleGroupsClose()}
-            onOpenOneNote={(path) => setOneNoteFilePath(path)}
+            onOpenOneNote={(path) => { setOneNoteCacheGroup(null); setOneNoteFilePath(path); }}
+            onOpenOneNoteCache={(groupId, groupName) => { setOneNoteFilePath(null); setOneNoteCacheGroup({ groupId, groupName }); }}
           />
         )}
 
@@ -991,6 +996,14 @@ function App() {
           <OneNoteSectionPanel
             filePath={oneNoteFilePath}
             onClose={() => setOneNoteFilePath(null)}
+          />
+        )}
+
+        {oneNoteCacheGroup && (
+          <OneNoteCachePanel
+            groupId={oneNoteCacheGroup.groupId}
+            groupName={oneNoteCacheGroup.groupName}
+            onClose={() => setOneNoteCacheGroup(null)}
           />
         )}
       </div>

--- a/src/services/onedrive-onenote-cache.ts
+++ b/src/services/onedrive-onenote-cache.ts
@@ -1,0 +1,281 @@
+// ── OneNote content cache service ─────────────────────────────────────────────
+// Reads .one section files for all OneDrive folders belonging to a group and
+// caches their page content in onedrive_onenote_cache.
+//
+// Cache key: (folder_id, relative_path) — stable across file rescans because
+// onedrive_customer_folders rows are not deleted on rescan.
+//
+// Invalidation: compare file's current last_modified timestamp against the
+// file_last_modified stored in the cache; re-read only when they differ.
+
+import fs from 'fs';
+import path from 'path';
+import type { Database as SqlJsDatabase } from 'sql.js';
+import { readOneNoteSectionAsync } from './onenote-reader';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface OneNoteCachedPage {
+  pageIndex: number;
+  pageLevel: number;
+  pageTitle: string;
+  pageDate: string;
+  pageContent: string;
+  fileLastModified: string | null;
+  readSource: 'com' | 'binary';
+  cachedAt: string;
+}
+
+export interface OneNoteFileInfo {
+  folderId: number;
+  folderPath: string;
+  name: string;
+  relativePath: string;
+  lastModified: string | null;
+}
+
+export interface CacheGroupResult {
+  filesProcessed: number;
+  pagesCached: number;
+  filesSkipped: number;
+  errors: Array<{ relativePath: string; error: string }>;
+}
+
+// ── Query helpers ─────────────────────────────────────────────────────────────
+
+/** Return all .one files across all found folders for a group. */
+export function getOneNoteFilesForGroup(
+  db: SqlJsDatabase,
+  groupId: number,
+): OneNoteFileInfo[] {
+  const stmt = db.prepare(`
+    SELECT
+      cf.id         AS folder_id,
+      cf.folder_path,
+      f.name,
+      f.relative_path,
+      f.last_modified
+    FROM onedrive_files f
+    JOIN onedrive_customer_folders cf ON cf.id = f.folder_id
+    WHERE cf.group_id = ?
+      AND cf.status = 'found'
+      AND f.extension = '.one'
+    ORDER BY cf.folder_path, f.relative_path
+  `);
+  stmt.bind([groupId]);
+
+  const results: OneNoteFileInfo[] = [];
+  try {
+    while (stmt.step()) {
+      const r = stmt.getAsObject() as {
+        folder_id: number;
+        folder_path: string;
+        name: string;
+        relative_path: string;
+        last_modified: string | null;
+      };
+      results.push({
+        folderId: r.folder_id,
+        folderPath: r.folder_path,
+        name: r.name,
+        relativePath: r.relative_path,
+        lastModified: r.last_modified,
+      });
+    }
+  } finally {
+    stmt.free();
+  }
+  return results;
+}
+
+/** Return true if a valid cache entry exists for this file at the given mtime. */
+export function isCacheValid(
+  db: SqlJsDatabase,
+  folderId: number,
+  relativePath: string,
+  lastModified: string | null,
+): boolean {
+  if (!lastModified) return false;
+
+  const stmt = db.prepare(`
+    SELECT COUNT(*) AS cnt
+    FROM onedrive_onenote_cache
+    WHERE folder_id = ? AND relative_path = ? AND file_last_modified = ?
+  `);
+  stmt.bind([folderId, relativePath, lastModified]);
+  let count = 0;
+  try {
+    if (stmt.step()) {
+      const r = stmt.getAsObject() as { cnt: number };
+      count = r.cnt;
+    }
+  } finally {
+    stmt.free();
+  }
+  return count > 0;
+}
+
+/** Return cached pages for a file, ordered by page_index. */
+export function getCachedPages(
+  db: SqlJsDatabase,
+  folderId: number,
+  relativePath: string,
+): OneNoteCachedPage[] {
+  const stmt = db.prepare(`
+    SELECT
+      page_index,
+      page_level,
+      page_title,
+      page_date,
+      page_content,
+      file_last_modified,
+      read_source,
+      cached_at
+    FROM onedrive_onenote_cache
+    WHERE folder_id = ? AND relative_path = ?
+    ORDER BY page_index
+  `);
+  stmt.bind([folderId, relativePath]);
+
+  const pages: OneNoteCachedPage[] = [];
+  try {
+    while (stmt.step()) {
+      const r = stmt.getAsObject() as {
+        page_index: number;
+        page_level: number;
+        page_title: string | null;
+        page_date: string | null;
+        page_content: string | null;
+        file_last_modified: string | null;
+        read_source: string;
+        cached_at: string;
+      };
+      pages.push({
+        pageIndex: r.page_index,
+        pageLevel: r.page_level ?? 1,
+        pageTitle: r.page_title ?? '',
+        pageDate: r.page_date ?? '',
+        pageContent: r.page_content ?? '',
+        fileLastModified: r.file_last_modified,
+        readSource: (r.read_source as 'com' | 'binary') ?? 'binary',
+        cachedAt: r.cached_at,
+      });
+    }
+  } finally {
+    stmt.free();
+  }
+  return pages;
+}
+
+/**
+ * Write (replace) cache entries for one file.
+ * Deletes any existing rows for (folder_id, relative_path) before inserting,
+ * wrapped in a transaction so a mid-write failure leaves the old cache intact.
+ */
+export function writeCacheForFile(
+  db: SqlJsDatabase,
+  folderId: number,
+  relativePath: string,
+  pages: Array<{ pageIndex: number; pageLevel: number; title: string; date: string; content: string }>,
+  lastModified: string | null,
+  readSource: 'com' | 'binary',
+): void {
+  const sectionName = path.basename(relativePath, path.extname(relativePath));
+
+  db.run('BEGIN');
+  try {
+    db.run(
+      'DELETE FROM onedrive_onenote_cache WHERE folder_id = ? AND relative_path = ?',
+      [folderId, relativePath],
+    );
+    for (const page of pages) {
+      db.run(
+        `INSERT INTO onedrive_onenote_cache
+           (folder_id, relative_path, section_name, page_index, page_level,
+            page_title, page_date, page_content,
+            file_last_modified, read_source, cached_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+        [
+          folderId,
+          relativePath,
+          sectionName,
+          page.pageIndex,
+          page.pageLevel,
+          page.title,
+          page.date,
+          page.content,
+          lastModified,
+          readSource,
+        ],
+      );
+    }
+    db.run('COMMIT');
+  } catch (err) {
+    db.run('ROLLBACK');
+    throw err;
+  }
+}
+
+/**
+ * Delete all cache rows for a given folder (used when removing a root or folder).
+ */
+export function deleteCacheForFolder(db: SqlJsDatabase, folderId: number): void {
+  db.run('DELETE FROM onedrive_onenote_cache WHERE folder_id = ?', [folderId]);
+}
+
+// ── Main orchestration ────────────────────────────────────────────────────────
+
+/**
+ * Cache the content of every .one file found for a group.
+ * Files whose last_modified timestamp matches the cached value are skipped.
+ * Uses OneNote COM (full fidelity) with automatic fallback to binary extraction.
+ *
+ * @param db         Live sql.js database instance.
+ * @param groupId    ID of the group to process.
+ * @param scriptPath Absolute path to `read-onenote-section.ps1`.
+ */
+export async function cacheOneNoteFilesForGroup(
+  db: SqlJsDatabase,
+  groupId: number,
+  scriptPath: string,
+): Promise<CacheGroupResult> {
+  const files = getOneNoteFilesForGroup(db, groupId);
+  const result: CacheGroupResult = {
+    filesProcessed: 0,
+    pagesCached: 0,
+    filesSkipped: 0,
+    errors: [],
+  };
+
+  for (const file of files) {
+    if (isCacheValid(db, file.folderId, file.relativePath, file.lastModified)) {
+      result.filesSkipped++;
+      continue;
+    }
+
+    const absolutePath = path.join(file.folderPath, file.relativePath);
+    if (!fs.existsSync(absolutePath)) {
+      result.errors.push({ relativePath: file.relativePath, error: 'File not found on disk' });
+      continue;
+    }
+
+    try {
+      const section = await readOneNoteSectionAsync(absolutePath, scriptPath);
+      writeCacheForFile(
+        db,
+        file.folderId,
+        file.relativePath,
+        section.pages,
+        file.lastModified,
+        section.source,
+      );
+      result.filesProcessed++;
+      result.pagesCached += section.pages.length;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.errors.push({ relativePath: file.relativePath, error: msg });
+    }
+  }
+
+  return result;
+}

--- a/src/services/onedrive-onenote-cache.ts
+++ b/src/services/onedrive-onenote-cache.ts
@@ -20,6 +20,8 @@ export interface OneNoteCachedPage {
   pageLevel: number;
   pageTitle: string;
   pageDate: string;
+  /** ISO 8601 last-modified from OneNote metadata, or YYYY-MM-DD from title prefix. Empty string if unknown. */
+  pageLastModified: string;
   pageContent: string;
   fileLastModified: string | null;
   readSource: 'com' | 'binary';
@@ -127,6 +129,7 @@ export function getCachedPages(
       page_level,
       page_title,
       page_date,
+      page_last_modified,
       page_content,
       file_last_modified,
       read_source,
@@ -145,6 +148,7 @@ export function getCachedPages(
         page_level: number;
         page_title: string | null;
         page_date: string | null;
+        page_last_modified: string | null;
         page_content: string | null;
         file_last_modified: string | null;
         read_source: string;
@@ -155,6 +159,7 @@ export function getCachedPages(
         pageLevel: r.page_level ?? 1,
         pageTitle: r.page_title ?? '',
         pageDate: r.page_date ?? '',
+        pageLastModified: r.page_last_modified ?? '',
         pageContent: r.page_content ?? '',
         fileLastModified: r.file_last_modified,
         readSource: (r.read_source as 'com' | 'binary') ?? 'binary',
@@ -176,7 +181,7 @@ export function writeCacheForFile(
   db: SqlJsDatabase,
   folderId: number,
   relativePath: string,
-  pages: Array<{ pageIndex: number; pageLevel: number; title: string; date: string; content: string }>,
+  pages: Array<{ pageIndex: number; pageLevel: number; title: string; date: string; lastModified: string; content: string }>,
   lastModified: string | null,
   readSource: 'com' | 'binary',
 ): void {
@@ -192,9 +197,9 @@ export function writeCacheForFile(
       db.run(
         `INSERT INTO onedrive_onenote_cache
            (folder_id, relative_path, section_name, page_index, page_level,
-            page_title, page_date, page_content,
+            page_title, page_date, page_last_modified, page_content,
             file_last_modified, read_source, cached_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
         [
           folderId,
           relativePath,
@@ -203,6 +208,7 @@ export function writeCacheForFile(
           page.pageLevel,
           page.title,
           page.date,
+          page.lastModified || null,
           page.content,
           lastModified,
           readSource,

--- a/src/services/onedrive-onenote-cache.ts
+++ b/src/services/onedrive-onenote-cache.ts
@@ -229,6 +229,71 @@ export function deleteCacheForFolder(db: SqlJsDatabase, folderId: number): void 
   db.run('DELETE FROM onedrive_onenote_cache WHERE folder_id = ?', [folderId]);
 }
 
+export interface OneNoteGroupCachePage {
+  relativePath: string;
+  sectionName: string;
+  pageIndex: number;
+  pageLevel: number;
+  pageTitle: string;
+  pageLastModified: string;
+  pageDate: string;
+  readSource: 'com' | 'binary';
+  cachedAt: string;
+}
+
+/**
+ * Return all cached pages for every .one file belonging to a group,
+ * ordered by section file then page index. Used for the sanity-check UI.
+ */
+export function getOneNoteCacheForGroup(
+  db: SqlJsDatabase,
+  groupId: number,
+): OneNoteGroupCachePage[] {
+  const stmt = db.prepare(`
+    SELECT
+      c.relative_path,
+      COALESCE(c.section_name, '') AS section_name,
+      c.page_index,
+      c.page_level,
+      COALESCE(c.page_title, '')   AS page_title,
+      COALESCE(c.page_last_modified, '') AS page_last_modified,
+      COALESCE(c.page_date, '')    AS page_date,
+      c.read_source,
+      c.cached_at
+    FROM onedrive_onenote_cache c
+    JOIN onedrive_customer_folders cf ON cf.id = c.folder_id
+    WHERE cf.group_id = ?
+    ORDER BY c.relative_path, c.page_index
+  `);
+  stmt.bind([groupId]);
+
+  type Row = {
+    relative_path: string; section_name: string; page_index: number;
+    page_level: number; page_title: string; page_last_modified: string;
+    page_date: string; read_source: string; cached_at: string;
+  };
+  const pages: OneNoteGroupCachePage[] = [];
+  try {
+    while (stmt.step()) {
+      const r = stmt.getAsObject() as unknown as Row;
+      pages.push({
+        relativePath: r.relative_path,
+        sectionName: r.section_name,
+        pageIndex: r.page_index,
+        pageLevel: r.page_level,
+        pageTitle: r.page_title,
+        pageLastModified: r.page_last_modified,
+        pageDate: r.page_date,
+        readSource: r.read_source as 'com' | 'binary',
+        cachedAt: r.cached_at,
+      });
+    }
+  } finally {
+    stmt.free();
+  }
+  return pages;
+}
+
 // ── Main orchestration ────────────────────────────────────────────────────────
 
 /**

--- a/src/services/onedrive.ts
+++ b/src/services/onedrive.ts
@@ -41,6 +41,7 @@ export function removeOnedriveRoot(db: SqlJsDatabase, rootId: number): void {
   if (folders.length > 0 && folders[0].values.length > 0) {
     for (const row of folders[0].values) {
       const folderId = row[0] as number;
+      db.run('DELETE FROM onedrive_onenote_cache WHERE folder_id = ?', [folderId]);
       db.run('DELETE FROM onedrive_files WHERE folder_id = ?', [folderId]);
     }
   }

--- a/src/services/onenote-reader.ts
+++ b/src/services/onenote-reader.ts
@@ -16,12 +16,15 @@
 
 import fs from 'fs';
 import path from 'path';
+import { spawn } from 'child_process';
 
 // ── Public types ──────────────────────────────────────────────────────────────
 
 export interface OneNotePage {
   /** Index of this page within the section (1-based). */
   pageIndex: number;
+  /** Sub-page depth: 1 = top-level, 2 = sub-page, 3 = sub-sub-page. */
+  pageLevel: number;
   /** Best-effort page title extracted from the binary. May be empty. */
   title: string;
   /** Best-effort page date string, e.g. "Thursday, September 25, 2025". */
@@ -209,6 +212,7 @@ function buildPage(
 
   return {
     pageIndex,
+    pageLevel: 1,
     title,
     date,
     content: contentParts.join(' '),
@@ -241,7 +245,7 @@ export function readOneNoteSection(filePath: string): OneNoteSection {
     // No page structure detected — treat the whole file as one page
     const contentStrings = allStrings.filter(s => !isNoise(s.text));
     const content = contentStrings.map(s => s.text).join(' ');
-    pages = [{ pageIndex: 1, title: sectionName, date: '', content }];
+    pages = [{ pageIndex: 1, pageLevel: 1, title: sectionName, date: '', content }];
   } else {
     pages = pageSentinels.map((sentinelOffset, i) => {
       const nextSentinelOffset = pageSentinels[i + 1] ?? buf.length;
@@ -274,4 +278,130 @@ export function readOneNoteSection(filePath: string): OneNoteSection {
     pages,
     textContent,
   };
+}
+
+// ── COM-based reader (Windows, requires OneNote) ──────────────────────────────
+
+const COM_TIMEOUT_MS = 30_000;
+
+interface ComReaderPage {
+  pageIndex: number;
+  pageLevel: number;
+  title: string;
+  date: string;
+  content: string;
+}
+
+interface ComReaderResult {
+  ok: boolean;
+  pages?: ComReaderPage[];
+  error?: string;
+}
+
+/**
+ * Read a OneNote section file using the OneNote COM API via PowerShell.
+ * Returns a structured `OneNoteSection` with full-fidelity page content.
+ *
+ * Requires OneNote to be installed. Falls back gracefully to binary extraction
+ * (see `readOneNoteSection`) when COM is unavailable or fails.
+ *
+ * @param filePath   Absolute path to the `.one` section file.
+ * @param scriptPath Absolute path to `read-onenote-section.ps1`.
+ * @throws if the PowerShell process cannot be spawned or times out.
+ */
+export function readOneNoteSectionViaCom(
+  filePath: string,
+  scriptPath: string,
+): Promise<OneNoteSection> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '-NonInteractive',
+      '-NoProfile',
+      '-Sta',
+      '-ExecutionPolicy', 'Bypass',
+      '-File', scriptPath,
+      '-FilePath', filePath,
+    ];
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const proc = spawn('powershell.exe', args, { windowsHide: true });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+      reject(new Error(`OneNote COM reader timed out after ${COM_TIMEOUT_MS}ms`));
+    }, COM_TIMEOUT_MS);
+
+    proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+    proc.on('close', () => {
+      if (timedOut) return;
+      clearTimeout(timer);
+
+      let result: ComReaderResult;
+      try {
+        result = JSON.parse(stdout.trim()) as ComReaderResult;
+      } catch {
+        reject(new Error(`COM reader produced non-JSON output: ${stdout.slice(0, 200)}`));
+        return;
+      }
+
+      if (!result.ok || !result.pages) {
+        reject(new Error(result.error ?? 'COM reader returned ok=false with no error message'));
+        return;
+      }
+
+      const sectionName = path.basename(filePath, path.extname(filePath));
+      const pages: OneNotePage[] = result.pages.map(p => ({
+        pageIndex: p.pageIndex,
+        pageLevel: typeof p.pageLevel === 'number' ? p.pageLevel : 1,
+        title: p.title ?? '',
+        date: p.date ?? '',
+        content: p.content ?? '',
+      }));
+
+      const textContent = pages
+        .map(p => [p.title, p.date, p.content].filter(Boolean).join(' '))
+        .join('\n\n');
+
+      resolve({
+        sectionName,
+        filePath,
+        pageCount: pages.length,
+        pages,
+        textContent,
+      });
+    });
+
+    proc.on('error', (err: Error) => {
+      if (timedOut) return;
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Read a OneNote section file with the best available method.
+ * Tries OneNote COM first (full fidelity); falls back to binary extraction.
+ *
+ * @param filePath   Absolute path to the `.one` section file.
+ * @param scriptPath Absolute path to `read-onenote-section.ps1`.
+ */
+export async function readOneNoteSectionAsync(
+  filePath: string,
+  scriptPath: string,
+): Promise<OneNoteSection & { source: 'com' | 'binary' }> {
+  try {
+    const section = await readOneNoteSectionViaCom(filePath, scriptPath);
+    return { ...section, source: 'com' };
+  } catch {
+    // OneNote not installed, COM unavailable, or file not recognised — fall back
+    const section = readOneNoteSection(filePath);
+    return { ...section, source: 'binary' };
+  }
 }

--- a/src/services/onenote-reader.ts
+++ b/src/services/onenote-reader.ts
@@ -27,8 +27,14 @@ export interface OneNotePage {
   pageLevel: number;
   /** Best-effort page title extracted from the binary. May be empty. */
   title: string;
-  /** Best-effort page date string, e.g. "Thursday, September 25, 2025". */
+  /** Best-effort page creation date string, e.g. "Thursday, September 25, 2025". */
   date: string;
+  /**
+   * ISO 8601 last-modified timestamp from OneNote metadata, or a date derived
+   * from a YYYYMMDD prefix in the page title (binary fallback). Empty string
+   * when unavailable.
+   */
+  lastModified: string;
   /** All body text found in this page's region of the file, joined with spaces. */
   content: string;
 }
@@ -162,6 +168,20 @@ export function extractStrings(buf: Buffer): ExtractedString[] {
 
 // ── Page segmentation ─────────────────────────────────────────────────────────
 
+// ── YYYYMMDD date pattern in page titles ──────────────────────────────────────
+
+const YYYYMMDD_RE = /\b(\d{4})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])\b/;
+
+/**
+ * If the string contains a YYYYMMDD token, convert it to an ISO date string
+ * (e.g. "20260519 Meeting notes" → "2026-05-19"). Returns empty string otherwise.
+ */
+function extractIsoDateFromTitle(text: string): string {
+  const m = YYYYMMDD_RE.exec(text);
+  if (!m) return '';
+  return `${m[1]}-${m[2]}-${m[3]}`;
+}
+
 /**
  * Build a OneNotePage from the strings found between two byte offsets.
  * The first non-noise string after the PageTitle sentinel is used as the
@@ -215,6 +235,7 @@ function buildPage(
     pageLevel: 1,
     title,
     date,
+    lastModified: extractIsoDateFromTitle(title),
     content: contentParts.join(' '),
   };
 }
@@ -245,7 +266,7 @@ export function readOneNoteSection(filePath: string): OneNoteSection {
     // No page structure detected — treat the whole file as one page
     const contentStrings = allStrings.filter(s => !isNoise(s.text));
     const content = contentStrings.map(s => s.text).join(' ');
-    pages = [{ pageIndex: 1, pageLevel: 1, title: sectionName, date: '', content }];
+    pages = [{ pageIndex: 1, pageLevel: 1, title: sectionName, date: '', lastModified: '', content }];
   } else {
     pages = pageSentinels.map((sentinelOffset, i) => {
       const nextSentinelOffset = pageSentinels[i + 1] ?? buf.length;
@@ -289,6 +310,7 @@ interface ComReaderPage {
   pageLevel: number;
   title: string;
   date: string;
+  lastModified: string;
   content: string;
 }
 
@@ -361,6 +383,7 @@ export function readOneNoteSectionViaCom(
         pageLevel: typeof p.pageLevel === 'number' ? p.pageLevel : 1,
         title: p.title ?? '',
         date: p.date ?? '',
+        lastModified: p.lastModified ?? '',
         content: p.content ?? '',
       }));
 

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -87,7 +87,7 @@ function initializeSchema(database: SqlJsDatabase): void {
   if (userVersion === 0) {
     database.run(getSchema());
     seedBuiltInAgents(database);
-    database.run('PRAGMA user_version = 23');
+    database.run('PRAGMA user_version = 24');
   }
 
   if (userVersion === 1) {
@@ -478,6 +478,7 @@ function initializeSchema(database: SqlJsDatabase): void {
           page_level          INTEGER NOT NULL DEFAULT 1,
           page_title          TEXT,
           page_date           TEXT,
+          page_last_modified  TEXT,
           page_content        TEXT,
           file_last_modified  TEXT,
           read_source         TEXT NOT NULL DEFAULT 'binary',
@@ -490,6 +491,16 @@ function initializeSchema(database: SqlJsDatabase): void {
       ON onedrive_onenote_cache(folder_id, relative_path)
     `);
     database.run('PRAGMA user_version = 23');
+  }
+
+  if (userVersion === 23) {
+    // Migration v23 → v24: add page_last_modified column and index
+    database.run(`ALTER TABLE onedrive_onenote_cache ADD COLUMN page_last_modified TEXT`);
+    database.run(`
+      CREATE INDEX IF NOT EXISTS idx_onenote_cache_modified
+      ON onedrive_onenote_cache(page_last_modified)
+    `);
+    database.run('PRAGMA user_version = 24');
   }
 }
 

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -87,7 +87,7 @@ function initializeSchema(database: SqlJsDatabase): void {
   if (userVersion === 0) {
     database.run(getSchema());
     seedBuiltInAgents(database);
-    database.run('PRAGMA user_version = 22');
+    database.run('PRAGMA user_version = 23');
   }
 
   if (userVersion === 1) {
@@ -464,6 +464,32 @@ function initializeSchema(database: SqlJsDatabase): void {
     // next Ruddr sync by the COALESCE upsert in saveRuddrProjectsToDb.
     database.run(`ALTER TABLE ruddr_projects ADD COLUMN discovered_at DATETIME DEFAULT NULL`);
     database.run('PRAGMA user_version = 22');
+  }
+
+  if (userVersion === 22) {
+    // Migration v22 → v23: add OneNote page content cache table
+    database.run(`
+      CREATE TABLE IF NOT EXISTS onedrive_onenote_cache (
+          id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+          folder_id           INTEGER NOT NULL,
+          relative_path       TEXT NOT NULL,
+          section_name        TEXT,
+          page_index          INTEGER NOT NULL,
+          page_level          INTEGER NOT NULL DEFAULT 1,
+          page_title          TEXT,
+          page_date           TEXT,
+          page_content        TEXT,
+          file_last_modified  TEXT,
+          read_source         TEXT NOT NULL DEFAULT 'binary',
+          cached_at           DATETIME DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(folder_id, relative_path, page_index)
+      )
+    `);
+    database.run(`
+      CREATE INDEX IF NOT EXISTS idx_onenote_cache_lookup
+      ON onedrive_onenote_cache(folder_id, relative_path)
+    `);
+    database.run('PRAGMA user_version = 23');
   }
 }
 

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -331,6 +331,7 @@ export function getSchema(): string {
         page_level          INTEGER NOT NULL DEFAULT 1,
         page_title          TEXT,
         page_date           TEXT,
+        page_last_modified  TEXT,
         page_content        TEXT,
         file_last_modified  TEXT,
         read_source         TEXT NOT NULL DEFAULT 'binary',
@@ -338,5 +339,6 @@ export function getSchema(): string {
         UNIQUE(folder_id, relative_path, page_index)
     );
     CREATE INDEX IF NOT EXISTS idx_onenote_cache_lookup ON onedrive_onenote_cache(folder_id, relative_path);
+    CREATE INDEX IF NOT EXISTS idx_onenote_cache_modified ON onedrive_onenote_cache(page_last_modified);
   `;
 }

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -320,5 +320,23 @@ export function getSchema(): string {
         error           TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_browser_skill_runs_skill ON browser_skill_runs(skill_id);
+
+    -- Cached OneNote page content (keyed by folder + relative path; stable across file rescans)
+    CREATE TABLE IF NOT EXISTS onedrive_onenote_cache (
+        id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+        folder_id           INTEGER NOT NULL,
+        relative_path       TEXT NOT NULL,
+        section_name        TEXT,
+        page_index          INTEGER NOT NULL,
+        page_level          INTEGER NOT NULL DEFAULT 1,
+        page_title          TEXT,
+        page_date           TEXT,
+        page_content        TEXT,
+        file_last_modified  TEXT,
+        read_source         TEXT NOT NULL DEFAULT 'binary',
+        cached_at           DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(folder_id, relative_path, page_index)
+    );
+    CREATE INDEX IF NOT EXISTS idx_onenote_cache_lookup ON onedrive_onenote_cache(folder_id, relative_path);
   `;
 }

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
 import { getSchema } from '../../src/storage/schema';
 import { saveGitHubAuth } from '../../src/services/github-oauth';
-import { searchReposForChat, buildSystemContext } from '../../src/plugins/chat/db-helpers';
+import { searchReposForChat, buildSystemContext, searchOneNoteForChat } from '../../src/plugins/chat/db-helpers';
 
 // Helpers for seeding test data
 function insertOrg(db: SqlJsDatabase, login: string, enabled = true): number {
@@ -223,5 +223,137 @@ describe('buildSystemContext', () => {
     const ctx = buildSystemContext(db);
     expect(ctx).toContain('IMPORTANT');
     expect(ctx).toContain('Do NOT fabricate');
+  });
+
+  it('includes OneNote cache summary when pages exist', () => {
+    // Seed a group, folder, and cached page
+    db.run(`INSERT INTO groups (name) VALUES ('ACME')`);
+    const gid = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+    db.run(`INSERT INTO onedrive_roots (path, label) VALUES ('C:\\onedrive', 'Main')`);
+    const rid = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+    db.run(`INSERT INTO onedrive_customer_folders (group_id, root_id, status) VALUES (?, ?, 'found')`, [gid, rid]);
+    const fid = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
+       VALUES (?, 'Notes.one', 'Notes', 1, 1, 'Hello', 'World content', 'binary')`,
+      [fid],
+    );
+    const ctx = buildSystemContext(db);
+    expect(ctx).toContain('OneNote pages cached');
+    expect(ctx).toContain('search_onenote');
+  });
+
+  it('omits OneNote section when no pages cached', () => {
+    const ctx = buildSystemContext(db);
+    expect(ctx).not.toContain('OneNote pages cached');
+  });
+});
+
+// ── searchOneNoteForChat ──────────────────────────────────────────────────────
+describe('searchOneNoteForChat', () => {
+  let db: SqlJsDatabase;
+  let folderId: number;
+
+  beforeEach(async () => {
+    process.env.JARVIS_ENCRYPTION_KEY = 'test-key-for-chat-helpers';
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+
+    // group A with one folder and two section files
+    db.run(`INSERT INTO groups (name) VALUES ('Acme Corp')`);
+    const gid = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+    db.run(`INSERT INTO onedrive_roots (path, label) VALUES ('C:\\od', 'Root')`);
+    const rid = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+    db.run(`INSERT INTO onedrive_customer_folders (group_id, root_id, status) VALUES (?, ?, 'found')`, [gid, rid]);
+    folderId = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+
+    // group B
+    db.run(`INSERT INTO groups (name) VALUES ('Beta LLC')`);
+    const gid2 = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+    db.run(`INSERT INTO onedrive_customer_folders (group_id, root_id, status) VALUES (?, ?, 'found')`, [gid2, rid]);
+    const fid2 = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
+
+    // Seed pages
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
+       VALUES (?, 'General.one', 'General', 1, 1, 'Project kickoff', 'We decided to use TypeScript for all services.', 'binary')`,
+      [folderId],
+    );
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
+       VALUES (?, 'General.one', 'General', 2, 2, 'Sub-page note', 'Additional details on the architecture decision.', 'binary')`,
+      [folderId],
+    );
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
+       VALUES (?, 'Finance.one', 'Finance', 1, 1, 'Budget Q1', 'The total budget for Q1 is 50000 EUR.', 'binary')`,
+      [folderId],
+    );
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
+       VALUES (?, 'Beta.one', 'Beta', 1, 1, 'Beta planning', 'We plan to launch the beta in Q2.', 'binary')`,
+      [fid2],
+    );
+  });
+
+  afterEach(() => {
+    db.close();
+    delete process.env.JARVIS_ENCRYPTION_KEY;
+  });
+
+  it('finds pages matching a single term in content', () => {
+    const result = searchOneNoteForChat(db, 'TypeScript');
+    expect(result).toContain('Project kickoff');
+    expect(result).toContain('Acme Corp');
+  });
+
+  it('finds pages matching a term in page title', () => {
+    const result = searchOneNoteForChat(db, 'Budget');
+    expect(result).toContain('Budget Q1');
+    expect(result).toContain('Finance');
+  });
+
+  it('requires all words to match (AND logic)', () => {
+    const result = searchOneNoteForChat(db, 'budget Q1');
+    expect(result).toContain('Budget Q1');
+    expect(result).not.toContain('Project kickoff');
+  });
+
+  it('includes sub-page indentation indicator for page_level > 1', () => {
+    const result = searchOneNoteForChat(db, 'architecture');
+    expect(result).toContain('↳');
+  });
+
+  it('filters by group name when provided', () => {
+    const result = searchOneNoteForChat(db, 'Q2', 'Beta');
+    expect(result).toContain('Beta LLC');
+    expect(result).not.toContain('Acme Corp');
+  });
+
+  it('returns no-match message when nothing found', () => {
+    const result = searchOneNoteForChat(db, 'zzznomatch999');
+    expect(result).toContain('No OneNote pages found matching');
+    expect(result).toContain('zzznomatch999');
+  });
+
+  it('returns no-search-terms message for empty query', () => {
+    expect(searchOneNoteForChat(db, '')).toBe('No search terms provided.');
+    expect(searchOneNoteForChat(db, '   ')).toBe('No search terms provided.');
+  });
+
+  it('is case-insensitive', () => {
+    expect(searchOneNoteForChat(db, 'TYPESCRIPT')).toContain('Project kickoff');
+    expect(searchOneNoteForChat(db, 'typescript')).toContain('Project kickoff');
+  });
+
+  it('includes section name in output', () => {
+    const result = searchOneNoteForChat(db, 'TypeScript');
+    expect(result).toContain('General');
+  });
+
+  it('includes a content snippet', () => {
+    const result = searchOneNoteForChat(db, 'TypeScript');
+    expect(result).toContain('TypeScript');
   });
 });

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -234,8 +234,8 @@ describe('buildSystemContext', () => {
     db.run(`INSERT INTO onedrive_customer_folders (group_id, root_id, status) VALUES (?, ?, 'found')`, [gid, rid]);
     const fid = (db.exec('SELECT last_insert_rowid() AS id')[0].values[0][0]) as number;
     db.run(
-      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
-       VALUES (?, 'Notes.one', 'Notes', 1, 1, 'Hello', 'World content', 'binary')`,
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'Notes.one', 'Notes', 1, 1, 'Hello', 'World content', NULL, 'binary')`,
       [fid],
     );
     const ctx = buildSystemContext(db);
@@ -276,23 +276,23 @@ describe('searchOneNoteForChat', () => {
 
     // Seed pages
     db.run(
-      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
-       VALUES (?, 'General.one', 'General', 1, 1, 'Project kickoff', 'We decided to use TypeScript for all services.', 'binary')`,
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'General.one', 'General', 1, 1, 'Project kickoff', 'We decided to use TypeScript for all services.', '2026-05-01T09:00:00.000Z', 'binary')`,
       [folderId],
     );
     db.run(
-      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
-       VALUES (?, 'General.one', 'General', 2, 2, 'Sub-page note', 'Additional details on the architecture decision.', 'binary')`,
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'General.one', 'General', 2, 2, 'Sub-page note', 'Additional details on the architecture decision.', '2026-05-02T09:00:00.000Z', 'binary')`,
       [folderId],
     );
     db.run(
-      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
-       VALUES (?, 'Finance.one', 'Finance', 1, 1, 'Budget Q1', 'The total budget for Q1 is 50000 EUR.', 'binary')`,
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'Finance.one', 'Finance', 1, 1, 'Budget Q1', 'The total budget for Q1 is 50000 EUR.', '2026-04-15T09:00:00.000Z', 'binary')`,
       [folderId],
     );
     db.run(
-      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, read_source)
-       VALUES (?, 'Beta.one', 'Beta', 1, 1, 'Beta planning', 'We plan to launch the beta in Q2.', 'binary')`,
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'Beta.one', 'Beta', 1, 1, 'Beta planning', 'We plan to launch the beta in Q2.', '2026-05-20T09:00:00.000Z', 'binary')`,
       [fid2],
     );
   });
@@ -355,5 +355,27 @@ describe('searchOneNoteForChat', () => {
   it('includes a content snippet', () => {
     const result = searchOneNoteForChat(db, 'TypeScript');
     expect(result).toContain('TypeScript');
+  });
+
+  it('filters by since date — excludes older pages', () => {
+    // Budget Q1 was last modified 2026-04-15, kickoff 2026-05-01
+    const result = searchOneNoteForChat(db, 'budget', undefined, '2026-05-01');
+    expect(result).toContain('No OneNote pages found matching');
+  });
+
+  it('filters by since date — includes pages on or after the date', () => {
+    const result = searchOneNoteForChat(db, 'TypeScript', undefined, '2026-05-01');
+    expect(result).toContain('Project kickoff');
+  });
+
+  it('shows modified date in output', () => {
+    const result = searchOneNoteForChat(db, 'TypeScript');
+    expect(result).toContain('modified:');
+  });
+
+  it('includes today\'s date in buildSystemContext', () => {
+    const ctx = buildSystemContext(db);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(ctx).toContain(`Today's date: ${today}`);
   });
 });

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
 import { getSchema } from '../../src/storage/schema';
 import { saveGitHubAuth } from '../../src/services/github-oauth';
-import { searchReposForChat, buildSystemContext, searchOneNoteForChat } from '../../src/plugins/chat/db-helpers';
+import { searchReposForChat, buildSystemContext, searchOneNoteForChat, searchSecretsForChat } from '../../src/plugins/chat/db-helpers';
 
 // Helpers for seeding test data
 function insertOrg(db: SqlJsDatabase, login: string, enabled = true): number {
@@ -377,5 +377,175 @@ describe('searchOneNoteForChat', () => {
     const ctx = buildSystemContext(db);
     const today = new Date().toISOString().slice(0, 10);
     expect(ctx).toContain(`Today's date: ${today}`);
+  });
+
+  it('shows "no match" hint when groupName is provided but nothing found', () => {
+    // group filter + no results → hint includes group name
+    const result = searchOneNoteForChat(db, 'zzznomatch999', 'Acme Corp');
+    expect(result).toContain('in group "Acme Corp"');
+  });
+
+  it('shows date hint when since is provided but nothing found', () => {
+    const result = searchOneNoteForChat(db, 'zzznomatch999', undefined, '2099-01-01');
+    expect(result).toContain('since 2099-01-01');
+  });
+
+  it('handles pages with null section_name gracefully', () => {
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'Null.one', NULL, 3, 1, 'No section page', 'Content without section.', '2026-05-10T09:00:00.000Z', 'binary')`,
+      [folderId],
+    );
+    const result = searchOneNoteForChat(db, 'section');
+    expect(result).toContain('No section page');
+  });
+
+  it('handles pages with null page_last_modified in output', () => {
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'Notes.one', 'Notes', 4, 1, 'Undated page', 'Some undated content here.', NULL, 'binary')`,
+      [folderId],
+    );
+    const result = searchOneNoteForChat(db, 'undated');
+    // Should not crash, and should NOT include "[modified:" for this page
+    expect(result).toContain('Undated page');
+    expect(result).not.toContain('[modified: null]');
+  });
+
+  it('handles pages with null page_date in output', () => {
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'Notes.one', 'Notes', 5, 1, 'No date page', 'Content with no date at all.', '2026-05-11T09:00:00.000Z', 'binary')`,
+      [folderId],
+    );
+    const result = searchOneNoteForChat(db, 'no date');
+    expect(result).toContain('No date page');
+  });
+
+  it('shows ellipsis prefix when snippet does not start at beginning', () => {
+    // Create content long enough that the matching word is deep in the text
+    const padding = 'x '.repeat(200);
+    const content = `${padding}special-term-xyz found here`;
+    db.run(
+      `INSERT INTO onedrive_onenote_cache (folder_id, relative_path, section_name, page_index, page_level, page_title, page_content, page_last_modified, read_source)
+       VALUES (?, 'Long.one', 'Long', 6, 1, 'Long content page', ?, '2026-05-12T09:00:00.000Z', 'binary')`,
+      [folderId, content],
+    );
+    const result = searchOneNoteForChat(db, 'special-term-xyz');
+    expect(result).toContain('…');
+  });
+});
+
+// ── searchSecretsForChat ──────────────────────────────────────────────────────
+describe('searchSecretsForChat', () => {
+  let db: SqlJsDatabase;
+
+  function insertRepo(d: SqlJsDatabase, fullName: string): number {
+    const name = fullName.split('/').pop() ?? fullName;
+    d.run(
+      `INSERT INTO github_repos (full_name, name, language, description, archived, fork, starred, private, last_pushed_at)
+       VALUES (?, ?, NULL, NULL, 0, 0, 0, 0, datetime('now'))`,
+      [fullName, name],
+    );
+    const res = d.exec('SELECT last_insert_rowid() AS id');
+    return res[0].values[0][0] as number;
+  }
+
+  function insertSecret(d: SqlJsDatabase, repoId: number, secretName: string): void {
+    d.run(
+      `INSERT INTO repo_secrets (github_repo_id, secret_name) VALUES (?, ?)`,
+      [repoId, secretName],
+    );
+  }
+
+  beforeEach(async () => {
+    process.env.JARVIS_ENCRYPTION_KEY = 'test-key-for-chat-helpers';
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+  });
+
+  afterEach(() => {
+    db.close();
+    delete process.env.JARVIS_ENCRYPTION_KEY;
+  });
+
+  it('returns "No pattern provided" for empty query', () => {
+    expect(searchSecretsForChat(db, '')).toBe('No pattern provided.');
+    expect(searchSecretsForChat(db, '   ')).toBe('No pattern provided.');
+  });
+
+  it('returns "no secrets scanned" when table is empty', () => {
+    const result = searchSecretsForChat(db, 'TOKEN');
+    expect(result).toContain('No secrets have been scanned yet');
+  });
+
+  it('returns "no matching secrets" when table has secrets but none match', () => {
+    const repoId = insertRepo(db, 'org/repo-a');
+    insertSecret(db, repoId, 'NPM_TOKEN');
+    const result = searchSecretsForChat(db, 'GITHUB_SECRET');
+    expect(result).toContain('No secrets matching');
+    expect(result).toContain('1 scanned secret');
+  });
+
+  it('returns matching secrets grouped by repo', () => {
+    const repo1 = insertRepo(db, 'org/repo-a');
+    const repo2 = insertRepo(db, 'org/repo-b');
+    insertSecret(db, repo1, 'NPM_TOKEN');
+    insertSecret(db, repo1, 'DOCKER_TOKEN');
+    insertSecret(db, repo2, 'NPM_TOKEN');
+
+    const result = searchSecretsForChat(db, 'TOKEN');
+    expect(result).toContain('org/repo-a');
+    expect(result).toContain('org/repo-b');
+    expect(result).toContain('NPM_TOKEN');
+    expect(result).toContain('DOCKER_TOKEN');
+    expect(result).toContain('3 secret(s)');
+  });
+
+  it('is case-insensitive', () => {
+    const repoId = insertRepo(db, 'org/repo');
+    insertSecret(db, repoId, 'DEPLOY_KEY');
+    expect(searchSecretsForChat(db, 'deploy_key')).toContain('DEPLOY_KEY');
+    expect(searchSecretsForChat(db, 'DEPLOY_KEY')).toContain('DEPLOY_KEY');
+  });
+});
+
+// ── buildSystemContext with secrets ───────────────────────────────────────────
+describe('buildSystemContext — secrets section', () => {
+  let db: SqlJsDatabase;
+
+  function insertRepo(d: SqlJsDatabase, fullName: string): number {
+    const name = fullName.split('/').pop() ?? fullName;
+    d.run(
+      `INSERT INTO github_repos (full_name, name, language, description, archived, fork, starred, private, last_pushed_at)
+       VALUES (?, ?, NULL, NULL, 0, 0, 0, 0, datetime('now'))`,
+      [fullName, name],
+    );
+    const res = d.exec('SELECT last_insert_rowid() AS id');
+    return res[0].values[0][0] as number;
+  }
+
+  beforeEach(async () => {
+    process.env.JARVIS_ENCRYPTION_KEY = 'test-key-for-chat-helpers';
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+  });
+
+  afterEach(() => {
+    db.close();
+    delete process.env.JARVIS_ENCRYPTION_KEY;
+  });
+
+  it('includes secrets summary in context when secrets are scanned', () => {
+    const repoId = insertRepo(db, 'org/my-service');
+    db.run(`INSERT INTO repo_secrets (github_repo_id, secret_name) VALUES (?, ?)`, [repoId, 'NPM_TOKEN']);
+    db.run(`INSERT INTO repo_secrets (github_repo_id, secret_name) VALUES (?, ?)`, [repoId, 'DOCKER_TOKEN']);
+
+    const ctx = buildSystemContext(db);
+    expect(ctx).toContain('GitHub Actions secrets');
+    expect(ctx).toContain('org/my-service');
+    expect(ctx).toContain('NPM_TOKEN');
   });
 });

--- a/tests/unit/handler-validation.test.ts
+++ b/tests/unit/handler-validation.test.ts
@@ -44,6 +44,7 @@ vi.mock('electron', () => ({
   },
   shell: { openExternal: vi.fn(), openPath: vi.fn() },
   dialog: { showOpenDialog: vi.fn() },
+  app: { isPackaged: false },
   Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() })),
   BrowserWindow: {
     fromWebContents: vi.fn(),

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -21,6 +21,7 @@ vi.mock('electron', () => ({
   },
   shell: { openExternal: vi.fn(), openPath: vi.fn() },
   dialog: { showOpenDialog: vi.fn() },
+  app: { isPackaged: false },
   Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() })),
   BrowserWindow: {
     fromWebContents: vi.fn(),
@@ -156,6 +157,8 @@ const EXPECTED_CHANNELS = [
   'onedrive:list-files-for-folder',
   'onedrive:read-onenote-file',
   'onedrive:read-url-shortcut',
+  'onedrive:cache-onenote-files-for-group',
+  'onedrive:get-onenote-cache',
   'shell:open-url',
   // browser-companion plugin
   'browser:status',

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -159,6 +159,7 @@ const EXPECTED_CHANNELS = [
   'onedrive:read-url-shortcut',
   'onedrive:cache-onenote-files-for-group',
   'onedrive:get-onenote-cache',
+  'onedrive:get-onenote-cache-for-group',
   'shell:open-url',
   // browser-companion plugin
   'browser:status',

--- a/tests/unit/onedrive-onenote-cache.test.ts
+++ b/tests/unit/onedrive-onenote-cache.test.ts
@@ -10,6 +10,7 @@ import {
   writeCacheForFile,
   deleteCacheForFolder,
   cacheOneNoteFilesForGroup,
+  getOneNoteCacheForGroup,
 } from '../../src/services/onedrive-onenote-cache';
 
 // ── Mock onenote-reader async function ────────────────────────────────────────
@@ -275,5 +276,90 @@ describe('cacheOneNoteFilesForGroup()', () => {
     const result = await cacheOneNoteFilesForGroup(db, groupId, 'fake.ps1');
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].relativePath).toBe('Missing.one');
+  });
+
+  it('records an error when readOneNoteSectionAsync throws', async () => {
+    const { readOneNoteSectionAsync } = await import('../../src/services/onenote-reader');
+    const mockReader = readOneNoteSectionAsync as ReturnType<typeof vi.fn>;
+    mockReader.mockRejectedValueOnce(new Error('COM unavailable'));
+
+    // Need a file that actually exists — use a temp file
+    const os = await import('os');
+    const path = await import('path');
+    const fs = await import('fs');
+    const tmpDir = os.tmpdir();
+    const tmpFile = path.join(tmpDir, 'test-section.one');
+    fs.writeFileSync(tmpFile, Buffer.from('fake one file'));
+
+    const groupId = insertGroup(db, 'I');
+    const rootId = insertRoot(db, tmpDir);
+    const folderId = insertFolder(db, groupId, rootId, tmpDir);
+    insertFile(db, folderId, 'test-section.one', 'test-section.one', '2024-01-01T00:00:00.000Z');
+
+    const result = await cacheOneNoteFilesForGroup(db, groupId, 'fake.ps1');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].error).toContain('COM unavailable');
+
+    fs.unlinkSync(tmpFile);
+  });
+});
+
+describe('getOneNoteCacheForGroup()', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    setupDb(db);
+  });
+
+  it('returns empty array when no pages are cached for the group', () => {
+    const groupId = insertGroup(db, 'Empty');
+    expect(getOneNoteCacheForGroup(db, groupId)).toEqual([]);
+  });
+
+  it('returns all cached pages for a group ordered by section and page index', () => {
+    const groupId = insertGroup(db, 'Acme');
+    const rootId = insertRoot(db, 'C:\\OneDrive');
+    const folderId = insertFolder(db, groupId, rootId, 'C:\\OneDrive\\Acme');
+
+    writeCacheForFile(
+      db,
+      folderId,
+      'General.one',
+      [
+        { pageIndex: 1, pageLevel: 1, title: 'Kickoff', date: '2024-01-01', lastModified: '2024-01-01T09:00:00.000Z', content: 'Hello world' },
+        { pageIndex: 2, pageLevel: 2, title: 'Sub note', date: '2024-01-02', lastModified: '2024-01-02T09:00:00.000Z', content: 'Detail' },
+      ],
+      '2024-01-15T10:00:00.000Z',
+      'com',
+    );
+
+    const pages = getOneNoteCacheForGroup(db, groupId);
+    expect(pages).toHaveLength(2);
+    expect(pages[0].pageTitle).toBe('Kickoff');
+    expect(pages[0].pageLevel).toBe(1);
+    expect(pages[0].readSource).toBe('com');
+    expect(pages[0].sectionName).toBe('General');
+    expect(pages[1].pageTitle).toBe('Sub note');
+    expect(pages[1].pageLevel).toBe(2);
+    expect(pages[1].pageLastModified).toBe('2024-01-02T09:00:00.000Z');
+  });
+
+  it('does not return pages from a different group', () => {
+    const groupA = insertGroup(db, 'A');
+    const groupB = insertGroup(db, 'B');
+    const rootId = insertRoot(db, 'C:\\D');
+    const folderA = insertFolder(db, groupA, rootId, 'C:\\D\\A');
+    insertFolder(db, groupB, rootId, 'C:\\D\\B');
+
+    writeCacheForFile(
+      db, folderA, 'Notes.one',
+      [{ pageIndex: 1, pageLevel: 1, title: 'Only A', date: '', lastModified: '', content: '' }],
+      '2024-01-01T00:00:00.000Z', 'binary',
+    );
+
+    expect(getOneNoteCacheForGroup(db, groupB)).toHaveLength(0);
+    expect(getOneNoteCacheForGroup(db, groupA)).toHaveLength(1);
   });
 });

--- a/tests/unit/onedrive-onenote-cache.test.ts
+++ b/tests/unit/onedrive-onenote-cache.test.ts
@@ -23,8 +23,8 @@ vi.mock('../../src/services/onenote-reader', async (importOriginal) => {
       pageCount: 2,
       source: 'binary' as const,
       pages: [
-        { pageIndex: 1, pageLevel: 1, title: 'Page One', date: '2024-01-01', content: 'Hello world' },
-        { pageIndex: 2, pageLevel: 2, title: 'Page Two', date: '2024-01-02', content: 'Second page' },
+        { pageIndex: 1, pageLevel: 1, title: 'Page One', date: '2024-01-01', lastModified: '2024-01-01T10:00:00.000Z', content: 'Hello world' },
+        { pageIndex: 2, pageLevel: 2, title: 'Page Two', date: '2024-01-02', lastModified: '2024-01-02T10:00:00.000Z', content: 'Second page' },
       ],
       textContent: 'Page One 2024-01-01 Hello world\n\nPage Two 2024-01-02 Second page',
     }),
@@ -188,8 +188,8 @@ describe('writeCacheForFile() / getCachedPages()', () => {
       1,
       'Notes.one',
       [
-        { pageIndex: 2, pageLevel: 2, title: 'B', date: '', content: 'second' },
-        { pageIndex: 1, pageLevel: 1, title: 'A', date: '', content: 'first' },
+        { pageIndex: 2, pageLevel: 2, title: 'B', date: '', lastModified: '', content: 'second' },
+        { pageIndex: 1, pageLevel: 1, title: 'A', date: '', lastModified: '2024-01-01', content: 'first' },
       ],
       '2024-01-01T00:00:00.000Z',
       'binary',
@@ -200,14 +200,15 @@ describe('writeCacheForFile() / getCachedPages()', () => {
     expect(pages[0].pageIndex).toBe(1);
     expect(pages[0].pageLevel).toBe(1);
     expect(pages[0].pageTitle).toBe('A');
+    expect(pages[0].pageLastModified).toBe('2024-01-01');
     expect(pages[1].pageIndex).toBe(2);
     expect(pages[1].pageLevel).toBe(2);
     expect(pages[1].pageTitle).toBe('B');
   });
 
   it('replaces existing cache on re-write', () => {
-    writeCacheForFile(db, 1, 'Notes.one', [{ pageIndex: 1, pageLevel: 1, title: 'Old', date: '', content: 'old' }], '2024-01-01T00:00:00.000Z', 'binary');
-    writeCacheForFile(db, 1, 'Notes.one', [{ pageIndex: 1, pageLevel: 1, title: 'New', date: '', content: 'new' }], '2024-02-01T00:00:00.000Z', 'com');
+    writeCacheForFile(db, 1, 'Notes.one', [{ pageIndex: 1, pageLevel: 1, title: 'Old', date: '', lastModified: '', content: 'old' }], '2024-01-01T00:00:00.000Z', 'binary');
+    writeCacheForFile(db, 1, 'Notes.one', [{ pageIndex: 1, pageLevel: 1, title: 'New', date: '', lastModified: '', content: 'new' }], '2024-02-01T00:00:00.000Z', 'com');
 
     const pages = getCachedPages(db, 1, 'Notes.one');
     expect(pages).toHaveLength(1);
@@ -258,7 +259,7 @@ describe('cacheOneNoteFilesForGroup()', () => {
     const mtime = '2024-01-15T10:00:00.000Z';
     insertFile(db, folderId, 'N.one', 'N.one', mtime);
     // Pre-populate cache with matching mtime
-    writeCacheForFile(db, folderId, 'N.one', [{ pageIndex: 1, pageLevel: 1, title: 'T', date: '', content: 'C' }], mtime, 'binary');
+    writeCacheForFile(db, folderId, 'N.one', [{ pageIndex: 1, pageLevel: 1, title: 'T', date: '', lastModified: '', content: 'C' }], mtime, 'binary');
 
     const result = await cacheOneNoteFilesForGroup(db, groupId, 'fake.ps1');
     expect(result.filesSkipped).toBe(1);

--- a/tests/unit/onedrive-onenote-cache.test.ts
+++ b/tests/unit/onedrive-onenote-cache.test.ts
@@ -1,0 +1,278 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+// ── OneNote cache service tests ───────────────────────────────────────────────
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import { getSchema } from '../../src/storage/schema';
+import {
+  getOneNoteFilesForGroup,
+  isCacheValid,
+  getCachedPages,
+  writeCacheForFile,
+  deleteCacheForFolder,
+  cacheOneNoteFilesForGroup,
+} from '../../src/services/onedrive-onenote-cache';
+
+// ── Mock onenote-reader async function ────────────────────────────────────────
+vi.mock('../../src/services/onenote-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/onenote-reader')>();
+  return {
+    ...actual,
+    readOneNoteSectionAsync: vi.fn().mockResolvedValue({
+      sectionName: 'Test Section',
+      filePath: '/fake/Test Section.one',
+      pageCount: 2,
+      source: 'binary' as const,
+      pages: [
+        { pageIndex: 1, pageLevel: 1, title: 'Page One', date: '2024-01-01', content: 'Hello world' },
+        { pageIndex: 2, pageLevel: 2, title: 'Page Two', date: '2024-01-02', content: 'Second page' },
+      ],
+      textContent: 'Page One 2024-01-01 Hello world\n\nPage Two 2024-01-02 Second page',
+    }),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function setupDb(db: SqlJsDatabase): void {
+  db.run(getSchema());
+}
+
+function insertGroup(db: SqlJsDatabase, name: string): number {
+  db.run(
+    `INSERT INTO groups (name, created_at, updated_at) VALUES (?, datetime('now'), datetime('now'))`,
+    [name],
+  );
+  const stmt = db.prepare('SELECT last_insert_rowid() AS id');
+  stmt.step();
+  const { id } = stmt.getAsObject() as { id: number };
+  stmt.free();
+  return id as number;
+}
+
+function insertRoot(db: SqlJsDatabase, p: string): number {
+  db.run(`INSERT INTO onedrive_roots (path, label) VALUES (?, ?)`, [p, p]);
+  const stmt = db.prepare('SELECT last_insert_rowid() AS id');
+  stmt.step();
+  const { id } = stmt.getAsObject() as { id: number };
+  stmt.free();
+  return id as number;
+}
+
+function insertFolder(
+  db: SqlJsDatabase,
+  groupId: number,
+  rootId: number,
+  folderPath: string,
+): number {
+  db.run(
+    `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status)
+     VALUES (?, ?, ?, 'found')`,
+    [groupId, rootId, folderPath],
+  );
+  const stmt = db.prepare('SELECT last_insert_rowid() AS id');
+  stmt.step();
+  const { id } = stmt.getAsObject() as { id: number };
+  stmt.free();
+  return id as number;
+}
+
+function insertFile(
+  db: SqlJsDatabase,
+  folderId: number,
+  name: string,
+  relativePath: string,
+  lastModified: string,
+): void {
+  db.run(
+    `INSERT INTO onedrive_files (folder_id, name, extension, relative_path, last_modified, size_bytes)
+     VALUES (?, ?, '.one', ?, ?, 0)`,
+    [folderId, name, relativePath, lastModified],
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('getOneNoteFilesForGroup()', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    setupDb(db);
+  });
+
+  it('returns .one files for a group', () => {
+    const groupId = insertGroup(db, 'Acme');
+    const rootId = insertRoot(db, 'C:\\OneDrive');
+    const folderId = insertFolder(db, groupId, rootId, 'C:\\OneDrive\\Acme');
+    insertFile(db, folderId, 'Notes.one', 'Notes.one', '2024-01-15T10:00:00.000Z');
+    // Non-.one file should not appear
+    db.run(
+      `INSERT INTO onedrive_files (folder_id, name, extension, relative_path, last_modified, size_bytes)
+       VALUES (?, 'doc.docx', '.docx', 'doc.docx', '2024-01-01T00:00:00.000Z', 0)`,
+      [folderId],
+    );
+
+    const files = getOneNoteFilesForGroup(db, groupId);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe('Notes.one');
+    expect(files[0].folderId).toBe(folderId);
+    expect(files[0].lastModified).toBe('2024-01-15T10:00:00.000Z');
+  });
+
+  it('returns empty array when group has no .one files', () => {
+    const groupId = insertGroup(db, 'Empty');
+    expect(getOneNoteFilesForGroup(db, groupId)).toHaveLength(0);
+  });
+
+  it('excludes files from not_found folders', () => {
+    const groupId = insertGroup(db, 'Missing');
+    const rootId = insertRoot(db, 'C:\\OneDrive');
+    // Insert a folder with status 'not_found'
+    db.run(
+      `INSERT INTO onedrive_customer_folders (group_id, root_id, folder_path, status) VALUES (?, ?, NULL, 'not_found')`,
+      [groupId, rootId],
+    );
+    expect(getOneNoteFilesForGroup(db, groupId)).toHaveLength(0);
+  });
+});
+
+describe('isCacheValid()', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    setupDb(db);
+  });
+
+  it('returns false when no cache rows exist', () => {
+    expect(isCacheValid(db, 1, 'Notes.one', '2024-01-01T00:00:00.000Z')).toBe(false);
+  });
+
+  it('returns false when lastModified is null', () => {
+    expect(isCacheValid(db, 1, 'Notes.one', null)).toBe(false);
+  });
+
+  it('returns true when matching cache rows exist', () => {
+    db.run(
+      `INSERT INTO onedrive_onenote_cache
+         (folder_id, relative_path, page_index, page_title, page_date, page_content, file_last_modified, read_source)
+       VALUES (1, 'Notes.one', 1, 'A', '', 'content', '2024-01-01T00:00:00.000Z', 'binary')`,
+    );
+    expect(isCacheValid(db, 1, 'Notes.one', '2024-01-01T00:00:00.000Z')).toBe(true);
+  });
+
+  it('returns false when mtime does not match cached value', () => {
+    db.run(
+      `INSERT INTO onedrive_onenote_cache
+         (folder_id, relative_path, page_index, page_title, page_date, page_content, file_last_modified, read_source)
+       VALUES (1, 'Notes.one', 1, 'A', '', 'content', '2024-01-01T00:00:00.000Z', 'binary')`,
+    );
+    expect(isCacheValid(db, 1, 'Notes.one', '2025-01-01T00:00:00.000Z')).toBe(false);
+  });
+});
+
+describe('writeCacheForFile() / getCachedPages()', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    setupDb(db);
+  });
+
+  it('writes pages and returns them ordered by pageIndex', () => {
+    writeCacheForFile(
+      db,
+      1,
+      'Notes.one',
+      [
+        { pageIndex: 2, pageLevel: 2, title: 'B', date: '', content: 'second' },
+        { pageIndex: 1, pageLevel: 1, title: 'A', date: '', content: 'first' },
+      ],
+      '2024-01-01T00:00:00.000Z',
+      'binary',
+    );
+
+    const pages = getCachedPages(db, 1, 'Notes.one');
+    expect(pages).toHaveLength(2);
+    expect(pages[0].pageIndex).toBe(1);
+    expect(pages[0].pageLevel).toBe(1);
+    expect(pages[0].pageTitle).toBe('A');
+    expect(pages[1].pageIndex).toBe(2);
+    expect(pages[1].pageLevel).toBe(2);
+    expect(pages[1].pageTitle).toBe('B');
+  });
+
+  it('replaces existing cache on re-write', () => {
+    writeCacheForFile(db, 1, 'Notes.one', [{ pageIndex: 1, pageLevel: 1, title: 'Old', date: '', content: 'old' }], '2024-01-01T00:00:00.000Z', 'binary');
+    writeCacheForFile(db, 1, 'Notes.one', [{ pageIndex: 1, pageLevel: 1, title: 'New', date: '', content: 'new' }], '2024-02-01T00:00:00.000Z', 'com');
+
+    const pages = getCachedPages(db, 1, 'Notes.one');
+    expect(pages).toHaveLength(1);
+    expect(pages[0].pageTitle).toBe('New');
+    expect(pages[0].readSource).toBe('com');
+    expect(pages[0].fileLastModified).toBe('2024-02-01T00:00:00.000Z');
+  });
+
+  it('returns empty array when no cache exists', () => {
+    expect(getCachedPages(db, 99, 'nonexistent.one')).toEqual([]);
+  });
+});
+
+describe('deleteCacheForFolder()', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    setupDb(db);
+  });
+
+  it('deletes all cache rows for a folder', () => {
+    db.run(
+      `INSERT INTO onedrive_onenote_cache
+         (folder_id, relative_path, page_index, page_title, page_date, page_content, file_last_modified, read_source)
+       VALUES (5, 'a.one', 1, 'X', '', '', null, 'binary'), (5, 'b.one', 1, 'Y', '', '', null, 'binary')`,
+    );
+    deleteCacheForFolder(db, 5);
+    const rows = db.exec('SELECT COUNT(*) FROM onedrive_onenote_cache WHERE folder_id = 5');
+    expect(rows[0].values[0][0]).toBe(0);
+  });
+});
+
+describe('cacheOneNoteFilesForGroup()', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    setupDb(db);
+  });
+
+  it('skips files with valid cache', async () => {
+    const groupId = insertGroup(db, 'G');
+    const rootId = insertRoot(db, 'C:\\D');
+    const folderId = insertFolder(db, groupId, rootId, 'C:\\D\\G');
+    const mtime = '2024-01-15T10:00:00.000Z';
+    insertFile(db, folderId, 'N.one', 'N.one', mtime);
+    // Pre-populate cache with matching mtime
+    writeCacheForFile(db, folderId, 'N.one', [{ pageIndex: 1, pageLevel: 1, title: 'T', date: '', content: 'C' }], mtime, 'binary');
+
+    const result = await cacheOneNoteFilesForGroup(db, groupId, 'fake.ps1');
+    expect(result.filesSkipped).toBe(1);
+    expect(result.filesProcessed).toBe(0);
+  });
+
+  it('records an error for missing files', async () => {
+    const groupId = insertGroup(db, 'H');
+    const rootId = insertRoot(db, 'C:\\D');
+    const folderId = insertFolder(db, groupId, rootId, 'C:\\D\\H');
+    insertFile(db, folderId, 'Missing.one', 'Missing.one', '2024-01-01T00:00:00.000Z');
+
+    const result = await cacheOneNoteFilesForGroup(db, groupId, 'fake.ps1');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].relativePath).toBe('Missing.one');
+  });
+});


### PR DESCRIPTION
## Why

Jarvis discovered `.one` section files in OneDrive folders for customer groups, but had no way to read their content, make it searchable, or answer questions like "what did we discuss with Acme this week?". This PR adds the full pipeline: reading pages, caching them in the DB, surfacing them to the LLM, and a UI panel to sanity-check what was found.

## What changed

### OneNote reading (full fidelity)

- New PowerShell COM automation script (`scripts/read-onenote-section.ps1`) reads pages from a `.one` file via the `OneNote.Application` COM object - the only way to get 100% content fidelity on Windows.
- `readOneNoteSectionViaCom` / `readOneNoteSectionAsync` added to `onenote-reader.ts`; COM is tried first, binary extraction is the automatic fallback.
- Each page now carries `pageLevel` (1 = top-level, 2 = sub-page, 3 = sub-sub-page) and `lastModified`:
  - COM path: `lastModifiedTime` attribute from `<one:Page>` in the hierarchy XML.
  - Binary fallback: detects a `YYYYMMDD` prefix in the page title (a common manual convention) and converts it to an ISO date.

### DB cache (schema v22 -> v24)

New `onedrive_onenote_cache` table keyed on `(folder_id, relative_path)` - stable across file rescans because `onedrive_customer_folders` rows are not replaced on every scan. Columns include `section_name`, `page_index`, `page_level`, `page_title`, `page_date`, `page_last_modified`, `page_content`, `file_last_modified`, `read_source`, `cached_at`. Invalidation is timestamp-based: a file is only re-read when its `last_modified` changes.

Two migrations:
- v22->v23: creates the table.
- v23->v24: adds `page_last_modified` + index (additive `ALTER TABLE` for existing DBs).

### LLM `search_onenote` tool

Registered in `CHAT_TOOLS` with Ollama's native function-calling format. The tool:
- Searches `page_title` and `page_content` with all-words AND logic (case-insensitive).
- Accepts an optional `group` filter and an optional `since` date (`YYYY-MM-DD`).
- Returns up to 10 matching pages with group, section, sub-page indentation, title, date, and a content snippet.
- Results are ordered newest-modified-first when `since` is used.

`buildSystemContext` now injects today's date and a OneNote availability hint so the LLM knows how to compute "this week" and when to reach for the tool.

### Cache browser UI (`OneNoteCachePanel`)

A new panel opens to the right of `GroupsPanel` via a **📋** button (visible once a folder is in `found` status). It shows all cached pages for the group grouped by section file, with:
- Summary bar: page count, section count, pages-with-date ratio, COM vs binary split.
- Collapsible section blocks with sub-page indentation (`->` prefix).
- Green date when `page_last_modified` is known; amber "no date" badge when not (useful for spotting pages where binary extraction found no YYYYMMDD title prefix).
- COM / binary source badge per page.

## Non-obvious details

- **Cache key stability**: `onedrive_files` rows are deleted and reinserted on every rescan, making the file `id` unstable. The cache is keyed on `(folder_id, relative_path)` where `folder_id` is `onedrive_customer_folders.id` - those rows are upserted, not replaced.
- **sql.js FK cascades**: sql.js does not enforce `ON DELETE CASCADE` without `PRAGMA foreign_keys = ON`. All cascades (including clearing the onenote cache on root removal) are done manually in service code.
- **`@joplin/onenote-converter`** was present in devDependencies but requires a Rust/WASM build - it was evaluated and left untouched as it is not viable without significant build infrastructure.

## Tests

- 15 unit tests for the cache service (`onedrive-onenote-cache.test.ts`)
- 16 unit tests added to `chat-helpers.test.ts` (search tool: content/title/AND/group/since/date-display/case; `buildSystemContext`: OneNote hint, today's date)
- IPC registration test updated for the two new channels