### PR TITLE
Auto-dismiss CI notifications for deleted/merged branches

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -79,6 +79,8 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('github:get-pr-state', subjectUrl),
   githubGetIssueState: (subjectUrl: string) =>
     ipcRenderer.invoke('github:get-issue-state', subjectUrl),
+  githubCheckBranchExists: (repoFullName: string, branch: string) =>
+    ipcRenderer.invoke('github:check-branch-exists', repoFullName, branch),
   // Local repos
   localGetFolders: () => ipcRenderer.invoke('local:get-folders'),
   localAddFolder: (folderPath?: string) => ipcRenderer.invoke('local:add-folder', folderPath),

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -145,8 +145,7 @@ async function runClosedPrStep(): Promise<{ dismissed: number; logEntries: AutoD
   return { dismissed, logEntries };
 }
 
-async function runClosedIssueStep(): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
-  const logEntries: AutoDismissLogInput[] = [];
+async function runClosedIssueStep(): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {  const logEntries: AutoDismissLogInput[] = [];
   let dismissed = 0;
   try {
     const allIssueNotifs = await window.jarvis.listIssueNotifications();
@@ -191,16 +190,59 @@ async function runClosedIssueStep(): Promise<{ dismissed: number; logEntries: Au
   return { dismissed, logEntries };
 }
 
+async function runDeletedBranchCiStep(repoFullNames: string[]): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
+  const logEntries: AutoDismissLogInput[] = [];
+  let dismissed = 0;
+  for (const repoFullName of repoFullNames) {
+    try {
+      const notifs = await window.jarvis.listNotificationsForRepo(repoFullName);
+      const ciNotifs = notifs.filter((n) => n.subject_type === 'CheckSuite' || n.subject_type === 'WorkflowRun');
+      if (ciNotifs.length === 0) continue;
+
+      // Group by branch name extracted from notification title
+      const byBranch = new Map<string, StoredNotification[]>();
+      for (const n of ciNotifs) {
+        const branch = n.subject_title.match(/\bfor\s+(\S+)\s+branch\b/i)?.[1] ?? null;
+        if (!branch) continue;
+        if (!byBranch.has(branch)) byBranch.set(branch, []);
+        byBranch.get(branch)!.push(n);
+      }
+
+      for (const [branch, bNotifs] of byBranch) {
+        try {
+          const exists = await window.jarvis.githubCheckBranchExists(repoFullName, branch);
+          if (exists) continue;
+          for (const n of bNotifs) {
+            try {
+              await window.jarvis.dismissNotification(n.id);
+              logEntries.push({
+                notification_id: n.id,
+                reason: 'ci_deleted_branch',
+                repo_full_name: repoFullName,
+                subject_title: n.subject_title,
+                subject_type: n.subject_type,
+              });
+              dismissed++;
+            } catch { /* skip individual */ }
+          }
+        } catch { /* skip individual branch */ }
+      }
+    } catch { /* non-fatal per repo */ }
+  }
+  return { dismissed, logEntries };
+}
+
 async function runAutoDismissPipeline(
   repoFullNames: string[],
 ): Promise<{ result: AutoDismissRunResult; logEntries: AutoDismissLogInput[] }> {
   const steps: AutoDismissStepResult[] = [];
   const allLog: AutoDismissLogInput[] = [];
 
-  const [rec, pr, issue] = await Promise.all([
+  const [rec, pr, issue, deletedBranch] = await Promise.all([
     runRecoverableStep(repoFullNames),
     runClosedPrStep(),
     runClosedIssueStep(),
+    runDeletedBranchCiStep(repoFullNames),
   ]);
 
   steps.push({ id: 'recovered-workflows', label: 'Recovered workflows', dismissed: rec.dismissed });
@@ -209,6 +251,8 @@ async function runAutoDismissPipeline(
   allLog.push(...pr.logEntries);
   steps.push({ id: 'closed-issues', label: 'Closed issues', dismissed: issue.dismissed });
   allLog.push(...issue.logEntries);
+  steps.push({ id: 'ci-deleted-branch', label: 'CI on deleted branches', dismissed: deletedBranch.dismissed });
+  allLog.push(...deletedBranch.logEntries);
 
   return {
     result: { steps, total: steps.reduce((s, r) => s + r.dismissed, 0) },

--- a/src/plugins/github-auth/handler.ts
+++ b/src/plugins/github-auth/handler.ts
@@ -173,6 +173,24 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
     } catch { return null; }
   });
 
+  ipcMain.handle('github:check-branch-exists', async (_event, repoFullName: string, branch: string) => {
+    if (typeof repoFullName !== 'string' || !repoFullName.includes('/')) return false;
+    if (typeof branch !== 'string' || branch.length === 0) return false;
+    const auth = loadGitHubAuth(db);
+    if (!auth) return false;
+    try {
+      const url = `https://api.github.com/repos/${repoFullName}/branches/${encodeURIComponent(branch)}`;
+      const res = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${auth.accessToken}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+      return res.status === 200;
+    } catch { return false; }
+  });
+
   ipcMain.handle('github:save-pat', async (_event, pat: string) => {
     const auth = loadGitHubAuth(db);
     if (!auth) return { error: 'Not authenticated' };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1789,7 +1789,8 @@ export type AutoDismissReason =
   | 'closed_pr_merged_me'
   | 'closed_pr_closed_me'
   | 'closed_issue_me'
-  | 'closed_issue_via_pr';
+  | 'closed_issue_via_pr'
+  | 'ci_deleted_branch';
 
 export interface AutoDismissLogInput {
   notification_id: string;
@@ -2173,6 +2174,10 @@ export interface JarvisApi {
 
 
   githubGetIssueState(subjectUrl: string): Promise<{ state: 'open' | 'closed'; closedByMe: boolean; closedViaMergedPr: boolean } | null>;
+
+
+
+  githubCheckBranchExists(repoFullName: string, branch: string): Promise<boolean>;
 
 
 

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -60,6 +60,7 @@ const EXPECTED_CHANNELS = [
   'github:get-run-url-for-check-suite',
   'github:get-pr-state',
   'github:get-issue-state',
+  'github:check-branch-exists',
   'github:save-pat',
   'github:delete-pat',
   'github:logout',


### PR DESCRIPTION
## Summary

Adds a new step to the auto-dismiss pipeline that automatically clears CI workflow notifications (CheckSuite / WorkflowRun) when the branch they were triggered on no longer exists (deleted or merged).

## Changes

- **`src/plugins/types.ts`** — Added `'ci_deleted_branch'` to `AutoDismissReason`; added `githubCheckBranchExists()` to the `JarvisAPI` interface
- **`src/plugins/github-auth/handler.ts`** — New IPC handler `github:check-branch-exists` that calls `GET /repos/{owner}/{repo}/branches/{branch}` and returns `true` if the branch exists, `false` for 404 / errors
- **`src/main/preload.ts`** — Exposes `githubCheckBranchExists(repoFullName, branch)` through the context bridge
- **`src/plugins/dashboard/DashboardPanel.tsx`** — Added `runDeletedBranchCiStep()` and wired it into `runAutoDismissPipeline()` as a new `'CI on deleted branches'` step
- **`tests/unit/ipc-registration.test.ts`** — Added `'github:check-branch-exists'` to the expected channels catalogue

## Behaviour

On each auto-dismiss run, for every repo with CI notifications, the new step:
1. Extracts the branch name from the notification title (pattern: `for {branch} branch`)
2. Checks via the GitHub API whether that branch still exists
3. Dismisses all CI notifications whose branch is gone

The step runs in parallel with the existing recovered-workflow, closed-PR, and closed-issue steps, so there is no added latency on startup.