### PR TITLE
Auto-dismiss notifications for deleted branches

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -73,6 +73,8 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.invoke('github:dismiss-notification', id),
   checkMergedDependabotPRs: () =>
     ipcRenderer.invoke('github:check-merged-dependabot-prs'),
+  checkDeletedBranches: () =>
+    ipcRenderer.invoke('github:check-deleted-branches'),
   getRunUrlForCheckSuite: (checkSuiteApiUrl: string) =>
     ipcRenderer.invoke('github:get-run-url-for-check-suite', checkSuiteApiUrl),
   githubGetPrState: (subjectUrl: string) =>

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -194,16 +194,39 @@ async function runClosedIssueStep(): Promise<{ dismissed: number; logEntries: Au
   return { dismissed, logEntries };
 }
 
+async function runDeletedBranchStep(): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
+  const logEntries: AutoDismissLogInput[] = [];
+  let dismissed = 0;
+  try {
+    const notifs = await window.jarvis.checkDeletedBranches();
+    for (const n of notifs) {
+      try {
+        await window.jarvis.dismissNotification(n.id);
+        logEntries.push({
+          notification_id: n.id,
+          reason: 'deleted_branch',
+          repo_full_name: n.repo_full_name,
+          subject_title: n.subject_title,
+          subject_type: n.subject_type,
+        });
+        dismissed++;
+      } catch { /* skip individual */ }
+    }
+  } catch { /* non-fatal */ }
+  return { dismissed, logEntries };
+}
+
 async function runAutoDismissPipeline(
   repoFullNames: string[],
 ): Promise<{ result: AutoDismissRunResult; logEntries: AutoDismissLogInput[] }> {
   const steps: AutoDismissStepResult[] = [];
   const allLog: AutoDismissLogInput[] = [];
 
-  const [rec, pr, issue] = await Promise.all([
+  const [rec, pr, issue, delBranch] = await Promise.all([
     runRecoverableStep(repoFullNames),
     runClosedPrStep(),
     runClosedIssueStep(),
+    runDeletedBranchStep(),
   ]);
 
   steps.push({ id: 'recovered-workflows', label: 'Recovered workflows', dismissed: rec.dismissed });
@@ -212,6 +235,8 @@ async function runAutoDismissPipeline(
   allLog.push(...pr.logEntries);
   steps.push({ id: 'closed-issues', label: 'Closed issues', dismissed: issue.dismissed });
   allLog.push(...issue.logEntries);
+  steps.push({ id: 'deleted-branches', label: 'Deleted branches', dismissed: delBranch.dismissed });
+  allLog.push(...delBranch.logEntries);
 
   return {
     result: { steps, total: steps.reduce((s, r) => s + r.dismissed, 0) },

--- a/src/plugins/notifications/handler.ts
+++ b/src/plugins/notifications/handler.ts
@@ -18,6 +18,7 @@ import {
   deleteNotification,
   markNotificationRead,
   listMergedDependabotPRNotifications,
+  listDeletedBranchNotifications,
 } from '../../services/github-notifications';
 import { loadGitHubAuth } from '../../services/github-oauth';
 import { saveDatabase } from '../../storage/database';
@@ -145,6 +146,17 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
       return await listMergedDependabotPRNotifications(db, auth.accessToken);
     } catch (err) {
       console.warn('[Jarvis] Could not check merged dependabot PRs:', err instanceof Error ? err.message : String(err));
+      return [];
+    }
+  });
+
+  ipcMain.handle('github:check-deleted-branches', async () => {
+    const auth = loadGitHubAuth(db);
+    if (!auth) return [];
+    try {
+      return await listDeletedBranchNotifications(db, auth.accessToken);
+    } catch (err) {
+      console.warn('[Jarvis] Could not check deleted branches:', err instanceof Error ? err.message : String(err));
       return [];
     }
   });

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1789,7 +1789,8 @@ export type AutoDismissReason =
   | 'closed_pr_merged_me'
   | 'closed_pr_closed_me'
   | 'closed_issue_me'
-  | 'closed_issue_via_pr';
+  | 'closed_issue_via_pr'
+  | 'deleted_branch';
 
 export interface AutoDismissLogInput {
   notification_id: string;
@@ -2161,6 +2162,10 @@ export interface JarvisApi {
 
 
   checkMergedDependabotPRs(): Promise<StoredNotification[]>;
+
+
+
+  checkDeletedBranches(): Promise<StoredNotification[]>;
 
 
 

--- a/src/services/github-notifications.ts
+++ b/src/services/github-notifications.ts
@@ -490,6 +490,107 @@ export async function listMergedDependabotPRNotifications(
   return merged;
 }
 
+// ── Deleted branch detection ───────────────────────────────────────────────────
+
+const BRANCH_FROM_TITLE_RE = /\bfor\s+(\S+)\s+branch\b/i;
+
+function extractBranchFromTitle(title: string): string | null {
+  const m = title.match(BRANCH_FROM_TITLE_RE);
+  return m ? m[1] : null;
+}
+
+async function fetchOneBranchPage(
+  accessToken: string,
+  pageUrl: string,
+): Promise<{ names: string[]; next: string | null }> {
+  const res = await fetch(pageUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!res.ok) return { names: [], next: null };
+  const json = (await res.json()) as Array<{ name: string }>;
+  const linkH = res.headers.get('Link');
+  const nx = linkH?.match(/<([^>]+)>;\s*rel="next"/);
+  return { names: json.map((b) => b.name), next: nx ? nx[1] : null };
+}
+
+async function fetchLiveBranchNames(
+  accessToken: string,
+  repoFullName: string,
+): Promise<Set<string>> {
+  const [owner, repo] = repoFullName.split('/');
+  const branchNames = new Set<string>();
+  let url: string | null = `${GITHUB_API_BASE}/repos/${owner}/${repo}/branches?per_page=100`;
+
+  for (let page = 0; url !== null && page < 3; page++) {
+    const pageData = await fetchOneBranchPage(accessToken, url);
+    for (const name of pageData.names) branchNames.add(name);
+    url = pageData.next;
+  }
+
+  return branchNames;
+}
+
+/**
+ * Scans all stored unread CheckSuite/WorkflowRun notifications and checks whether
+ * the branch referenced in the subject title still exists on the remote. Returns
+ * notifications whose branches have been deleted (404 from the branches API).
+ * Uses a single `GET /repos/{owner}/{repo}/branches` call per repo for efficiency.
+ */
+export async function listDeletedBranchNotifications(
+  db: SqlJsDatabase,
+  accessToken: string,
+): Promise<StoredNotification[]> {
+  const stmt = db.prepare(`
+    SELECT id, repo_full_name, repo_owner, subject_type, subject_title, subject_url,
+           subject_actor_login, subject_actor_type, reason, unread, updated_at, fetched_at
+    FROM github_notifications
+    WHERE unread = 1 AND subject_type IN ('CheckSuite', 'WorkflowRun')
+    ORDER BY repo_full_name, updated_at DESC
+  `);
+  const rows: StoredNotification[] = [];
+  while (stmt.step()) rows.push(stmt.getAsObject() as unknown as StoredNotification);
+  stmt.free();
+
+  // Group unique (repo, branch) pairs to minimise API calls
+  const repoBranches = new Map<string, Set<string>>();
+  const notifByKey = new Map<string, StoredNotification[]>();
+
+  for (const n of rows) {
+    const branch = extractBranchFromTitle(n.subject_title);
+    if (!branch) continue;
+    const key = `${n.repo_full_name}::${branch}`;
+    if (!notifByKey.has(key)) notifByKey.set(key, []);
+    notifByKey.get(key)!.push(n);
+    if (!repoBranches.has(n.repo_full_name)) repoBranches.set(n.repo_full_name, new Set());
+    repoBranches.get(n.repo_full_name)!.add(branch);
+  }
+
+  if (repoBranches.size === 0) return [];
+
+  const deleted: StoredNotification[] = [];
+
+  for (const [repoFullName, branchesToCheck] of repoBranches) {
+    try {
+      const liveBranches = await fetchLiveBranchNames(accessToken, repoFullName);
+      for (const branch of branchesToCheck) {
+        if (!liveBranches.has(branch)) {
+          const key = `${repoFullName}::${branch}`;
+          const notifs = notifByKey.get(key) ?? [];
+          deleted.push(...notifs);
+        }
+      }
+    } catch {
+      // Non-fatal per repo — skip
+    }
+  }
+
+  return deleted;
+}
+
 /**
  * Calls the GitHub API to mark a notification thread as done (removes it from GitHub inbox).
  * DELETE /notifications/threads/{thread_id} — returns 204 No Content.

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -90,6 +90,7 @@ const EXPECTED_CHANNELS = [
   'github:list-issue-notifications',
   'github:dismiss-notification',
   'github:check-merged-dependabot-prs',
+  'github:check-deleted-branches',
   'github:log-auto-dismiss',
   'github:list-auto-dismiss-log',
   'github:auto-dismiss-stats',


### PR DESCRIPTION
When a PR is merged, the source branch is often deleted but CI failure notifications for that branch persist in your inbox. This adds a new auto-dismiss step to the boot pipeline that:

1. Scans all stored unread CheckSuite/WorkflowRun notifications
2. Extracts the branch name from the subject title (e.g. \CI workflow run for fix/something branch\)
3. Fetches live branches from GitHub (\GET /repos/{owner}/{repo}/branches\) per repo (pagination supported up to 3 pages)
4. Dismisses any notification whose branch no longer exists on the remote
5. Logs the dismissals with reason \deleted_branch\ in the auto-dismiss audit log

This runs alongside the existing recovered-workflows, closed-PRs, and closed-issues auto-dismiss steps.