### PR TITLE
Add dismiss-all button for 'Other notifications' group on repo dashboard

### DIFF
--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -547,8 +547,9 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
     }
   };
 
-  const handleDismissGroup = async (workflowName: string, ids: string[]) => {
-    setDismissingGroup(workflowName);
+  const handleDismissGroup = async (workflowName: string | null, ids: string[]) => {
+    const key = workflowName ?? '__other__';
+    setDismissingGroup(key);
     let dismissed = 0;
     for (const id of ids) {
       try {
@@ -649,6 +650,15 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
                 )}
               </span>
               <span class="dash-notif-group-count">{group.notifications.length}</span>
+              {!group.workflowName && (
+                <button
+                  class={`dash-dismiss-group-btn${dismissingGroup === '__other__' ? ' dash-dismiss-group-btn--busy' : ''}`}
+                  disabled={dismissingGroup === '__other__'}
+                  onClick={() => void handleDismissGroup(null, group.notifications.map((n) => n.id))}
+                >
+                  {dismissingGroup === '__other__' ? <span class="dismiss-spinner" /> : 'Dismiss all'}
+                </button>
+              )}
               {group.workflowName && checkingRecovery && (
                 <span class="dash-group-status dash-group-status--checking">checking…</span>
               )}


### PR DESCRIPTION
The **'Other notifications'** group (containing non-workflow notifications like Issues, Discussions, Pull Requests) was missing a dismiss-all button, unlike workflow groups which already had one.

**Changes in \DashboardPanel.tsx\:**
- Updated \handleDismissGroup\ to accept \string | null\ (uses \'__other__'\ as sentinel key when null)
- Added a dismiss-all button for the 'Other notifications' group using the same pattern as workflow groups (busy state, spinner, disabled during dismissal)