### PR TITLE
fix: move Ruddr Projects panel into dashboard, add hide toggle

### DIFF
--- a/src/plugins/groups/GroupsDashboardPanel.tsx
+++ b/src/plugins/groups/GroupsDashboardPanel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource preact */
-import { useState, useEffect, useRef } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import type { Group, RuddrProjectMatch, RuddrBudget, RuddrProjectInfo } from '../types';
 import { RuddrProjectsPanel } from './RuddrProjectsPanel';
 
@@ -12,11 +12,10 @@ export function GroupsDashboardPanel() {
   const [groups, setGroups] = useState<Group[]>([]);
   const [loading, setLoading] = useState(true);
   const [detailsLoading, setDetailsLoading] = useState(false);
-  const [mainMaxWidth, setMainMaxWidth] = useState<number>(600);
-  const mainRef = useRef<HTMLDivElement>(null);
+  const [ruddrVisible, setRuddrVisible] = useState(true);
   const [budgetData, setBudgetData] = useState<Record<string, RuddrBudget>>({});
   const [budgetChecking, setBudgetChecking] = useState<string | null>(null);
-  const [newRuddrProjects, setNewRuddrProjects] = useState<Array<{ name: string; path: string }>>([]);
+  const [newRuddrProjects, setNewRuddrProjects] = useState<Array<{ name: string; path: string }>>([]); 
 
   const loadData = async () => {
     setLoading(true);
@@ -51,28 +50,6 @@ export function GroupsDashboardPanel() {
       setLoading(false);
     }
   };
-
-  // Keep groups-dash-main width capped to the left of the fixed Ruddr panel.
-  // Measures real DOM positions so no magic numbers or 100vw assumptions are needed.
-  useEffect(() => {
-    const GAP = 19; // ~1.2rem visual gap between grid and panel
-    const recompute = () => {
-      const panel = document.querySelector('.ruddr-projects-panel') as HTMLElement | null;
-      if (!panel || !mainRef.current) return;
-      const panelLeft = panel.getBoundingClientRect().left;
-      const mainLeft  = mainRef.current.getBoundingClientRect().left;
-      setMainMaxWidth(Math.max(280, panelLeft - mainLeft - GAP));
-    };
-    // Defer initial measurement until both elements are painted
-    const raf = requestAnimationFrame(recompute);
-    window.addEventListener('resize', recompute);
-    window.addEventListener('ruddr-panel-resize', recompute);
-    return () => {
-      cancelAnimationFrame(raf);
-      window.removeEventListener('resize', recompute);
-      window.removeEventListener('ruddr-panel-resize', recompute);
-    };
-  }, []);
 
   useEffect(() => {
     loadData();
@@ -167,10 +144,17 @@ export function GroupsDashboardPanel() {
           </svg>
           {loading ? 'Refreshing…' : 'Refresh'}
         </button>
+        <button
+          class="dash-toggle-ruddr-btn"
+          onClick={() => setRuddrVisible((v) => !v)}
+          title={ruddrVisible ? 'Hide Ruddr Projects panel' : 'Show Ruddr Projects panel'}
+        >
+          {ruddrVisible ? '◀ Ruddr' : '▶ Ruddr'}
+        </button>
       </div>
 
       <div class="groups-dash-body">
-        <div class="groups-dash-main" ref={mainRef} style={{ maxWidth: `${mainMaxWidth}px`, overflow: 'hidden' }}>
+        <div class="groups-dash-main">
           {/* ── New Ruddr project notification banners ── */}
           {newRuddrProjects.length > 0 && (
             <div class="groups-dash-new-projects">
@@ -218,7 +202,7 @@ export function GroupsDashboardPanel() {
           )}
         </div>
 
-        <RuddrProjectsPanel onGroupCreated={loadData} />
+        {ruddrVisible && <RuddrProjectsPanel onGroupCreated={loadData} />}
       </div>
     </div>
   );

--- a/src/plugins/groups/RuddrProjectsPanel.tsx
+++ b/src/plugins/groups/RuddrProjectsPanel.tsx
@@ -23,16 +23,7 @@ export function RuddrProjectsPanel(props: { onGroupCreated?: () => void }) {
   const [width, setWidth] = useState(240);
   const [creatingFor, setCreatingFor] = useState<string | null>(null);
 
-  // Notify the rest of the page when panel width changes
-  useEffect(() => {
-    document.documentElement.style.setProperty('--ruddr-panel-width', `${width}px`);
-    window.dispatchEvent(new CustomEvent('ruddr-panel-resize', { detail: width }));
-  }, [width]);
-
-  // Clean up on unmount
-  useEffect(() => {
-    return () => { document.documentElement.style.removeProperty('--ruddr-panel-width'); };
-  }, []);
+  // ── Drag-to-resize ──────────────────────────────────────────────────────────
   const [newGroupName, setNewGroupName] = useState('');
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -2826,7 +2826,7 @@ h5.ec-heading { font-size: 0.85rem; }
 .groups-dash-main {
   flex: 1 1 0;
   min-width: 0;
-  /* max-width and overflow are set as inline styles by GroupsDashboardPanel.tsx */
+  overflow: hidden;
 }
 
 .groups-dash-header {
@@ -2841,6 +2841,23 @@ h5.ec-heading { font-size: 0.85rem; }
   font-size: 1.15rem;
   font-weight: 600;
   flex: 1;
+}
+
+.dash-toggle-ruddr-btn {
+  padding: 0.3rem 0.75rem;
+  background: #12183a;
+  border: 1px solid #1e2d5a;
+  border-radius: 6px;
+  color: #8898cc;
+  font-size: 0.78rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.dash-toggle-ruddr-btn:hover {
+  border-color: #3a5aaa;
+  color: #c8d0f0;
 }
 
 
@@ -3279,17 +3296,14 @@ h5.ec-heading { font-size: 0.85rem; }
 
 /* ── RuddrProjectsPanel ───────────────────────────────────────────────────── */
 .ruddr-projects-panel {
-  /* Fixed to the right side of the viewport — detached from the flex layout.
-     --chat-panel-width (set by EmbeddedChatPanel) keeps it left of the chat
-     window. Using top+bottom instead of top+max-height means it automatically
-     stays above the status bar without any JS measurement. */
-  position: fixed;
-  right: calc(var(--chat-panel-width, 0px) + 1rem);
-  top: 8rem;
-  bottom: calc(var(--status-bar-height, 0px) + 1rem);
+  /* Inline flex child — sits to the right of the groups grid, scrolls independently. */
+  position: relative;
+  flex-shrink: 0;
+  align-self: flex-start;
   width: 240px;
   min-width: 180px;
   max-width: 600px;
+  max-height: calc(100vh - 11rem);
   background: #12183a;
   border: 1px solid #1e2d5a;
   border-radius: 8px;
@@ -3299,7 +3313,6 @@ h5.ec-heading { font-size: 0.85rem; }
   flex-direction: column;
   gap: 0.6rem;
   overflow-y: auto;
-  z-index: 50;
 }
 
 /* Left-edge drag handle */


### PR DESCRIPTION
## Problem
The Ruddr Projects panel used \position: fixed\ which caused it to float on top of everything including the Refresh button.

## Changes
- **Removed \position: fixed\** from \.ruddr-projects-panel\ — it's now a normal flex child inside \.groups-dash-body\, sitting to the right of the groups grid
- **Added hide/show toggle button** (◀/▶ Ruddr) next to the Refresh button in the header
- **Removed JS max-width measurement** (\mainMaxWidth\ state + DOM measurement useEffect) — no longer needed since the panel is in normal flow
- **Cleaned up dead code** in \RuddrProjectsPanel\: removed \uddr-panel-resize\ event dispatch and \--ruddr-panel-width\ CSS variable (no longer used)