### PR TITLE
fix(ipc): add input validation guards and standardize error responses

### DIFF
--- a/src/plugins/agents/handler.ts
+++ b/src/plugins/agents/handler.ts
@@ -51,16 +51,16 @@ export function registerHandlers(
       scopeValue: string,
       workflowFilter?: string,
     ) => {
-      if (typeof agentId !== 'number') return { error: 'Invalid agentId' };
-      if (!['repo', 'org', 'global'].includes(scopeType)) return { error: 'Invalid scopeType' };
-      if (typeof scopeValue !== 'string' || scopeValue.length === 0) return { error: 'Invalid scopeValue' };
-      if (workflowFilter !== undefined && typeof workflowFilter !== 'string') return { error: 'Invalid workflowFilter' };
+      if (typeof agentId !== 'number') return { ok: false, error: 'Invalid agentId' };
+      if (!['repo', 'org', 'global'].includes(scopeType)) return { ok: false, error: 'Invalid scopeType' };
+      if (typeof scopeValue !== 'string' || scopeValue.length === 0) return { ok: false, error: 'Invalid scopeValue' };
+      if (workflowFilter !== undefined && typeof workflowFilter !== 'string') return { ok: false, error: 'Invalid workflowFilter' };
 
       const model = getConfigValue(db, 'selected_ollama_model');
-      if (!model) return { error: 'No Ollama model selected. Please select one in settings.' };
+      if (!model) return { ok: false, error: 'No Ollama model selected. Please select one in settings.' };
 
       const agentDef = getAgentDefinition(db, agentId);
-      if (!agentDef) return { error: `Agent definition ${agentId} not found` };
+      if (!agentDef) return { ok: false, error: `Agent definition ${agentId} not found` };
 
       const sessionId = createAgentSession(db, agentId, scopeType, scopeValue);
       saveDatabase();

--- a/src/plugins/chat/handler.ts
+++ b/src/plugins/chat/handler.ts
@@ -238,6 +238,7 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
   });
 
   ipcMain.handle('window:adjust-width', (event, delta: number) => {
+    if (typeof delta !== 'number') return { ok: false };
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return { ok: false };
     const [w, h] = win.getSize();

--- a/src/plugins/notifications/handler.ts
+++ b/src/plugins/notifications/handler.ts
@@ -60,14 +60,14 @@ async function fetchTokenRateLimitRemaining(token: string): Promise<number | nul
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('github:fetch-notifications', async () => {
     const auth = loadGitHubAuth(db);
-    if (!auth) return { error: 'Not authenticated' };
+    if (!auth) return { ok: false, error: 'Not authenticated' };
     try {
       const notifications = await fetchNotifications(auth.accessToken);
       storeNotifications(db, notifications);
       saveDatabase();
       return getNotificationCounts(db);
     } catch (err) {
-      return { error: err instanceof Error ? err.message : String(err) };
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
   });
 
@@ -76,30 +76,30 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
   });
 
   ipcMain.handle('github:fetch-notifications-for-owner', async (_event, owner: string) => {
-    if (typeof owner !== 'string' || owner.length === 0) return { error: 'Invalid owner' };
+    if (typeof owner !== 'string' || owner.length === 0) return { ok: false, error: 'Invalid owner' };
     const auth = loadGitHubAuth(db);
-    if (!auth) return { error: 'Not authenticated' };
+    if (!auth) return { ok: false, error: 'Not authenticated' };
     try {
       const notifications = await fetchNotifications(auth.accessToken);
       storeNotificationsForOwner(db, owner, notifications);
       saveDatabase();
       return getNotificationCounts(db);
     } catch (err) {
-      return { error: err instanceof Error ? err.message : String(err) };
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
   });
 
   ipcMain.handle('github:fetch-notifications-for-repo', async (_event, repoFullName: string) => {
-    if (typeof repoFullName !== 'string' || !repoFullName.includes('/')) return { error: 'Invalid repo' };
+    if (typeof repoFullName !== 'string' || !repoFullName.includes('/')) return { ok: false, error: 'Invalid repo' };
     const auth = loadGitHubAuth(db);
-    if (!auth) return { error: 'Not authenticated' };
+    if (!auth) return { ok: false, error: 'Not authenticated' };
     try {
       const notifications = await fetchNotificationsForRepo(auth.accessToken, repoFullName);
       storeNotificationsForRepo(db, repoFullName, notifications);
       saveDatabase();
       return getNotificationCounts(db);
     } catch (err) {
-      return { error: err instanceof Error ? err.message : String(err) };
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
   });
 

--- a/src/plugins/repos/handler.ts
+++ b/src/plugins/repos/handler.ts
@@ -5,7 +5,7 @@ import type { BrowserWindow } from 'electron';
 
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('github:search-repos', (_event, query: string) => {
-    if (!query || query.trim().length < 2) return [];
+    if (typeof query !== 'string' || !query || query.trim().length < 2) return [];
 
     try {
       const words = query.trim().split(/\s+/).filter((w) => w.length > 0);

--- a/tests/unit/agents-handler.test.ts
+++ b/tests/unit/agents-handler.test.ts
@@ -151,22 +151,22 @@ describe('Agents plugin — IPC handlers', () => {
   describe('agents:run', () => {
     it('returns error for non-number agentId', async () => {
       const result = await callHandler('agents:run', 'bad', 'repo', 'owner/repo');
-      expect(result).toEqual({ error: 'Invalid agentId' });
+      expect(result).toEqual({ ok: false, error: 'Invalid agentId' });
     });
 
     it('returns error for invalid scopeType', async () => {
       const result = await callHandler('agents:run', 1, 'invalid', 'owner/repo');
-      expect(result).toEqual({ error: 'Invalid scopeType' });
+      expect(result).toEqual({ ok: false, error: 'Invalid scopeType' });
     });
 
     it('returns error for empty scopeValue', async () => {
       const result = await callHandler('agents:run', 1, 'repo', '');
-      expect(result).toEqual({ error: 'Invalid scopeValue' });
+      expect(result).toEqual({ ok: false, error: 'Invalid scopeValue' });
     });
 
     it('returns error for non-string workflowFilter', async () => {
       const result = await callHandler('agents:run', 1, 'repo', 'owner/repo', 42);
-      expect(result).toEqual({ error: 'Invalid workflowFilter' });
+      expect(result).toEqual({ ok: false, error: 'Invalid workflowFilter' });
     });
 
     it('returns error when no Ollama model is selected', async () => {

--- a/tests/unit/handler-validation.test.ts
+++ b/tests/unit/handler-validation.test.ts
@@ -204,6 +204,28 @@ describe('IPC handler input validation', () => {
 
   // ── repos handlers ────────────────────────────────────────────────────────
 
+  describe('github:search-repos', () => {
+    it('returns empty array for non-string query', async () => {
+      const result = await callHandler('github:search-repos', 123);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array for undefined query', async () => {
+      const result = await callHandler('github:search-repos', undefined);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array for empty string query', async () => {
+      const result = await callHandler('github:search-repos', '');
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array for single character query', async () => {
+      const result = await callHandler('github:search-repos', 'a');
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('github:list-repos-for-org', () => {
     it('accepts null orgLogin (personal repos)', async () => {
       const result = await callHandler('github:list-repos-for-org', null);
@@ -280,6 +302,23 @@ describe('IPC handler input validation', () => {
 
   // ── chat handler ──────────────────────────────────────────────────────────
 
+  describe('window:adjust-width', () => {
+    it('returns { ok: false } for non-number delta', () => {
+      const result = callHandler('window:adjust-width', 'not a number');
+      expect(result).toEqual({ ok: false });
+    });
+
+    it('returns { ok: false } for undefined delta', () => {
+      const result = callHandler('window:adjust-width', undefined);
+      expect(result).toEqual({ ok: false });
+    });
+
+    it('returns { ok: false } when no window exists', () => {
+      const result = callHandler('window:adjust-width', 100);
+      expect(result).toEqual({ ok: false });
+    });
+  });
+
   describe('chat:send', () => {
     it('returns error when messages is not an array', () => {
       const result = callHandler('chat:send', 'hello');
@@ -348,22 +387,22 @@ describe('IPC handler input validation', () => {
   describe('agents:run', () => {
     it('returns error for non-number agentId', async () => {
       const result = await callHandler('agents:run', 'bad', 'repo', 'owner/repo');
-      expect(result).toEqual({ error: 'Invalid agentId' });
+      expect(result).toEqual({ ok: false, error: 'Invalid agentId' });
     });
 
     it('returns error for invalid scopeType', async () => {
       const result = await callHandler('agents:run', 1, 'invalid', 'owner/repo');
-      expect(result).toEqual({ error: 'Invalid scopeType' });
+      expect(result).toEqual({ ok: false, error: 'Invalid scopeType' });
     });
 
     it('returns error for empty scopeValue', async () => {
       const result = await callHandler('agents:run', 1, 'repo', '');
-      expect(result).toEqual({ error: 'Invalid scopeValue' });
+      expect(result).toEqual({ ok: false, error: 'Invalid scopeValue' });
     });
 
     it('returns error for non-string workflowFilter', async () => {
       const result = await callHandler('agents:run', 1, 'repo', 'owner/repo', 42);
-      expect(result).toEqual({ error: 'Invalid workflowFilter' });
+      expect(result).toEqual({ ok: false, error: 'Invalid workflowFilter' });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes all issues identified in #180: IPC Input Validation Coverage Gaps

### Changes Made

#### 🔴 High Priority Fixes
- **`window:adjust-width`**: Added `typeof delta !== 'number'` guard to prevent silent width calculation corruption when non-number values are passed
- **`github:search-repos`**: Added `typeof query !== 'string'` guard to prevent `TypeError` when non-string query is passed

#### 🟡 Medium Priority Fixes  
- **Standardized error response shape**: Changed all error returns from `{ error: '...' }` to `{ ok: false, error: '...' }` for consistency:
  - `agents:run` handler (4 validation checks)
  - `github:fetch-notifications` handler
  - `github:fetch-notifications-for-owner` handler
  - `github:fetch-notifications-for-repo` handler

#### 🧪 Test Coverage
- Added validation tests for `window:adjust-width` (3 test cases)
- Added validation tests for `github:search-repos` (4 test cases)
- Updated existing `agents:run` tests to match new error response shape

### Files Modified
- `src/plugins/chat/handler.ts` - Added typeof guard
- `src/plugins/repos/handler.ts` - Added typeof guard
- `src/plugins/agents/handler.ts` - Standardized error responses
- `src/plugins/notifications/handler.ts` - Standardized error responses
- `tests/unit/handler-validation.test.ts` - Added new tests, updated existing tests

### Verification
All changes follow existing code patterns and maintain backward compatibility for valid inputs.
