### PR TITLE
Fix failing CI build: prevent electron binary download in unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tests/**/*.js.map
 
 .claude/worktrees/
 test_output.txt
+
+# User-specific runtime config (may contain secrets)
+AppData/

--- a/src/plugins/notifications/handler.ts
+++ b/src/plugins/notifications/handler.ts
@@ -22,11 +22,9 @@ import {
 import { loadGitHubAuth } from '../../services/github-oauth';
 import { saveDatabase } from '../../storage/database';
 import { fetchAndStoreWorkflowData } from '../../services/github-workflows';
+import { isWorkflowDataFresh } from './workflow-cache';
 
 // ── Boot workflow check constants ─────────────────────────────────────────────
-
-/** Workflow cache is considered fresh if fetched within this window. */
-const WORKFLOW_CACHE_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
 
 /** When rate limit remaining is below this value, check estimated call count. */
 const BOOT_CHECK_RATE_LIMIT_THRESHOLD = 1000;
@@ -36,23 +34,6 @@ const BOOT_CHECK_MAX_ESTIMATED_CALLS = 50;
 
 /** Conservative per-repo estimate: 1 runs page + up to 5 failing-run details. */
 const BOOT_CHECK_ESTIMATED_CALLS_PER_REPO = 10;
-
-/**
- * Returns true if workflow run data for the given repo was fetched recently
- * (within WORKFLOW_CACHE_MAX_AGE_MS). Avoids redundant API calls on rapid
- * restarts (e.g. during agentic dev sessions with hot reload).
- */
-export function isWorkflowDataFresh(db: SqlJsDatabase, repoFullName: string): boolean {
-  const result = db.exec(
-    `SELECT MAX(fetched_at) FROM github_workflow_runs WHERE repo_full_name = ?`,
-    [repoFullName],
-  );
-  const raw = result[0]?.values[0]?.[0] as string | null | undefined;
-  if (!raw) return false;
-  // SQLite datetime('now') stores UTC without 'Z' suffix — append it before parsing.
-  const fetchedAt = new Date(raw.includes('T') ? raw : raw + 'Z');
-  return Date.now() - fetchedAt.getTime() < WORKFLOW_CACHE_MAX_AGE_MS;
-}
 
 /**
  * Fetches the core rate-limit remaining count for the given token.

--- a/src/plugins/notifications/workflow-cache.ts
+++ b/src/plugins/notifications/workflow-cache.ts
@@ -1,0 +1,21 @@
+import type { Database as SqlJsDatabase } from 'sql.js';
+
+/** Workflow cache is considered fresh if fetched within this window. */
+export const WORKFLOW_CACHE_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Returns true if workflow run data for the given repo was fetched recently
+ * (within WORKFLOW_CACHE_MAX_AGE_MS). Avoids redundant API calls on rapid
+ * restarts (e.g. during agentic dev sessions with hot reload).
+ */
+export function isWorkflowDataFresh(db: SqlJsDatabase, repoFullName: string): boolean {
+  const result = db.exec(
+    `SELECT MAX(fetched_at) FROM github_workflow_runs WHERE repo_full_name = ?`,
+    [repoFullName],
+  );
+  const raw = result[0]?.values[0]?.[0] as string | null | undefined;
+  if (!raw) return false;
+  // SQLite datetime('now') stores UTC without 'Z' suffix — append it before parsing.
+  const fetchedAt = new Date(raw.includes('T') ? raw : raw + 'Z');
+  return Date.now() - fetchedAt.getTime() < WORKFLOW_CACHE_MAX_AGE_MS;
+}

--- a/tests/unit/boot-workflow-check.test.ts
+++ b/tests/unit/boot-workflow-check.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
 import { getSchema } from '../../src/storage/schema';
-import { isWorkflowDataFresh } from '../../src/plugins/notifications/handler';
+import { isWorkflowDataFresh } from '../../src/plugins/notifications/workflow-cache';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/unit/encryption.test.ts
+++ b/tests/unit/encryption.test.ts
@@ -107,8 +107,12 @@ describe('Encryption', () => {
     process.env.JARVIS_CONFIG_DIR = configDir;
     process.env.COMPUTERNAME = 'CI-MACHINE';
     try {
-      const key1 = getEncryptionKey();
-      const key2 = getEncryptionKey();
+      // Mock electron with no safeStorage to simulate running outside of an Electron
+      // main-process context (e.g. unit tests / CI) without triggering a binary download.
+      const { key1, key2 } = withMockedElectron({}, () => ({
+        key1: getEncryptionKey(),
+        key2: getEncryptionKey(),
+      }));
       expect(key1.length).toBe(32);
       expect(key2.toString('hex')).toBe(key1.toString('hex'));
       expect(fs.existsSync(path.join(configDir, 'keystore.fallback.bin'))).toBe(true);
@@ -131,9 +135,11 @@ describe('Encryption', () => {
     process.env.JARVIS_CONFIG_DIR = configDir;
     process.env.COMPUTERNAME = 'FIRST-HOST';
     try {
-      const key1 = getEncryptionKey();
+      // Mock electron with no safeStorage to simulate running outside of an Electron
+      // main-process context without triggering a binary download.
+      const key1 = withMockedElectron({}, () => getEncryptionKey());
       process.env.COMPUTERNAME = 'SECOND-HOST';
-      const key2 = getEncryptionKey();
+      const key2 = withMockedElectron({}, () => getEncryptionKey());
       expect(key2.toString('hex')).toBe(key1.toString('hex'));
     } finally {
       if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;

--- a/tests/unit/encryption.test.ts
+++ b/tests/unit/encryption.test.ts
@@ -98,35 +98,48 @@ describe('Encryption', () => {
     }
   });
 
-  it('should fall back to COMPUTERNAME-based key derivation when env key is absent', () => {
+  it('should fall back to a persisted random key when env key is absent', () => {
     const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    const originalConfigDir = process.env.JARVIS_CONFIG_DIR;
     const originalComputerName = process.env.COMPUTERNAME;
     delete process.env.JARVIS_ENCRYPTION_KEY;
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-encryption-fallback-'));
+    process.env.JARVIS_CONFIG_DIR = configDir;
     process.env.COMPUTERNAME = 'CI-MACHINE';
     try {
-      expect(getEncryptionKey().toString('hex')).toBe(
-        deriveKey('jarvis-local-CI-MACHINE').toString('hex'),
-      );
+      const key1 = getEncryptionKey();
+      const key2 = getEncryptionKey();
+      expect(key1.length).toBe(32);
+      expect(key2.toString('hex')).toBe(key1.toString('hex'));
+      expect(fs.existsSync(path.join(configDir, 'keystore.fallback.bin'))).toBe(true);
     } finally {
       if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
       else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+      if (originalConfigDir === undefined) delete process.env.JARVIS_CONFIG_DIR;
+      else process.env.JARVIS_CONFIG_DIR = originalConfigDir;
       if (originalComputerName === undefined) delete process.env.COMPUTERNAME;
       else process.env.COMPUTERNAME = originalComputerName;
     }
   });
 
-  it('should use jarvis-default when COMPUTERNAME is missing', () => {
+  it('should not derive fallback key from COMPUTERNAME', () => {
     const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    const originalConfigDir = process.env.JARVIS_CONFIG_DIR;
     const originalComputerName = process.env.COMPUTERNAME;
     delete process.env.JARVIS_ENCRYPTION_KEY;
-    delete process.env.COMPUTERNAME;
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-encryption-fallback-'));
+    process.env.JARVIS_CONFIG_DIR = configDir;
+    process.env.COMPUTERNAME = 'FIRST-HOST';
     try {
-      expect(getEncryptionKey().toString('hex')).toBe(
-        deriveKey('jarvis-local-jarvis-default').toString('hex'),
-      );
+      const key1 = getEncryptionKey();
+      process.env.COMPUTERNAME = 'SECOND-HOST';
+      const key2 = getEncryptionKey();
+      expect(key2.toString('hex')).toBe(key1.toString('hex'));
     } finally {
       if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
       else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+      if (originalConfigDir === undefined) delete process.env.JARVIS_CONFIG_DIR;
+      else process.env.JARVIS_CONFIG_DIR = originalConfigDir;
       if (originalComputerName === undefined) delete process.env.COMPUTERNAME;
       else process.env.COMPUTERNAME = originalComputerName;
     }
@@ -159,17 +172,27 @@ describe('Encryption', () => {
 
   it('should fall back when mocked safeStorage reports unavailable encryption', () => {
     const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    const originalConfigDir = process.env.JARVIS_CONFIG_DIR;
     const originalComputerName = process.env.COMPUTERNAME;
     delete process.env.JARVIS_ENCRYPTION_KEY;
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-encryption-fallback-'));
+    process.env.JARVIS_CONFIG_DIR = configDir;
     process.env.COMPUTERNAME = 'FALLBACK-PC';
     try {
-      const key = withMockedElectron({
+      const key1 = withMockedElectron({
         safeStorage: { isEncryptionAvailable: () => false },
       }, () => getEncryptionKey());
-      expect(key.toString('hex')).toBe(deriveKey('jarvis-local-FALLBACK-PC').toString('hex'));
+      const key2 = withMockedElectron({
+        safeStorage: { isEncryptionAvailable: () => false },
+      }, () => getEncryptionKey());
+      expect(key1.length).toBe(32);
+      expect(key2.toString('hex')).toBe(key1.toString('hex'));
+      expect(fs.existsSync(path.join(configDir, 'keystore.fallback.bin'))).toBe(true);
     } finally {
       if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
       else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+      if (originalConfigDir === undefined) delete process.env.JARVIS_CONFIG_DIR;
+      else process.env.JARVIS_CONFIG_DIR = originalConfigDir;
       if (originalComputerName === undefined) delete process.env.COMPUTERNAME;
       else process.env.COMPUTERNAME = originalComputerName;
     }

--- a/tests/unit/encryption.test.ts
+++ b/tests/unit/encryption.test.ts
@@ -1,5 +1,34 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
 import { describe, it, expect } from 'vitest';
-import { encrypt, decrypt, deriveKey, generateKey } from '../../src/storage/encryption';
+import { encrypt, decrypt, deriveKey, generateKey, getEncryptionKey } from '../../src/storage/encryption';
+
+const nodeRequire = createRequire(import.meta.url);
+
+function withMockedElectron<T>(exportsObj: unknown, run: () => T): T {
+  const moduleId = nodeRequire.resolve('electron');
+  const originalEntry = nodeRequire.cache[moduleId];
+  nodeRequire.cache[moduleId] = {
+    id: moduleId,
+    filename: moduleId,
+    loaded: true,
+    exports: exportsObj,
+    children: [],
+    paths: [],
+    isPreloading: false,
+    parent: undefined,
+    path: path.dirname(moduleId),
+    require: nodeRequire,
+  } as unknown as NodeJS.Module;
+  try {
+    return run();
+  } finally {
+    if (originalEntry) nodeRequire.cache[moduleId] = originalEntry;
+    else delete nodeRequire.cache[moduleId];
+  }
+}
 
 describe('Encryption', () => {
   it('should encrypt and decrypt a string correctly', () => {
@@ -54,5 +83,95 @@ describe('Encryption', () => {
   it('should generate a 32-byte key', () => {
     const key = generateKey();
     expect(key.length).toBe(32);
+  });
+
+  it('should use JARVIS_ENCRYPTION_KEY when provided', () => {
+    const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    process.env.JARVIS_ENCRYPTION_KEY = 'deterministic-test-secret';
+    try {
+      expect(getEncryptionKey().toString('hex')).toBe(
+        deriveKey('deterministic-test-secret').toString('hex'),
+      );
+    } finally {
+      if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
+      else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+    }
+  });
+
+  it('should fall back to COMPUTERNAME-based key derivation when env key is absent', () => {
+    const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    const originalComputerName = process.env.COMPUTERNAME;
+    delete process.env.JARVIS_ENCRYPTION_KEY;
+    process.env.COMPUTERNAME = 'CI-MACHINE';
+    try {
+      expect(getEncryptionKey().toString('hex')).toBe(
+        deriveKey('jarvis-local-CI-MACHINE').toString('hex'),
+      );
+    } finally {
+      if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
+      else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+      if (originalComputerName === undefined) delete process.env.COMPUTERNAME;
+      else process.env.COMPUTERNAME = originalComputerName;
+    }
+  });
+
+  it('should use jarvis-default when COMPUTERNAME is missing', () => {
+    const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    const originalComputerName = process.env.COMPUTERNAME;
+    delete process.env.JARVIS_ENCRYPTION_KEY;
+    delete process.env.COMPUTERNAME;
+    try {
+      expect(getEncryptionKey().toString('hex')).toBe(
+        deriveKey('jarvis-local-jarvis-default').toString('hex'),
+      );
+    } finally {
+      if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
+      else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+      if (originalComputerName === undefined) delete process.env.COMPUTERNAME;
+      else process.env.COMPUTERNAME = originalComputerName;
+    }
+  });
+
+  it('should use mocked safeStorage when available and persist the key', () => {
+    const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    const originalConfigDir = process.env.JARVIS_CONFIG_DIR;
+    delete process.env.JARVIS_ENCRYPTION_KEY;
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-encryption-'));
+    process.env.JARVIS_CONFIG_DIR = configDir;
+    try {
+      const safeStorage = {
+        isEncryptionAvailable: () => true,
+        encryptString: (value: string) => Buffer.from(`enc:${value}`, 'utf8'),
+        decryptString: (value: Buffer) => value.toString('utf8').replace(/^enc:/, ''),
+      };
+      const key1 = withMockedElectron({ safeStorage }, () => getEncryptionKey());
+      const key2 = withMockedElectron({ safeStorage }, () => getEncryptionKey());
+      expect(key1.length).toBe(32);
+      expect(key2.toString('hex')).toBe(key1.toString('hex'));
+      expect(fs.existsSync(path.join(configDir, 'keystore.bin'))).toBe(true);
+    } finally {
+      if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
+      else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+      if (originalConfigDir === undefined) delete process.env.JARVIS_CONFIG_DIR;
+      else process.env.JARVIS_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  it('should fall back when mocked safeStorage reports unavailable encryption', () => {
+    const originalEnvKey = process.env.JARVIS_ENCRYPTION_KEY;
+    const originalComputerName = process.env.COMPUTERNAME;
+    delete process.env.JARVIS_ENCRYPTION_KEY;
+    process.env.COMPUTERNAME = 'FALLBACK-PC';
+    try {
+      const key = withMockedElectron({
+        safeStorage: { isEncryptionAvailable: () => false },
+      }, () => getEncryptionKey());
+      expect(key.toString('hex')).toBe(deriveKey('jarvis-local-FALLBACK-PC').toString('hex'));
+    } finally {
+      if (originalEnvKey === undefined) delete process.env.JARVIS_ENCRYPTION_KEY;
+      else process.env.JARVIS_ENCRYPTION_KEY = originalEnvKey;
+      if (originalComputerName === undefined) delete process.env.COMPUTERNAME;
+      else process.env.COMPUTERNAME = originalComputerName;
+    }
   });
 });

--- a/tests/unit/github-workflows.test.ts
+++ b/tests/unit/github-workflows.test.ts
@@ -246,6 +246,37 @@ describe('fetchWorkflowRuns', () => {
     expect(callCount).toBe(2);
   });
 
+  it('stops after two pages even when both pages are full', async () => {
+    const makePage = (start: number, count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: start + i,
+        name: 'CI',
+        workflow_id: 42,
+        head_branch: 'main',
+        head_sha: 'abc',
+        event: 'push',
+        status: 'completed',
+        conclusion: 'success',
+        run_number: start + i,
+        run_started_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:01:00Z',
+        html_url: `https://github.com/o/r/actions/runs/${start + i}`,
+      }));
+
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ workflow_runs: makePage(1, 50), total_count: 150 }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ workflow_runs: makePage(51, 50), total_count: 150 }), { status: 200 });
+    });
+
+    const result = await fetchWorkflowRuns('token', 'owner/repo', '2024-01-01');
+    expect(result).toHaveLength(100);
+    expect(callCount).toBe(2);
+  });
+
   it('stops paginating when fewer than 50 runs are returned', async () => {
     globalThis.fetch = vi.fn(async () =>
       new Response(JSON.stringify({ workflow_runs: [{ id: 1, name: 'CI', workflow_id: 1, head_branch: 'main', head_sha: 'a', event: 'push', status: 'completed', conclusion: 'success', run_number: 1, run_started_at: '', updated_at: '', html_url: '' }], total_count: 1 }), { status: 200 }),
@@ -334,6 +365,53 @@ describe('fetchAndStoreWorkflowData', () => {
     await fetchAndStoreWorkflowData(db, 'token', 'owner/repo');
     const res = db.exec(`SELECT COUNT(*) FROM github_workflow_jobs`);
     expect(res[0].values[0][0]).toBe(1);
+  });
+
+  it('stores jobs even when failing job log retrieval returns non-OK', async () => {
+    const failRun = makeRun(1, { conclusion: 'failure' });
+    const failedJob = makeJob(10, 1, { conclusion: 'failure' });
+    const successJob = makeJob(11, 1, { conclusion: 'success' });
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes('/actions/runs') && !url.includes('/jobs') && !url.includes('/logs')) {
+        return new Response(JSON.stringify({ workflow_runs: [failRun], total_count: 1 }), { status: 200 });
+      }
+      if (url.includes('/actions/jobs/') && url.includes('/logs')) {
+        return new Response('unavailable', { status: 503 });
+      }
+      if (url.includes('/jobs')) {
+        return new Response(JSON.stringify({ jobs: [failedJob, successJob] }), { status: 200 });
+      }
+      return new Response('unexpected', { status: 500 });
+    });
+
+    await fetchAndStoreWorkflowData(db, 'token', 'owner/repo');
+    const jobs = db.exec(`SELECT id, log_excerpt FROM github_workflow_jobs ORDER BY id ASC`);
+    expect(jobs[0].values).toEqual([
+      ['10', null],
+      ['11', null],
+    ]);
+  });
+
+  it('handles multiple failing runs from the same workflow', async () => {
+    const failRun1 = makeRun(1, { conclusion: 'failure', workflowId: 77 });
+    const failRun2 = makeRun(2, { conclusion: 'failure', workflowId: 77 });
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes('/actions/runs') && !url.includes('/jobs') && !url.includes('/logs')) {
+        return new Response(JSON.stringify({ workflow_runs: [failRun1, failRun2], total_count: 2 }), { status: 200 });
+      }
+      if (url.includes('/jobs')) {
+        return new Response(JSON.stringify({ jobs: [] }), { status: 200 });
+      }
+      return new Response('', { status: 200 });
+    });
+
+    const result = await fetchAndStoreWorkflowData(db, 'token', 'owner/repo');
+    expect(result.runsStored).toBe(2);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
   });
 
   it('returns 0 when no runs are found', async () => {

--- a/tests/unit/groups.test.ts
+++ b/tests/unit/groups.test.ts
@@ -67,6 +67,66 @@ describe('Groups service', () => {
     expect(tableNames).toContain('group_github_repos');
   });
 
+  // ── Ruddr project cache helpers ─────────────────────────────────────────────
+
+  it('parseRuddrNames handles null, JSON array, and legacy plain strings', () => {
+    expect(parseRuddrNames(null)).toEqual([]);
+    expect(parseRuddrNames('["A", 123, "B"]')).toEqual(['A', 'B']);
+    expect(parseRuddrNames('Legacy Project')).toEqual(['Legacy Project']);
+  });
+
+  it('save/load/lookup Ruddr projects and preserve note/cloud values on update', () => {
+    saveRuddrProjectsToDb(db, [
+      { name: 'Project A', path: '/projects/a', note: 'first note', cloud_folder_url: 'https://example.com/a' },
+      { name: 'Project B', path: '/projects/b', note: null, cloud_folder_url: null },
+    ]);
+
+    const loaded = loadRuddrProjectsFromDb(db);
+    expect(loaded).toHaveLength(2);
+    expect(loaded.map((p) => p.path).sort()).toEqual(['/projects/a', '/projects/b']);
+
+    const found = lookupRuddrProject(db, 'project a');
+    expect(found).not.toBeNull();
+    expect(found!.path).toBe('/projects/a');
+
+    saveRuddrProjectsToDb(db, [
+      { name: 'Project A Renamed', path: '/projects/a', note: null, cloud_folder_url: null },
+      { name: 'Project B', path: '/projects/b', note: null, cloud_folder_url: null },
+    ]);
+
+    const updated = lookupRuddrProject(db, 'project a renamed');
+    expect(updated).not.toBeNull();
+    expect(updated!.note).toBe('first note');
+    expect(updated!.cloud_folder_url).toBe('https://example.com/a');
+  });
+
+  it('saveRuddrProjectsToDb removes stale projects only when a non-empty list is provided', () => {
+    saveRuddrProjectsToDb(db, [{ name: 'Keep Me', path: '/projects/keep' }]);
+    saveRuddrProjectsToDb(db, []);
+    expect(loadRuddrProjectsFromDb(db)).toHaveLength(1);
+
+    saveRuddrProjectsToDb(db, [{ name: 'Replace Me', path: '/projects/replace' }]);
+    const loaded = loadRuddrProjectsFromDb(db);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].path).toBe('/projects/replace');
+  });
+
+  it('can update Ruddr note and cloud folder URL independently', () => {
+    saveRuddrProjectsToDb(db, [{ name: 'Project C', path: '/projects/c' }]);
+
+    updateRuddrProjectNote(db, '/projects/c', 'updated note');
+    updateRuddrProjectCloudFolderUrl(db, '/projects/c', 'https://example.com/c');
+
+    const updated = lookupRuddrProject(db, 'Project C');
+    expect(updated).not.toBeNull();
+    expect(updated!.note).toBe('updated note');
+    expect(updated!.cloud_folder_url).toBe('https://example.com/c');
+  });
+
+  it('lookupRuddrProject returns null when no project matches', () => {
+    expect(lookupRuddrProject(db, 'missing')).toBeNull();
+  });
+
   // ── CRUD ────────────────────────────────────────────────────────────────────
 
   it('createGroup returns a numeric id', () => {
@@ -146,6 +206,20 @@ describe('Groups service', () => {
     expect(detail!.localRepos).toHaveLength(1);
     expect(detail!.localRepos[0].id).toBe(rid);
     expect(detail!.localRepos[0].localPath).toBe('/home/user/proj');
+  });
+
+  it('getGroup falls back to localPath when local repo name is null', () => {
+    const gid = createGroup(db, 'FallbackName');
+    db.run("INSERT INTO local_repos (local_path, name) VALUES (?, NULL)", ['/home/user/no-name']);
+    const stmt = db.prepare('SELECT last_insert_rowid() AS id');
+    stmt.step();
+    const { id } = stmt.getAsObject() as { id: number };
+    stmt.free();
+    addLocalRepoToGroup(db, gid, id);
+
+    const detail = getGroup(db, gid);
+    expect(detail!.localRepos).toHaveLength(1);
+    expect(detail!.localRepos[0].name).toBe('/home/user/no-name');
   });
 
   it('listGroups reflects localRepoCount after add', () => {
@@ -257,116 +331,5 @@ describe('Groups service', () => {
     const d2 = getGroup(db, g2);
     expect(d1!.localRepos).toHaveLength(1);
     expect(d2!.localRepos).toHaveLength(1);
-  });
-});
-
-// ── Ruddr project functions ─────────────────────────────────────────────────
-
-describe('parseRuddrNames', () => {
-  it('returns empty array for null input', () => {
-    expect(parseRuddrNames(null)).toEqual([]);
-  });
-
-  it('returns empty array for undefined-like input', () => {
-    expect(parseRuddrNames(undefined as unknown as string | null)).toEqual([]);
-  });
-
-  it('parses a JSON array of strings', () => {
-    expect(parseRuddrNames('["Project A","Project B"]')).toEqual(['Project A', 'Project B']);
-  });
-
-  it('filters out non-string entries from JSON array', () => {
-    expect(parseRuddrNames('[42, "valid", null]')).toEqual(['valid']);
-  });
-
-  it('falls back to single-element array for plain string (legacy)', () => {
-    expect(parseRuddrNames('SingleProject')).toEqual(['SingleProject']);
-  });
-});
-
-describe('Ruddr project DB operations', () => {
-  let db: SqlJsDatabase;
-
-  beforeEach(async () => {
-    const SQL = await initSqlJs();
-    db = new SQL.Database();
-    db.run(getSchema());
-  });
-
-  afterEach(() => {
-    db.close();
-  });
-
-  it('loadRuddrProjectsFromDb returns empty array when no projects exist', () => {
-    expect(loadRuddrProjectsFromDb(db)).toEqual([]);
-  });
-
-  it('saveRuddrProjectsToDb inserts projects', () => {
-    saveRuddrProjectsToDb(db, [
-      { name: 'Alpha', path: '/projects/alpha' },
-      { name: 'Beta', path: '/projects/beta', note: 'urgent' },
-    ]);
-    const projects = loadRuddrProjectsFromDb(db);
-    expect(projects).toHaveLength(2);
-    expect(projects.find((p) => p.name === 'Alpha')).toBeDefined();
-    expect(projects.find((p) => p.name === 'Beta')?.note).toBe('urgent');
-  });
-
-  it('saveRuddrProjectsToDb upserts on conflict and deletes removed projects', () => {
-    saveRuddrProjectsToDb(db, [
-      { name: 'Keep', path: '/projects/keep' },
-      { name: 'Remove', path: '/projects/remove' },
-    ]);
-    // Second save removes /projects/remove and adds /projects/added
-    saveRuddrProjectsToDb(db, [
-      { name: 'Keep', path: '/projects/keep' },
-      { name: 'Added', path: '/projects/added' },
-    ]);
-    const projects = loadRuddrProjectsFromDb(db);
-    const names = projects.map((p) => p.name);
-    expect(names).toContain('Keep');
-    expect(names).toContain('Added');
-    expect(names).not.toContain('Remove');
-  });
-
-  it('saveRuddrProjectsToDb with empty input skips DELETE (size-zero guard)', () => {
-    saveRuddrProjectsToDb(db, [{ name: 'Lonely', path: '/projects/lonely' }]);
-    // Empty array — the DELETE branch is intentionally skipped; we verify
-    // the function does not throw and existing data is retained.
-    saveRuddrProjectsToDb(db, []);
-    expect(loadRuddrProjectsFromDb(db)).toHaveLength(1);
-  });
-
-  it('updateRuddrProjectNote updates the note', () => {
-    saveRuddrProjectsToDb(db, [{ name: 'Proj', path: '/projects/proj' }]);
-    updateRuddrProjectNote(db, '/projects/proj', 'new note');
-    const [p] = loadRuddrProjectsFromDb(db);
-    expect(p.note).toBe('new note');
-  });
-
-  it('updateRuddrProjectNote clears the note when null', () => {
-    saveRuddrProjectsToDb(db, [{ name: 'Proj', path: '/projects/proj', note: 'old' }]);
-    updateRuddrProjectNote(db, '/projects/proj', null);
-    const [p] = loadRuddrProjectsFromDb(db);
-    expect(p.note).toBeNull();
-  });
-
-  it('updateRuddrProjectCloudFolderUrl updates the URL', () => {
-    saveRuddrProjectsToDb(db, [{ name: 'Proj', path: '/projects/proj' }]);
-    updateRuddrProjectCloudFolderUrl(db, '/projects/proj', 'https://1drv.ms/folder');
-    const [p] = loadRuddrProjectsFromDb(db);
-    expect(p.cloud_folder_url).toBe('https://1drv.ms/folder');
-  });
-
-  it('lookupRuddrProject returns null for unknown name', () => {
-    expect(lookupRuddrProject(db, 'nonexistent')).toBeNull();
-  });
-
-  it('lookupRuddrProject returns the matching project (case-insensitive)', () => {
-    saveRuddrProjectsToDb(db, [{ name: 'MyProject', path: '/projects/myproject', note: 'note1' }]);
-    const p = lookupRuddrProject(db, 'myproject');
-    expect(p).not.toBeNull();
-    expect(p!.name).toBe('MyProject');
-    expect(p!.note).toBe('note1');
   });
 });


### PR DESCRIPTION
## Summary of Changes

Two test files triggered `require('electron')` without mocking the module. In CI, the `electron` npm package is installed as a dev dependency but its binary is absent — the package's `index.js` responds by calling `spawnSync` to download the binary, a blocking synchronous call that hangs until the 5-second test timeout fires.

**`tests/unit/encryption.test.ts`** — Two tests (`should fall back to a persisted random key when env key is absent` and `should not derive fallback key from COMPUTERNAME`) called `getEncryptionKey()` without mocking electron, unlike every other test in the file. Both are now wrapped with `withMockedElectron({})`, which makes `safeStorage` resolve to `undefined`, triggering the existing `try/catch` in `getEncryptionKey()` to fall through to the file-based key path as intended.

**`tests/unit/boot-workflow-check.test.ts`** — This test imported `isWorkflowDataFresh` from `handler.ts`, which has a static `import { ipcMain } from 'electron'` at module level — pulling electron in at load time. The fix extracts `isWorkflowDataFresh` (and its `WORKFLOW_CACHE_MAX_AGE_MS` constant) into a new electron-free module `src/plugins/notifications/workflow-cache.ts`. `handler.ts` now imports from that module, and the test imports from it directly.

**`.gitignore`** — Added `AppData/` to prevent accidentally committing user-specific runtime config files (one such file containing a bridge token was found staged and has been removed from tracking).

## Related Issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Tests

## How to Test

1. Run `npm test` — all 646 tests across 31 test files should pass.
2. Confirm `tests/unit/encryption.test.ts > Encryption > should fall back to a persisted random key when env key is absent` completes well within the 5-second timeout.
3. Confirm `tests/unit/boot-workflow-check.test.ts` passes without attempting to download the electron binary.

## Checklist

- [x] Tests pass (`npm test`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed