### PR TITLE
Fix: Deduplicate notifications in People First view

### DIFF
--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -1168,6 +1168,10 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
         setOwnRepoNotifications(
           lists.flat()
             .filter((notification) => !dismissed.has(String(notification.id)))
+            // Deduplicate by notification ID (in case same notification appears in multiple repos)
+            .filter((notification, index, self) =>
+              index === self.findIndex((n) => String(n.id) === String(notification.id))
+            )
             .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()),
         );
       })


### PR DESCRIPTION
## Problem
The DashboardNotificationTriage component was showing duplicate notifications in the People First view. This occurred when loading notifications from multiple repos because there was no deduplication step after combining the results.

## Solution
Added a deduplication filter that ensures each notification appears only once, even if it was returned from multiple repos.

## Changes
- Modified  to add deduplication logic using  and 
- The fix is minimal and targeted, only affecting the notification loading pipeline for the People First view

## Testing
- The fix ensures that notifications are deduplicated by their ID
- Existing functionality remains unchanged
- No breaking changes to the API or component interfaces