### PR TITLE
feat: secure browser extension bridge

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -21,6 +21,11 @@ export interface JarvisConfig {
     dashboardSortMode?: 'attention' | 'local-activity' | 'remote-activity';
     dashboardNotifSort?: 'count' | 'name';
   };
+  /** Localhost bridge security settings (browser extension pairing). */
+  bridge?: {
+    /** Shared secret token required by the browser extension to authenticate. */
+    token?: string;
+  };
 }
 
 const DEFAULT_CONFIG: JarvisConfig = {

--- a/src/browser-extension/background.js
+++ b/src/browser-extension/background.js
@@ -30,12 +30,35 @@ let ws = null;
 let reconnectDelay = RECONNECT_DELAY_MS;
 let reconnectTimer = null;
 let keepAliveTimer = null;
-let isConnected = false;
+let isConnected = false;   // true only after auth-ok received
+let isAuthenticated = false;
+
+// ── Token storage ─────────────────────────────────────────────────────────────
+
+async function getStoredToken() {
+  try {
+    const result = await chrome.storage.local.get('jarvisToken');
+    return typeof result.jarvisToken === 'string' ? result.jarvisToken : null;
+  } catch {
+    return null;
+  }
+}
+
+async function setStoredToken(token) {
+  await chrome.storage.local.set({ jarvisToken: token });
+}
 
 // ── Connection management ─────────────────────────────────────────────────────
 
-function connect() {
+async function connect() {
   if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+    return;
+  }
+
+  const token = await getStoredToken();
+  if (!token) {
+    console.log('[JarvisBridge] No pairing token configured — not connecting. Open the extension popup to set the token.');
+    notifyPopup({ type: 'status', connected: false, needsToken: true });
     return;
   }
 
@@ -50,28 +73,37 @@ function connect() {
 
   ws.addEventListener('open', () => {
     try {
-      console.log('[JarvisBridge] Connected to Jarvis desktop app');
-      isConnected = true;
-      reconnectDelay = RECONNECT_DELAY_MS; // reset backoff
-      updateBadge(true);
-      startKeepAlive();
-      notifyPopup({ type: 'status', connected: true });
+      console.log('[JarvisBridge] Socket open — sending auth');
+      isAuthenticated = false;
+      // Send auth token immediately; wait for auth-ok before marking connected
+      ws.send(JSON.stringify({ type: 'auth', token }));
     } catch (e) {
       console.error('[JarvisBridge] Error in open handler:', e);
     }
   });
 
   ws.addEventListener('message', (event) => {
+    if (!isAuthenticated) {
+      handleAuthResponse(event.data);
+      return;
+    }
     handleCommand(event.data);
   });
 
   ws.addEventListener('close', (event) => {
     console.log('[JarvisBridge] Disconnected', event.code, event.reason);
     isConnected = false;
+    isAuthenticated = false;
     updateBadge(false);
     stopKeepAlive();
     notifyPopup({ type: 'status', connected: false });
-    scheduleReconnect();
+    // Don't reconnect if the server rejected our token
+    if (event.code === 1008 && event.reason && event.reason.includes('token')) {
+      console.warn('[JarvisBridge] Token rejected by server. Open the extension popup to update the token.');
+      notifyPopup({ type: 'status', connected: false, invalidToken: true });
+    } else {
+      scheduleReconnect();
+    }
   });
 
   ws.addEventListener('error', (event) => {
@@ -79,11 +111,30 @@ function connect() {
   });
 }
 
+function handleAuthResponse(rawData) {
+  let msg;
+  try { msg = JSON.parse(rawData); } catch { return; }
+
+  if (msg.type === 'auth-ok') {
+    isAuthenticated = true;
+    isConnected = true;
+    reconnectDelay = RECONNECT_DELAY_MS; // reset backoff
+    updateBadge(true);
+    startKeepAlive();
+    notifyPopup({ type: 'status', connected: true });
+    console.log('[JarvisBridge] Authenticated — ready');
+  } else if (msg.type === 'auth-fail') {
+    console.warn('[JarvisBridge] Authentication failed:', msg.reason);
+    notifyPopup({ type: 'status', connected: false, invalidToken: msg.reason === 'invalid-token' });
+    // The server will close the socket; let the close handler take over
+  }
+}
+
 function scheduleReconnect() {
   if (reconnectTimer) return;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
-    connect();
+    void connect();
   }, reconnectDelay);
   // Exponential backoff, capped
   reconnectDelay = Math.min(reconnectDelay * 1.5, MAX_RECONNECT_DELAY_MS);
@@ -206,6 +257,16 @@ async function getTargetTabId(preferredTabId) {
 async function cmdNavigate(tabId, payload) {
   const { url } = payload;
   if (!url) throw new Error('url is required');
+
+  // Defense-in-depth: validate URL scheme (server also validates, but this is a local guard)
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`URL scheme "${parsed.protocol}" is not allowed`);
+    }
+  } catch (e) {
+    throw new Error(`Invalid or disallowed URL: ${e.message}`);
+  }
 
   const targetTabId = await getTargetTabId(tabId);
 
@@ -823,26 +884,43 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     sendResponse({ connected: isConnected });
     return true;
   }
+  if (msg.type === 'reconnect') {
+    // Popup saved a new token — close existing socket and reconnect immediately
+    if (ws) {
+      ws.close(1000, 'Manual reconnect');
+      ws = null;
+    }
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    reconnectDelay = RECONNECT_DELAY_MS; // reset backoff
+    isConnected = false;
+    isAuthenticated = false;
+    void connect();
+    sendResponse({ ok: true });
+    return true;
+  }
 });
 
 // ── Boot ──────────────────────────────────────────────────────────────────────
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log('[JarvisBridge] Extension installed/updated');
-  connect();
+  void connect();
 });
 
 chrome.runtime.onStartup.addListener(() => {
-  connect();
+  void connect();
 });
 
 // Connect immediately when service worker starts
