### PR TITLE
Improve bootup pipeline visibility with live progress banner

### DIFF
--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -44,6 +44,9 @@ interface AutoDismissRunResult {
   total: number;
 }
 
+/** Module-level flag so the pipeline only runs once per app session (survives remounts). */
+let autoDismissRanGlobally = false;
+
 async function runRecoverableStep(repoFullNames: string[]): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
   const logEntries: AutoDismissLogInput[] = [];
   let dismissed = 0;
@@ -1096,7 +1099,7 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
   const [autoDismissResult, setAutoDismissResult] = useState<AutoDismissRunResult | null>(null);
   const [autoDismissAcknowledged, setAutoDismissAcknowledged] = useState(false);
   const [autoDismissDone, setAutoDismissDone] = useState(false);
-  const autoDismissRan = useRef(false);
+  const [pipelineStatus, setPipelineStatus] = useState<'idle' | 'running' | 'done'>('idle');
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -1116,10 +1119,11 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
 
   useEffect(() => { void load(); }, [load]);
 
-  // Run the auto-dismiss pipeline once after summary is first available
+  // Run the auto-dismiss pipeline once per session after summary is first available
   useEffect(() => {
-    if (!summary || autoDismissRan.current) return;
-    autoDismissRan.current = true;
+    if (!summary || autoDismissRanGlobally) return;
+    autoDismissRanGlobally = true;
+    setPipelineStatus('running');
     const repoFullNames = summary.repos
       .filter((r) => r.notificationCount > 0 && r.linkedGithubRepo !== null)
       .map((r) => r.linkedGithubRepo!);
@@ -1130,11 +1134,12 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
       }
       if (result.total > 0) setAutoDismissResult(result);
       setAutoDismissDone(true);
+      setPipelineStatus('done');
     });
   }, [summary, load]);
 
   useEffect(() => {
-    if (!summary || !currentUserLogin) {
+    if (!summary || !currentUserLogin || !autoDismissDone) {
       setOwnRepoNotifications([]);
       return;
     }
@@ -1186,7 +1191,7 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
       });
 
     return () => { cancelled = true; };
-  }, [summary, currentUserLogin, dismissedNotifIds]);
+  }, [summary, currentUserLogin, dismissedNotifIds, autoDismissDone]);
 
   const handleOpenFolder = (localPath: string) => {
     window.jarvis.localOpenFolder(localPath);
@@ -1337,6 +1342,19 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
         active={cardFilter}
         onSelect={setCardFilter}
       />
+
+      {/* Pipeline in-progress banner — shown while auto-dismiss is checking notifications */}
+      {pipelineStatus === 'running' && (
+        <div class="dash-recoverable-banner dash-auto-dismiss-banner dash-pipeline-running">
+          <span class="dash-recoverable-icon dash-pipeline-running-icon">⟳</span>
+          <div class="dash-recoverable-body">
+            <span class="dash-recoverable-title">Checking stale notifications…</span>
+            <span class="dash-recoverable-detail">
+              Verifying {summary.totalNotifications} notification{summary.totalNotifications !== 1 ? 's' : ''} against GitHub to auto-dismiss closed issues, merged PRs, and recovered workflows
+            </span>
+          </div>
+        </div>
+      )}
 
       {/* Auto-dismiss summary banner — shown after the pipeline runs and dismissed something */}
       {autoDismissResult && !autoDismissAcknowledged && (

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -4007,6 +4007,22 @@ h5.ec-heading { font-size: 0.85rem; }
   color: #8ab4e8;
 }
 
+/* Pipeline in-progress state — pulsing icon to show background work */
+.dash-pipeline-running {
+  border-color: #4fc3f7;
+  background: #0a1e3a;
+  pointer-events: none;
+}
+
+.dash-pipeline-running-icon {
+  animation: dash-pipeline-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes dash-pipeline-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.5; transform: scale(0.85); }
+}
+
 /* ── Auto-dismiss history panel ──────────────────────────────────────────── */
 .adh-panel {
   background: #111827;


### PR DESCRIPTION
### Changes

- **Live progress banner**: While the auto-dismiss pipeline runs on bootup, a pulsing banner shows "Checking stale notifications..." with the exact notification count being verified against GitHub
- **No stale triage data**: The People First notification triage now waits until the pipeline finishes before loading, so you never see outdated cached notifications first
- **Runs once per session**: Switched from a component-level useRef to a module-level flag so switching tabs no longer re-triggers the pipeline

### Before
1. Dashboard loads cached data (including stale notifications)
2. Pipeline runs invisibly in background
3. Banner pops up: "Auto-dismissed 19 notifications" -- feels final but isn't
4. Switch tabs and back -> pipeline re-runs, another popup

### After
1. Dashboard loads -> pulsing banner: "Checking stale notifications... Verifying 23 notifications against GitHub"
2. Pipeline completes -> banner transitions to result summary
3. Switch tabs and back -> no re-run, no second popup
