### PR TITLE
fix: expand dismissed notifications panel to full viewport height

### DIFF
--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -754,7 +754,7 @@ function App() {
         {!showChatPanel && selectedOllamaModel && (
           <button class="chat-reopen-btn" title="Open Chat" onClick={handleOpenChat}>💬</button>
         )}
-        <div class={`container${activeTab === 'groups-dashboard' ? ' container--fill' : ''}`}>
+        <div class={`container${(activeTab === 'groups-dashboard' || activeTab === 'dismiss-history') ? ' container--fill' : ''}`}>
       <h1>Jarvis</h1>
       <p class="subtitle">Personal Assistant</p>
 

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -1471,6 +1471,10 @@ body.onboarding {
 .container--fill {
   min-width: 0;
   width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 h1 {
@@ -4028,8 +4032,11 @@ h5.ec-heading { font-size: 0.85rem; }
   background: #111827;
   border: 1px solid #1e3a5a;
   border-radius: 8px;
-  margin-bottom: 0.85rem;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
 .adh-header {
@@ -4114,7 +4121,8 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .adh-list {
-  max-height: 280px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -4181,6 +4189,9 @@ h5.ec-heading { font-size: 0.85rem; }
 
 /* Chart sub-view */
 .adh-chart-view {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   padding: 0.75rem 1rem 0.5rem;
 }
 


### PR DESCRIPTION
## Summary

- Removed the fixed `max-height: 280px` on the dismissed notifications list and replaced it with a flex-based layout that fills the available viewport height
- Added `dismiss-history` to the `container--fill` class condition so the tab container participates in the flex height chain
- Made `.adh-panel`, `.adh-list`, and `.adh-chart-view` flex children that grow to fill remaining space below the header and tab bar
- Both the List and Chart views now use the full available height

## Test plan

- [ ] Open the Dismissed tab and verify the notification list fills the full viewport (minus header/tab bar)
- [ ] Switch to Chart view and verify it also fills the full height
- [ ] Verify the Groups Dashboard tab still renders correctly (also uses `container--fill`)
- [ ] Verify other tabs (Repo Dashboard, Browser, Setup) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)