-connect();
+void connect();
 
 // Re-connect if the service worker wakes up and isn't connected
 chrome.alarms.create('keepalive', { periodInMinutes: 0.4 });
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === 'keepalive' && !isConnected) {
-    connect();
+    void connect();
   }
 });

--- a/src/browser-extension/popup.html
+++ b/src/browser-extension/popup.html
@@ -7,7 +7,7 @@
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      width: 300px;
+      width: 320px;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       font-size: 13px;
       background: #1a1a1a;
@@ -45,6 +45,11 @@
       border: 1px solid #795548;
       color: #ffb74d;
     }
+    .status-badge.invalid-token {
+      background: #2a0a0a;
+      border: 1px solid #c62828;
+      color: #ef9a9a;
+    }
     .dot {
       width: 8px;
       height: 8px;
@@ -53,17 +58,59 @@
     }
     .connected .dot { background: #4caf50; }
     .disconnected .dot { background: #ff9800; }
-    .help {
+    .invalid-token .dot { background: #f44336; }
+    .token-section {
       margin-top: 10px;
+      background: #222;
+      border: 1px solid #444;
+      border-radius: 6px;
+      padding: 10px;
+    }
+    .token-section label {
+      display: block;
       font-size: 11px;
-      color: #888;
-      line-height: 1.5;
+      font-weight: 600;
+      color: #aaa;
+      margin-bottom: 5px;
     }
-    .help a {
-      color: #6a8caf;
-      text-decoration: none;
+    .token-row {
+      display: flex;
+      gap: 6px;
     }
-    .help a:hover { text-decoration: underline; }
+    .token-row input {
+      flex: 1;
+      background: #111;
+      border: 1px solid #555;
+      border-radius: 4px;
+      color: #ccc;
+      font-size: 12px;
+      font-family: monospace;
+      padding: 4px 6px;
+      min-width: 0;
+    }
+    .token-row input:focus { outline: none; border-color: #6a8caf; }
+    .btn-save {
+      background: #1565c0;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-size: 11px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .btn-save:hover { background: #1976d2; }
+    .token-hint {
+      font-size: 10px;
+      color: #666;
+      margin-top: 5px;
+    }
+    .saved-msg {
+      font-size: 11px;
+      color: #81c784;
+      margin-top: 4px;
+      display: none;
+    }
     .version {
       margin-top: 10px;
       font-size: 10px;
@@ -83,9 +130,14 @@
     <span id="status-text">Connecting…</span>
   </div>
 
-  <div class="help" id="help-text" style="display:none">
-    Make sure the Jarvis desktop app is running. The bridge listens on
-    <code>ws://127.0.0.1:35789</code>.
+  <div class="token-section">
+    <label for="token-input">🔑 Pairing Token</label>
+    <div class="token-row">
+      <input id="token-input" type="text" placeholder="Paste token from Jarvis app" autocomplete="off" spellcheck="false" />
+      <button id="btn-save" class="btn-save">Save</button>
+    </div>
+    <div class="token-hint">Copy the token from the Browser Companion panel in the Jarvis app.</div>
+    <div class="saved-msg" id="saved-msg">✓ Token saved — reconnecting…</div>
   </div>
 
   <div class="version">v1.0.0</div>

--- a/src/browser-extension/popup.js
+++ b/src/browser-extension/popup.js
@@ -1,36 +1,60 @@
 /**
  * Jarvis Browser Companion — Popup Script
- * Updates the popup UI based on connection status from the background worker.
+ * Updates the popup UI based on connection/auth status from the background worker.
  */
 
 const statusEl = document.getElementById('status');
 const statusTextEl = document.getElementById('status-text');
-const helpEl = document.getElementById('help-text');
+const tokenInput = document.getElementById('token-input');
+const btnSave = document.getElementById('btn-save');
+const savedMsg = document.getElementById('saved-msg');
 
-function setConnected(connected) {
+function setStatus(connected, invalidToken, needsToken) {
   if (connected) {
     statusEl.className = 'status-badge connected';
     statusTextEl.textContent = 'Connected to Jarvis';
-    if (helpEl) helpEl.style.display = 'none';
+  } else if (invalidToken) {
+    statusEl.className = 'status-badge invalid-token';
+    statusTextEl.textContent = 'Invalid token — update below';
+  } else if (needsToken) {
+    statusEl.className = 'status-badge disconnected';
+    statusTextEl.textContent = 'Token required — paste below';
   } else {
     statusEl.className = 'status-badge disconnected';
     statusTextEl.textContent = 'Not connected — is Jarvis running?';
-    if (helpEl) helpEl.style.display = 'block';
   }
 }
+
+// Load stored token into the input field
+chrome.storage.local.get('jarvisToken').then((result) => {
+  if (typeof result.jarvisToken === 'string' && result.jarvisToken) {
+    tokenInput.value = result.jarvisToken;
+  }
+});
+
+// Save token and trigger reconnect
+btnSave.addEventListener('click', async () => {
+  const token = tokenInput.value.trim();
+  if (!token) return;
+  await chrome.storage.local.set({ jarvisToken: token });
+  savedMsg.style.display = 'block';
+  setTimeout(() => { savedMsg.style.display = 'none'; }, 3000);
+  // Tell the background service worker to reconnect with the new token
+  chrome.runtime.sendMessage({ type: 'reconnect' }).catch(() => { /* SW may be sleeping */ });
+});
 
 // Listen for status messages from the background worker
 chrome.runtime.onMessage.addListener((msg) => {
   if (msg.type === 'status') {
-    setConnected(msg.connected);
+    setStatus(msg.connected, msg.invalidToken, msg.needsToken);
   }
 });
 
 // Ask the background worker for current status
 chrome.runtime.sendMessage({ type: 'get-status' }).then((response) => {
   if (response && typeof response.connected === 'boolean') {
-    setConnected(response.connected);
+    setStatus(response.connected, false, false);
   }
 }).catch(() => {
-  setConnected(false);
+  setStatus(false, false, false);
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -251,6 +251,8 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('shell:open-url', url),
   // Browser Companion
   browserStatus: () => ipcRenderer.invoke('browser:status'),
+  browserGetToken: () => ipcRenderer.invoke('browser:get-token'),
+  browserRegenerateToken: () => ipcRenderer.invoke('browser:regenerate-token'),
   browserListSkills: () => ipcRenderer.invoke('browser:list-skills'),
   browserCreateSkill: (name: string, description: string, startUrl: string, instructions: string, extractSelector: string) =>
     ipcRenderer.invoke('browser:create-skill', name, description, startUrl, instructions, extractSelector),

--- a/src/plugins/browser-companion/BrowserCompanionPanel.tsx
+++ b/src/plugins/browser-companion/BrowserCompanionPanel.tsx
@@ -185,6 +185,9 @@ export function BrowserCompanionPanel({ onBack }: { onBack: () => void }) {
   const [runningSkillId, setRunningSkillId] = useState<number | null>(null);
   const [lastResult, setLastResult] = useState<{ skillId: number; ok: boolean; data?: unknown; error?: string; testMode: boolean } | null>(null);
   const [selectedSkillId, setSelectedSkillId] = useState<number | null>(null);
+  const [pairingToken, setPairingToken] = useState<string | null>(null);
+  const [tokenCopied, setTokenCopied] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
 
   const loadStatus = useCallback(async () => {
     try {
@@ -192,6 +195,15 @@ export function BrowserCompanionPanel({ onBack }: { onBack: () => void }) {
       setStatus(s);
     } catch (e) {
       console.warn('[BrowserCompanion] status error:', e);
+    }
+  }, []);
+
+  const loadToken = useCallback(async () => {
+    try {
+      const result = await window.jarvis.browserGetToken();
+      setPairingToken(result.token);
+    } catch (e) {
+      console.warn('[BrowserCompanion] get-token error:', e);
     }
   }, []);
 
@@ -217,11 +229,12 @@ export function BrowserCompanionPanel({ onBack }: { onBack: () => void }) {
     void loadStatus();
     void loadSkills();
     void loadRuns();
+    void loadToken();
 
     // Poll connection status every 3 seconds
     const timer = setInterval(() => void loadStatus(), 3000);
     return () => clearInterval(timer);
-  }, [loadStatus, loadSkills, loadRuns]);
+  }, [loadStatus, loadSkills, loadRuns, loadToken]);
 
   // Listen for extension connection events
   useEffect(() => {
@@ -283,6 +296,27 @@ export function BrowserCompanionPanel({ onBack }: { onBack: () => void }) {
       console.warn('[BrowserCompanion] focus-window error:', e);
     } finally {
       setFocusing(false);
+    }
+  };
+
+  const handleCopyToken = async () => {
+    if (!pairingToken) return;
+    await navigator.clipboard.writeText(pairingToken);
+    setTokenCopied(true);
+    setTimeout(() => setTokenCopied(false), 2000);
+  };
+
+  const handleRegenerateToken = async () => {
+    if (!confirm('Regenerate the pairing token? The extension will disconnect and you will need to paste the new token into the extension popup.')) return;
+    setRegenerating(true);
+    try {
+      const result = await window.jarvis.browserRegenerateToken();
+      setPairingToken(result.token);
+      await loadStatus();
+    } catch (e) {
+      console.warn('[BrowserCompanion] regenerate-token error:', e);
+    } finally {
+      setRegenerating(false);
     }
   };
 
@@ -354,10 +388,54 @@ export function BrowserCompanionPanel({ onBack }: { onBack: () => void }) {
             <li>Open Edge/Chrome and navigate to <code>edge://extensions</code> or <code>chrome://extensions</code></li>
             <li>Enable <strong>Developer mode</strong></li>
             <li>Click <strong>Load unpacked</strong> and select the <code>src/browser-extension</code> folder from the Jarvis source directory</li>
-            <li>The extension icon should appear in your toolbar — click it to confirm connection</li>
+            <li>Click the extension icon in your toolbar and paste the pairing token below</li>
           </ol>
         </div>
       )}
+
+      {/* Pairing token section */}
+      <div style={{ background: '#1e1e1e', border: '1px solid #444', borderRadius: 6, padding: '10px 12px' }}>
+        <div style={{ fontWeight: 600, fontSize: 12, color: '#ccc', marginBottom: 6 }}>
+          🔑 Pairing Token
+        </div>
+        <div style={{ fontSize: 11, color: '#888', marginBottom: 8 }}>
+          Paste this token into the extension popup to authorise it. Keep it private — it grants the extension access to browser automation.
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <code style={{
+            flex: 1, background: '#111', border: '1px solid #555', borderRadius: 4,
+            padding: '4px 8px', fontSize: 12, color: '#6cf', userSelect: 'all',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>
+            {pairingToken ?? '…'}
+          </code>
+          <button
+            onClick={() => void handleCopyToken()}
+            disabled={!pairingToken}
+            title="Copy token to clipboard"
+            style={{
+              padding: '4px 10px', borderRadius: 4, border: 'none',
+              background: tokenCopied ? '#1b5e20' : '#333', color: tokenCopied ? '#a5d6a7' : '#ccc',
+              cursor: !pairingToken ? 'not-allowed' : 'pointer', fontSize: 11, whiteSpace: 'nowrap',
+            }}
+          >
+            {tokenCopied ? '✓ Copied' : '📋 Copy'}
+          </button>
+          <button
+            onClick={() => void handleRegenerateToken()}
+            disabled={regenerating}
+            title="Generate a new token (disconnects current extension)"
+            style={{
+              padding: '4px 10px', borderRadius: 4, border: 'none',
+              background: '#2a1a0a', color: '#ffb74d',
+              cursor: regenerating ? 'not-allowed' : 'pointer', fontSize: 11, whiteSpace: 'nowrap',
+              opacity: regenerating ? 0.6 : 1,
+            }}
+          >
+            {regenerating ? '⏳' : '🔄'} Regenerate
+          </button>
+        </div>
+      </div>
 
       {/* Skills section */}
       <div>

--- a/src/plugins/browser-companion/handler.ts
+++ b/src/plugins/browser-companion/handler.ts
@@ -6,6 +6,8 @@ import { saveDatabase } from '../../storage/database';
 import {
   startBridgeServer,
   getBridgeStatus,
+  getBridgeToken,
+  regenerateBridgeToken,
   sendCommand,
 } from './server';
 
@@ -20,6 +22,17 @@ export function registerHandlers(
 
   ipcMain.handle('browser:status', () => {
     return getBridgeStatus();
+  });
+
+  // ── Token management ──────────────────────────────────────────────────────
+
+  ipcMain.handle('browser:get-token', () => {
+    return { token: getBridgeToken() };
+  });
+
+  ipcMain.handle('browser:regenerate-token', () => {
+    const token = regenerateBridgeToken();
+    return { token };
   });
 
   // ── Skill CRUD ────────────────────────────────────────────────────────────

--- a/src/plugins/browser-companion/server.ts
+++ b/src/plugins/browser-companion/server.ts
@@ -2,7 +2,9 @@
 // Runs in the Electron main process. The matching browser extension connects
 // here via WebSocket and acts as an RPC relay into the user's live browser.
 import { WebSocketServer, WebSocket } from 'ws';
+import { randomBytes } from 'crypto';
 import type { BrowserWindow } from 'electron';
+import { loadConfig, saveConfig } from '../../agent/config';
 
 export const BRIDGE_PORT = 35789;
 export const BRIDGE_ORIGIN = `ws://localhost:${BRIDGE_PORT}`;
@@ -40,10 +42,28 @@ export interface BridgeEvent {
   data?: unknown;
 }
 
+// ── Security constants ────────────────────────────────────────────────────────
+
+const AUTH_TIMEOUT_MS = 5_000;
+const RATE_LIMIT_WINDOW_MS = 10_000;
+const RATE_LIMIT_MAX_COMMANDS = 30;
+const ALLOWED_URL_SCHEMES = new Set(['http:', 'https:']);
+
 // ── Server state ──────────────────────────────────────────────────────────────
 
 let wss: WebSocketServer | null = null;
+
+/** All connected sockets (authenticated or pending). Used for cleanup only. */
 const connectedClients = new Set<WebSocket>();
+
+/** The single authenticated extension socket, or null. */
+let authenticatedClient: WebSocket | null = null;
+
+/** Auth handshake timeouts: socket → timer handle. */
+const authTimeouts = new Map<WebSocket, ReturnType<typeof setTimeout>>();
+
+/** Rate-limit state per socket. */
+const rateLimitMap = new Map<WebSocket, { count: number; windowStart: number }>();
 
 // Pending RPC calls: id → { resolve, reject, timer }
 const pending = new Map<
@@ -53,10 +73,92 @@ const pending = new Map<
 
 let getWindowFn: (() => BrowserWindow | null) | null = null;
 
+// ── Token management ──────────────────────────────────────────────────────────
+
+/**
+ * Returns the current bridge token, generating and persisting one if none exists.
+ * The token is stored in config.json (plaintext) and is a localhost pairing secret,
+ * not a hardened credential.
+ */
+export function getBridgeToken(): string {
+  const config = loadConfig();
+  if (config.bridge?.token) return config.bridge.token;
+  const token = randomBytes(16).toString('hex');
+  saveConfig({ ...config, bridge: { ...config.bridge, token } });
+  return token;
+}
+
+/**
+ * Generates a fresh token, saves it, and closes the currently authenticated
+ * extension so it must re-pair with the new token.
+ */
+export function regenerateBridgeToken(): string {
+  const config = loadConfig();
+  const token = randomBytes(16).toString('hex');
+  saveConfig({ ...config, bridge: { token } });
+  // Drop the authenticated client — it will need to re-pair
+  if (authenticatedClient) {
+    authenticatedClient.close(1008, 'Token rotated');
+    authenticatedClient = null;
+  }
+  rejectAllPending(new Error('Bridge token rotated'));
+  getWindowFn?.()?.webContents.send('browser:extension-connected', { count: 0 });
+  return token;
+}
+
+// ── URL validation ────────────────────────────────────────────────────────────
+
+/**
+ * Validates that a URL is safe to navigate to.
+ * Only http: and https: schemes are allowed.
+ * Throws a descriptive error for blocked URLs.
+ */
+export function validateNavigateUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: "${url}"`);
+  }
+  if (!ALLOWED_URL_SCHEMES.has(parsed.protocol)) {
+    throw new Error(
+      `URL scheme "${parsed.protocol}" is not allowed. Only http: and https: are permitted.`,
+    );
+  }
+}
+
+// ── Rate limiting ─────────────────────────────────────────────────────────────
+
+function checkRateLimit(ws: WebSocket): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ws) ?? { count: 0, windowStart: now };
+  if (now - entry.windowStart > RATE_LIMIT_WINDOW_MS) {
+    entry.count = 1;
+    entry.windowStart = now;
+  } else {
+    entry.count++;
+  }
+  rateLimitMap.set(ws, entry);
+  return entry.count <= RATE_LIMIT_MAX_COMMANDS;
+}
+
+// ── Helper: reject all pending calls ─────────────────────────────────────────
+
+function rejectAllPending(err: Error): void {
+  for (const [id, entry] of pending) {
+    clearTimeout(entry.timer);
+    entry.reject(err);
+    pending.delete(id);
+  }
+}
+
 // ── Start / stop ──────────────────────────────────────────────────────────────
 
 export function startBridgeServer(getWindow: () => BrowserWindow | null): void {
   if (wss) return; // already running
+
+  // Ensure a token exists (generates one on first run)
+  getBridgeToken();
 
   getWindowFn = getWindow;
 
@@ -77,10 +179,38 @@ export function startBridgeServer(getWindow: () => BrowserWindow | null): void {
     }
 
     connectedClients.add(ws);
-    console.log('[BrowserBridge] Extension connected. Total clients:', connectedClients.size);
-    getWindowFn?.()?.webContents.send('browser:extension-connected', { count: connectedClients.size });
+    console.log('[BrowserBridge] Client connecting (pending auth). Total sockets:', connectedClients.size);
+
+    // Start auth timeout — client must authenticate within AUTH_TIMEOUT_MS
+    const authTimer = setTimeout(() => {
+      if (authTimeouts.has(ws)) {
+        console.warn('[BrowserBridge] Auth timeout — closing unauthenticated socket');
+        authTimeouts.delete(ws);
+        ws.close(1008, 'Authentication timeout');
+      }
+    }, AUTH_TIMEOUT_MS);
+    authTimeouts.set(ws, authTimer);
 
     ws.on('message', (raw) => {
+      // If socket is not yet authenticated, only allow auth messages
+      if (ws !== authenticatedClient) {
+        handleAuthMessage(ws, raw.toString());
+        return;
+      }
+
+      // Rate-limit authenticated commands
+      if (!checkRateLimit(ws)) {
+        console.warn('[BrowserBridge] Rate limit exceeded');
+        // Send error response if the message has an id
+        try {
+          const msg = JSON.parse(raw.toString()) as { id?: string };
+          if (msg.id) {
+            ws.send(JSON.stringify({ id: msg.id, ok: false, error: 'Rate limit exceeded' }));
+          }
+        } catch { /* ignore */ }
+        return;
+      }
+
       try {
         const msg = JSON.parse(raw.toString()) as BridgeResponse | BridgeEvent;
         if ('id' in msg) {
@@ -102,18 +232,21 @@ export function startBridgeServer(getWindow: () => BrowserWindow | null): void {
     });
 
     ws.on('close', () => {
-      connectedClients.delete(ws);
-      // Reject any pending calls that were in-flight on this socket
-      // (we can't tell which socket a pending call was sent to, so reject all if no more clients)
-      if (connectedClients.size === 0) {
-        for (const [id, entry] of pending) {
-          clearTimeout(entry.timer);
-          entry.reject(new Error('Extension disconnected'));
-          pending.delete(id);
-        }
+      // Clean up auth timeout if still pending
+      const authTimer = authTimeouts.get(ws);
+      if (authTimer) {
+        clearTimeout(authTimer);
+        authTimeouts.delete(ws);
       }
-      console.log('[BrowserBridge] Extension disconnected. Total clients:', connectedClients.size);
-      getWindowFn?.()?.webContents.send('browser:extension-connected', { count: connectedClients.size });
+      connectedClients.delete(ws);
+      rateLimitMap.delete(ws);
+
+      if (ws === authenticatedClient) {
+        authenticatedClient = null;
+        rejectAllPending(new Error('Extension disconnected'));
+        console.log('[BrowserBridge] Authenticated extension disconnected');
+        getWindowFn?.()?.webContents.send('browser:extension-connected', { count: 0 });
+      }
     });
 
     ws.on('error', (err) => {
@@ -130,13 +263,59 @@ export function startBridgeServer(getWindow: () => BrowserWindow | null): void {
   });
 }
 
-export function stopBridgeServer(): void {
-  for (const [id, entry] of pending) {
-    clearTimeout(entry.timer);
-    entry.reject(new Error('Bridge server stopping'));
-    pending.delete(id);
+function handleAuthMessage(ws: WebSocket, rawData: string): void {
+  let msg: { type?: string; token?: string };
+  try {
+    msg = JSON.parse(rawData) as { type?: string; token?: string };
+  } catch {
+    ws.close(1008, 'Invalid message');
+    return;
   }
+
+  if (msg.type !== 'auth') {
+    // Ignore keep-alive pings during auth window; reject anything else
+    if (msg.type !== 'ping') {
+      ws.send(JSON.stringify({ type: 'auth-fail', reason: 'auth-required' }));
+      ws.close(1008, 'Authentication required');
+    }
+    return;
+  }
+
+  const expected = getBridgeToken();
+  if (!msg.token || msg.token !== expected) {
+    console.warn('[BrowserBridge] Bad token from extension — closing');
+    ws.send(JSON.stringify({ type: 'auth-fail', reason: 'invalid-token' }));
+    ws.close(1008, 'Invalid token');
+    return;
+  }
+
+  // Token is valid — clear auth timeout
+  const authTimer = authTimeouts.get(ws);
+  if (authTimer) {
+    clearTimeout(authTimer);
+    authTimeouts.delete(ws);
+  }
+
+  // If another extension was already authenticated, close it first (single-client policy)
+  if (authenticatedClient && authenticatedClient !== ws) {
+    console.log('[BrowserBridge] New extension authenticated — replacing previous connection');
+    rejectAllPending(new Error('Extension replaced by new connection'));
+    authenticatedClient.close(1000, 'Replaced by new connection');
+  }
+
+  authenticatedClient = ws;
+  ws.send(JSON.stringify({ type: 'auth-ok' }));
+  console.log('[BrowserBridge] Extension authenticated');
+  getWindowFn?.()?.webContents.send('browser:extension-connected', { count: 1 });
+}
+
+export function stopBridgeServer(): void {
+  rejectAllPending(new Error('Bridge server stopping'));
+  for (const timer of authTimeouts.values()) clearTimeout(timer);
+  authTimeouts.clear();
+  authenticatedClient = null;
   connectedClients.clear();
+  rateLimitMap.clear();
   wss?.close();
   wss = null;
   getWindowFn = null;
@@ -146,7 +325,7 @@ export function getBridgeStatus(): { running: boolean; port: number; connectedCl
   return {
     running: wss !== null,
     port: BRIDGE_PORT,
-    connectedClients: connectedClients.size,
+    connectedClients: authenticatedClient ? 1 : 0,
   };
 }
 
@@ -155,12 +334,13 @@ export function getBridgeStatus(): { running: boolean; port: number; connectedCl
 const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
 
 function nextId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${Date.now()}-${randomBytes(4).toString('hex')}`;
 }
 
 /**
  * Send a command to the connected browser extension and wait for the response.
- * Rejects if no extension is connected, or if the command times out.
+ * Rejects if no authenticated extension is connected, or if the command times out.
+ * Navigate commands are URL-validated before sending.
  * Pass `timeoutMs` to override the default 30s timeout (e.g. for slow scroll-extract).
  */
 export function sendCommand(
@@ -168,9 +348,20 @@ export function sendCommand(
   timeoutMs: number = DEFAULT_COMMAND_TIMEOUT_MS,
 ): Promise<BridgeResponse> {
   return new Promise((resolve, reject) => {
-    if (connectedClients.size === 0) {
+    if (!authenticatedClient) {
       reject(new Error('No browser extension connected'));
       return;
+    }
+
+    // Centralized URL validation for navigate commands
+    if (command.type === 'navigate') {
+      const url = command.payload?.url;
+      try {
+        validateNavigateUrl(typeof url === 'string' ? url : String(url ?? ''));
+      } catch (err) {
+        reject(err);
+        return;
+      }
     }
 
     const id = nextId();
@@ -183,10 +374,8 @@ export function sendCommand(
 
     pending.set(id, { resolve, reject, timer });
 
-    // Send to the first available client (extension is single-instance)
-    const [client] = connectedClients;
     try {
-      client.send(JSON.stringify(full));
+      authenticatedClient.send(JSON.stringify(full));
     } catch (e) {
       clearTimeout(timer);
       pending.delete(id);

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2451,6 +2451,14 @@ export interface JarvisApi {
 
 
 
+  browserGetToken(): Promise<{ token: string }>;
+
+
+
+  browserRegenerateToken(): Promise<{ token: string }>;
+
+
+
   browserListSkills(): Promise<BrowserSkill[]>;
 
 

--- a/tests/unit/browser-companion-server.test.ts
+++ b/tests/unit/browser-companion-server.test.ts
@@ -5,6 +5,9 @@
  * - getBridgeStatus (status reporting)
  * - sendCommand (rejects when no clients are connected)
  * - stopBridgeServer (safe to call even without a running server)
+ * - validateNavigateUrl (URL scheme allow-list)
+ * - getBridgeToken (token generation and persistence)
+ * - regenerateBridgeToken (token rotation)
  *
  * startBridgeServer is exercised indirectly via the IPC registration tests
  * (handler-validation.test.ts), which call registerIpcHandlers and produce the
@@ -12,11 +15,69 @@
  * branches for connection handling.  The tests below focus on the branches that
  * are exercised WITHOUT a live WebSocket connection.
  */
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ── WebSocket mock ─────────────────────────────────────────────────────────────
+// Using vi.hoisted so variables are available inside the vi.mock factory.
+// This avoids binding a real port and prevents flaky port-conflict failures
+// when handler-validation.test.ts also starts the server in its own worker.
+
+const mockRegistry = vi.hoisted(() => ({
+  serverEmitter: null as null | (ReturnType<typeof import('events').EventEmitter> & { close: () => void }),
+  createSocket: null as null | ((remoteAddr?: string) => {
+    emit: (event: string, ...args: unknown[]) => void;
+    send: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    readyState: number;
+  }),
+}));
+
+vi.mock('ws', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require('events') as typeof import('events');
+
+  class MockWebSocket extends EventEmitter {
+    readyState = 1;
+    send = vi.fn();
+    close = vi.fn((code?: number, reason?: string | Buffer) => {
+      this.readyState = 3;
+      this.emit('close', code, typeof reason === 'string' ? Buffer.from(reason) : (reason ?? Buffer.alloc(0)));
+    });
+    socket: { remoteAddress: string } = { remoteAddress: '127.0.0.1' };
+  }
+
+  class MockWebSocketServer extends EventEmitter {
+    close = vi.fn();
+    constructor(_opts?: unknown) {
+      super();
+      // Store as "any" to keep typing simple across hoisted boundary
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockRegistry as any).serverEmitter = this;
+    }
+  }
+
+  // Expose a factory so tests can create sockets with a chosen remoteAddress
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (mockRegistry as any).createSocket = (remoteAddr = '127.0.0.1') => {
+    const ws = new MockWebSocket();
+    ws.socket = { remoteAddress: remoteAddr };
+    return ws;
+  };
+
+  return { WebSocketServer: MockWebSocketServer, WebSocket: MockWebSocket };
+});
+
 import {
   getBridgeStatus,
   sendCommand,
   stopBridgeServer,
+  startBridgeServer,
+  validateNavigateUrl,
+  getBridgeToken,
+  regenerateBridgeToken,
   BRIDGE_PORT,
 } from '../../src/plugins/browser-companion/server';
 
@@ -61,6 +122,8 @@ describe('sendCommand', () => {
       ).rejects.toThrow('No browser extension connected');
     }
   });
+
+
 });
 
 describe('stopBridgeServer', () => {
@@ -83,3 +146,292 @@ describe('stopBridgeServer', () => {
     expect(status.connectedClients).toBe(0);
   });
 });
+
+// ── validateNavigateUrl ────────────────────────────────────────────────────────
+
+describe('validateNavigateUrl', () => {
+  it('accepts http: URLs without throwing', () => {
+    expect(() => validateNavigateUrl('http://example.com')).not.toThrow();
+  });
+
+  it('accepts https: URLs without throwing', () => {
+    expect(() => validateNavigateUrl('https://example.com/path?q=1')).not.toThrow();
+  });
+
+  it('rejects file: URLs', () => {
+    expect(() => validateNavigateUrl('file:///etc/passwd')).toThrow('not allowed');
+  });
+
+  it('rejects chrome: URLs', () => {
+    expect(() => validateNavigateUrl('chrome://extensions')).toThrow('not allowed');
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(() => validateNavigateUrl('javascript:alert(1)')).toThrow('not allowed');
+  });
+
+  it('rejects data: URLs', () => {
+    expect(() => validateNavigateUrl('data:text/html,<h1>hi</h1>')).toThrow('not allowed');
+  });
+
+  it('rejects ftp: URLs', () => {
+    expect(() => validateNavigateUrl('ftp://example.com/file')).toThrow('not allowed');
+  });
+
+  it('throws a descriptive error for completely invalid URLs', () => {
+    expect(() => validateNavigateUrl('not-a-valid-url')).toThrow('Invalid URL');
+  });
+
+  it('throws a descriptive error for empty string', () => {
+    expect(() => validateNavigateUrl('')).toThrow('Invalid URL');
+  });
+
+  it('includes the blocked scheme in the error message', () => {
+    expect(() => validateNavigateUrl('file:///test')).toThrow('file:');
+  });
+});
+
+// ── getBridgeToken / regenerateBridgeToken ─────────────────────────────────────
+
+describe('getBridgeToken', () => {
+  let tmpDir: string;
+  const originalEnv = process.env.JARVIS_CONFIG_DIR;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-bridge-token-test-'));
+    process.env.JARVIS_CONFIG_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalEnv === undefined) {
+      delete process.env.JARVIS_CONFIG_DIR;
+    } else {
+      process.env.JARVIS_CONFIG_DIR = originalEnv;
+    }
+  });
+
+  it('generates a non-empty token when no config exists', () => {
+    const token = getBridgeToken();
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  it('persists the token to config.json', () => {
+    const token = getBridgeToken();
+    const configPath = path.join(tmpDir, 'config.json');
+    expect(fs.existsSync(configPath)).toBe(true);
+    const saved = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as { bridge?: { token?: string } };
+    expect(saved.bridge?.token).toBe(token);
+  });
+
+  it('returns the same token on repeated calls', () => {
+    const first = getBridgeToken();
+    const second = getBridgeToken();
+    expect(second).toBe(first);
+  });
+
+  it('returns an existing token from config without regenerating', () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({ bridge: { token: 'existing-token-abc123' } }), 'utf-8');
+    const token = getBridgeToken();
+    expect(token).toBe('existing-token-abc123');
+  });
+
+  it('generates a token matching the expected hex format (32 hex chars)', () => {
+    const token = getBridgeToken();
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe('regenerateBridgeToken', () => {
+  let tmpDir: string;
+  const originalEnv = process.env.JARVIS_CONFIG_DIR;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-bridge-regen-test-'));
+    process.env.JARVIS_CONFIG_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalEnv === undefined) {
+      delete process.env.JARVIS_CONFIG_DIR;
+    } else {
+      process.env.JARVIS_CONFIG_DIR = originalEnv;
+    }
+  });
+
+  it('returns a new token in hex format', () => {
+    const token = regenerateBridgeToken();
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('replaces the previously stored token', () => {
+    const first = getBridgeToken();
+    const second = regenerateBridgeToken();
+    // The new token should be persisted
+    const third = getBridgeToken();
+    expect(third).toBe(second);
+    // With high probability (collision extremely unlikely) the new token differs
+    expect(second).not.toBe(first);
+  });
+
+  it('persists the new token to config.json', () => {
+    const newToken = regenerateBridgeToken();
+    const configPath = path.join(tmpDir, 'config.json');
+    const saved = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as { bridge?: { token?: string } };
+    expect(saved.bridge?.token).toBe(newToken);
+  });
+});
+
+// ── WebSocket auth flow (via mocked ws module) ────────────────────────────────
+// These tests exercise the auth handshake, rate-limiting, and single-client
+// branches of startBridgeServer / handleAuthMessage without binding a real port.
+
+describe('startBridgeServer — WebSocket auth flow', () => {
+  let tmpDir: string;
+  const originalEnv = process.env.JARVIS_CONFIG_DIR;
+  let token: string;
+
+  // Helper: emit the 'listening' event so startBridgeServer's callback fires
+  function emitListening(): void {
+    (mockRegistry.serverEmitter as unknown as { emit: (e: string) => void })?.emit('listening');
+  }
+
+  // Helper: simulate a new WebSocket connection from localhost
+  function connectSocket(remoteAddr = '127.0.0.1'): ReturnType<NonNullable<typeof mockRegistry.createSocket>> {
+    const ws = mockRegistry.createSocket!(remoteAddr);
+    const req = { socket: { remoteAddress: remoteAddr } };
+    (mockRegistry.serverEmitter as unknown as { emit: (e: string, ...a: unknown[]) => void }).emit('connection', ws, req);
+    return ws;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-ws-test-'));
+    process.env.JARVIS_CONFIG_DIR = tmpDir;
+    // Start the server (uses mocked WSS — no real port binding)
+    startBridgeServer(() => null);
+    emitListening();
+    token = getBridgeToken();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalEnv === undefined) {
+      delete process.env.JARVIS_CONFIG_DIR;
+    } else {
+      process.env.JARVIS_CONFIG_DIR = originalEnv;
+    }
+  });
+
+  it('startBridgeServer marks the server as running', () => {
+    expect(getBridgeStatus().running).toBe(true);
+  });
+
+  it('calling startBridgeServer a second time is a no-op', () => {
+    startBridgeServer(() => null); // second call — should return early
+    expect(getBridgeStatus().running).toBe(true);
+  });
+
+  it('authenticates a socket that sends the correct token', () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'auth', token })));
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'auth-ok' }));
+    expect(getBridgeStatus().connectedClients).toBe(1);
+  });
+
+  it('rejects a socket that sends a wrong token', () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'auth', token: 'wrong-token' })));
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'auth-fail', reason: 'invalid-token' }));
+    expect(ws.close).toHaveBeenCalledWith(1008, 'Invalid token');
+  });
+
+  it('rejects a socket that sends a non-auth, non-ping message before authenticating', () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'navigate', url: 'https://example.com' })));
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'auth-fail', reason: 'auth-required' }));
+    expect(ws.close).toHaveBeenCalledWith(1008, 'Authentication required');
+  });
+
+  it('ignores ping messages received before authentication (no close)', () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'ping' })));
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  it('closes a socket that sends invalid JSON before authenticating', () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from('not-valid-json{'));
+    expect(ws.close).toHaveBeenCalledWith(1008, 'Invalid message');
+  });
+
+  it('closes non-localhost connections immediately', () => {
+    const ws = connectSocket('10.0.0.1');
+    expect(ws.close).toHaveBeenCalledWith(1008, 'Forbidden');
+  });
+
+  it('replaces an existing authenticated client when a new one connects and authenticates', () => {
+    // First client authenticates
+    const ws1 = connectSocket();
+    ws1.emit('message', Buffer.from(JSON.stringify({ type: 'auth', token })));
+    expect(getBridgeStatus().connectedClients).toBe(1);
+
+    // Second client authenticates — should replace first
+    const ws2 = connectSocket();
+    ws2.emit('message', Buffer.from(JSON.stringify({ type: 'auth', token })));
+    // First client should be closed
+    expect(ws1.close).toHaveBeenCalledWith(1000, 'Replaced by new connection');
+    // Second client is now authenticated
+    expect(getBridgeStatus().connectedClients).toBe(1);
+  });
+
+  it('resets connected count to 0 when the authenticated client disconnects', () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'auth', token })));
+    expect(getBridgeStatus().connectedClients).toBe(1);
+    ws.emit('close');
+    expect(getBridgeStatus().connectedClients).toBe(0);
+  });
+
+  it('sends rate-limit error when authenticated client exceeds 30 commands in a window', () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'auth', token })));
+    ws.send.mockClear(); // clear the auth-ok call
+
+    // Send 31 messages — the 31st should be rate-limited
+    const msg = JSON.stringify({ id: 'test-id', type: 'list-tabs' });
+    for (let i = 0; i < 31; i++) {
+      ws.emit('message', Buffer.from(msg));
+    }
+
+    // At least one rate-limit response should have been sent
+    const rateLimitCalls = (ws.send.mock.calls as string[][]).filter(
+      ([payload]) => typeof payload === 'string' && payload.includes('Rate limit exceeded'),
+    );
+    expect(rateLimitCalls.length).toBeGreaterThan(0);
+  });
+
+  it('responds to pending sendCommand promises when a response arrives', async () => {
+    const ws = connectSocket();
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'auth', token })));
+
+    // Intercept the outgoing command to extract its id
+    ws.send.mockClear();
+    const cmdPromise = sendCommand({ type: 'list-tabs', payload: {} });
+
+    // Wait for the send call to happen
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    const sentPayload = JSON.parse((ws.send.mock.calls[0] as [string])[0]) as { id: string };
+    const id = sentPayload.id;
+
+    // Simulate the extension's response
+    ws.emit('message', Buffer.from(JSON.stringify({ id, ok: true, data: [] })));
+
+    const result = await cmdPromise;
+    expect(result.ok).toBe(true);
+    expect(result.id).toBe(id);
+  });
+});
+

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -159,6 +159,8 @@ const EXPECTED_CHANNELS = [
   'shell:open-url',
   // browser-companion plugin
   'browser:status',
+  'browser:get-token',
+  'browser:regenerate-token',
   'browser:list-skills',
   'browser:create-skill',
   'browser:update-skill',


### PR DESCRIPTION
## Security improvements for the browser companion WebSocket bridge

### What was wrong
- Any local process could connect to \ws://127.0.0.1:35789\ and issue browser commands (navigate, fill forms, click, screenshot, exfiltrate tab data) — only a localhost IP check existed
- No URL validation — navigate commands could target \ile://\, \chrome://\, private IPs, etc.
- No rate limiting — unlimited commands per second

### What's fixed

#### 🔐 Shared secret handshake (token auth)
- A random 32-hex token is generated on first run and persisted in \config.json\
- The extension **must** send \{ type: 'auth', token }\ as the first message within 5 seconds
- Server responds \uth-ok\ or \uth-fail\ (with reason) and closes bad connections
- Only one authenticated extension is active at a time (new auth replaces old)

#### 🔄 Token rotation
- New **Regenerate** button in the Browser Companion panel generates a fresh token and drops the current connection

#### 🔗 URL scheme validation (centralized + defense-in-depth)
- \alidateNavigateUrl()\ is called inside \sendCommand()\ for every navigate command — only \http:\ and \https:\ allowed
- Same check also applied in the extension's \cmdNavigate\ for defense-in-depth

#### ⏱️ Rate limiting
- Max 30 commands per 10-second window per connection
- Excess commands get an error response (no disconnect)

#### 🧩 Extension UX
- Extension popup now shows a token input field
- Extension **does not connect** if no token is configured (shows 'Token required')
- 'Save' in popup triggers immediate reconnect with new token
- Invalid token shows a red 'Invalid token' badge

### Files changed
- \src/agent/config.ts\ — added \ridge.token\ to config schema
- \src/plugins/browser-companion/server.ts\ — auth, rate limiting, URL validation, single-client enforcement
- \src/plugins/browser-companion/handler.ts\ — added \rowser:get-token\ and \rowser:regenerate-token\ IPC
- \src/plugins/types.ts\ + \src/main/preload.ts\ — wired up new IPC methods
- \src/plugins/browser-companion/BrowserCompanionPanel.tsx\ — pairing token display + regenerate button
- \src/browser-extension/background.js\ — auth handshake, no-token guard, reconnect on token save
- \src/browser-extension/popup.html\ + \popup.js\ — token input UI