### PR TITLE
Improve readability of auto-dismiss text and button

### DIFF
--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -1406,7 +1406,7 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
           <span class="dash-auto-dismiss-mini-label">
             {autoDismissResult
               ? `Auto-dismissed ${autoDismissResult.total} notification${autoDismissResult.total !== 1 ? 's' : ''}`
-              : 'Nothing auto-dismissed this run'}
+              : 'No notifications auto-dismissed'}
           </span>
           <button
             class="dash-auto-dismiss-mini-btn"

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -3976,13 +3976,13 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .dash-auto-dismiss-mini-label {
   font-size: 0.72rem;
-  color: #3a5a7a;
+  color: #7ab3f5;
 }
 
 .dash-auto-dismiss-mini-btn {
   background: transparent;
   border: 1px solid #1e3a5a;
-  color: #4a7aaa;
+  color: #7ab3f5;
   border-radius: 4px;
   font-size: 0.72rem;
   padding: 0.1rem 0.45rem;


### PR DESCRIPTION
- Changed label text from 'Nothing auto-dismissed this run' to 'No notifications auto-dismissed'\n- Updated .dash-auto-dismiss-mini-label color from #3a5a7a to #7ab3f5\n- Updated .dash-auto-dismiss-mini-btn color from #4a7aaa to #7ab3f5