### PR TITLE
feat: follow OS regional number format settings

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -294,6 +294,8 @@ contextBridge.exposeInMainWorld('jarvis', {
     ipcRenderer.on('groups:project-details-refreshed', listener);
     return () => { ipcRenderer.removeListener('groups:project-details-refreshed', listener); };
   },
+  // System locale (for OS-aware number formatting)
+  getSystemLocale: () => ipcRenderer.invoke('app:get-system-locale'),
   // GitHub rate limit
   getGitHubRateLimit: () => ipcRenderer.invoke('github:get-rate-limit'),
   // Auto-dismiss log

--- a/src/plugins/config/handler.ts
+++ b/src/plugins/config/handler.ts
@@ -1,5 +1,5 @@
 // ── Config & onboarding IPC handlers ─────────────────────────────────────────
-import { ipcMain } from 'electron';
+import { ipcMain, app } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import type { BrowserWindow } from 'electron';
 import { getOnboardingStatus } from '../../agent/onboarding';
@@ -13,6 +13,8 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
   });
+
+  ipcMain.handle('app:get-system-locale', () => app.getSystemLocale());
 
   ipcMain.handle('app:get-preferences', () => {
     try {

--- a/src/plugins/github-auth/DiscoverySection.tsx
+++ b/src/plugins/github-auth/DiscoverySection.tsx
@@ -1,4 +1,5 @@
 import { StatusBadge } from '../shared/StatusBadge';
+import { formatNumber } from '../shared/utils';
 import type { DiscoveryProgress } from '../types';
 
 interface DiscoverySectionProps {
@@ -16,22 +17,22 @@ export function DiscoverySection({ progress, finished, onToggleOrgs }: Discovery
     badgeStatus = 'completed';
     badgeLabel = 'Complete';
     const p = progress!;
-    detail = `Found ${p.orgsFound.toLocaleString()} org${p.orgsFound !== 1 ? 's' : ''} and ${p.reposFound.toLocaleString()} repo${p.reposFound !== 1 ? 's' : ''}`;
+    detail = `Found ${formatNumber(p.orgsFound)} org${p.orgsFound !== 1 ? 's' : ''} and ${formatNumber(p.reposFound)} repo${p.reposFound !== 1 ? 's' : ''}`;
   } else if (progress) {
     badgeStatus = 'in-progress';
     badgeLabel = 'Running';
     const phaseLabels: Record<string, string> = {
       orgs: 'Discovering organizations...',
-      repos: `Scanning org repositories... (${progress.reposFound.toLocaleString()} repos so far)`,
-      'user-repos': `Scanning personal + collaborator repos... (${progress.reposFound.toLocaleString()} repos so far)`,
-      starred: `Fetching starred repos... (${progress.reposFound.toLocaleString()} repos so far)`,
+      repos: `Scanning org repositories... (${formatNumber(progress.reposFound)} repos so far)`,
+      'user-repos': `Scanning personal + collaborator repos... (${formatNumber(progress.reposFound)} repos so far)`,
+      starred: `Fetching starred repos... (${formatNumber(progress.reposFound)} repos so far)`,
       'pat-repos': progress.currentOrg
-        ? `PAT: scanning ${progress.currentOrg}... (${progress.reposFound.toLocaleString()} new repos)`
-        : `PAT: scanning collaborator repos... (${progress.reposFound.toLocaleString()} new repos)`,
+        ? `PAT: scanning ${progress.currentOrg}... (${formatNumber(progress.reposFound)} new repos)`
+        : `PAT: scanning collaborator repos... (${formatNumber(progress.reposFound)} new repos)`,
     };
     detail = phaseLabels[progress.phase] || 'Working...';
     if (progress.orgsFound > 0) {
-      detail += ` \u2014 ${progress.orgsFound.toLocaleString()} org${progress.orgsFound !== 1 ? 's' : ''} found`;
+      detail += ` \u2014 ${formatNumber(progress.orgsFound)} org${progress.orgsFound !== 1 ? 's' : ''} found`;
     }
   }
 

--- a/src/plugins/local-repos/LocalFolderPanel.tsx
+++ b/src/plugins/local-repos/LocalFolderPanel.tsx
@@ -1,4 +1,5 @@
 import type { ScanFolder } from '../types';
+import { formatNumber } from '../shared/utils';
 
 interface LocalFolderPanelProps {
   folders: ScanFolder[];
@@ -36,7 +37,7 @@ export function LocalFolderPanel({
             >
               <span class="org-label" title={folder.path}>{label}</span>
               <span class="org-meta">
-                {(folder.repoCount ?? 0).toLocaleString()} repo{(folder.repoCount ?? 0) !== 1 ? 's' : ''}
+                {formatNumber(folder.repoCount ?? 0)} repo{(folder.repoCount ?? 0) !== 1 ? 's' : ''}
               </span>
             </div>
           );

--- a/src/plugins/local-repos/LocalRepoPanelView.tsx
+++ b/src/plugins/local-repos/LocalRepoPanelView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 import { LocalRepoCard } from './LocalRepoCard';
-import { deduplicateLocalRepos } from '../shared/utils';
+import { deduplicateLocalRepos, formatNumber } from '../shared/utils';
 import type { LocalRepo, NotificationCounts } from '../types';
 
 type LocalSortKey = 'name' | 'scanned' | 'notifs';
@@ -45,7 +45,7 @@ export function LocalRepoPanelView({ title, repos, notifCounts, initialSortKey =
         <button class="repo-panel-close" title="Back" onClick={onClose}>&#8249;</button>
         <span class="repo-panel-title">{title}</span>
         <span class="local-panel-count">
-          {deduped.length.toLocaleString()} repo{deduped.length !== 1 ? 's' : ''}
+          {formatNumber(deduped.length)} repo{deduped.length !== 1 ? 's' : ''}
           {hasDuplicates && (
             <span title={`${totalLocalPaths} local copies across ${deduped.length} unique repo${deduped.length !== 1 ? 's' : ''}`}> ({totalLocalPaths} local copies)</span>
           )}

--- a/src/plugins/local-repos/LocalReposStep.tsx
+++ b/src/plugins/local-repos/LocalReposStep.tsx
@@ -1,4 +1,5 @@
 import { StatusBadge } from '../shared/StatusBadge';
+import { formatNumber } from '../shared/utils';
 import type { ScanFolder, LocalScanProgress } from '../types';
 
 interface LocalReposStepProps {
@@ -25,7 +26,7 @@ export function LocalReposStep({
   if (configured && (scanFinished || scanProgress?.phase === 'done')) {
     badgeStatus = 'completed';
     badgeLabel = 'Ready';
-    detail = `${totalRepos.toLocaleString()} local repo${totalRepos !== 1 ? 's' : ''} found`;
+    detail = `${formatNumber(totalRepos)} local repo${totalRepos !== 1 ? 's' : ''} found`;
   } else if (configured && scanning) {
     badgeStatus = 'in-progress';
     badgeLabel = 'Scanning';

--- a/src/plugins/local-repos/LocalSubfolderPanel.tsx
+++ b/src/plugins/local-repos/LocalSubfolderPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 import type { LocalRepo, NotificationCounts } from '../types';
-import { getImmediateChildren, normalizeGitHubUrl } from '../shared/utils';
+import { getImmediateChildren, normalizeGitHubUrl, formatNumber } from '../shared/utils';
 
 interface LocalSubfolderPanelProps {
   path: string;
@@ -63,7 +63,7 @@ export function LocalSubfolderPanel({
           <button class="repo-panel-close" title="Back" onClick={onBack}>&#8249;</button>
         )}
         <span class="repo-panel-title">{folderName}</span>
-        <span class="local-panel-count">{totalRepos.toLocaleString()} repo{totalRepos !== 1 ? 's' : ''}</span>
+        <span class="local-panel-count">{formatNumber(totalRepos)} repo{totalRepos !== 1 ? 's' : ''}</span>
         <span style={{ flex: 1 }} />
         {notifCounts && totalNotifs > 0 && (
           <span
@@ -93,7 +93,7 @@ export function LocalSubfolderPanel({
                   {nc > 0 && (
                     <span class="notif-badge" title={`${nc} unread`}>{nc}</span>
                   )}
-                  <span class="org-repos-count">{child.repoCount.toLocaleString()} repo{child.repoCount !== 1 ? 's' : ''}</span>
+                  <span class="org-repos-count">{formatNumber(child.repoCount)} repo{child.repoCount !== 1 ? 's' : ''}</span>
                 </span>
               </div>
             );

--- a/src/plugins/orgs/OrgPanel.tsx
+++ b/src/plugins/orgs/OrgPanel.tsx
@@ -1,4 +1,5 @@
 import type { Org, NotificationCounts } from '../types';
+import { formatNumber } from '../shared/utils';
 
 interface OrgPanelProps {
   orgs: Org[];
@@ -99,7 +100,7 @@ export function OrgPanel({
                     {nc}
                   </span>
                 )}
-                <span class="org-repos-count">{org.repoCount.toLocaleString()} repo{org.repoCount !== 1 ? 's' : ''}</span>
+                <span class="org-repos-count">{formatNumber(org.repoCount)} repo{org.repoCount !== 1 ? 's' : ''}</span>
               </span>
               <span
                 class={`fav-star${isFav ? ' fav-star-active' : ''}`}
@@ -142,7 +143,7 @@ export function OrgPanel({
                   {personalCount}
                 </span>
               )}
-              <span class="org-repos-count">{directRepoCount.toLocaleString()} repo{directRepoCount !== 1 ? 's' : ''}</span>
+              <span class="org-repos-count">{formatNumber(directRepoCount)} repo{directRepoCount !== 1 ? 's' : ''}</span>
             </span>
           </div>
         )}
@@ -163,7 +164,7 @@ export function OrgPanel({
                   {starredCount}
                 </span>
               )}
-              <span class="org-repos-count">{starredRepoCount.toLocaleString()} repo{starredRepoCount !== 1 ? 's' : ''}</span>
+              <span class="org-repos-count">{formatNumber(starredRepoCount)} repo{starredRepoCount !== 1 ? 's' : ''}</span>
             </span>
           </div>
         )}

--- a/src/plugins/shared/utils.ts
+++ b/src/plugins/shared/utils.ts
@@ -1,5 +1,18 @@
 // ── Shared renderer utility helpers ──────────────────────────────────────────
 
+// System locale for OS-aware number formatting. Set once at app startup via
+// setSystemLocale() so all components share the same locale without re-fetching.
+let _systemLocale: string | undefined;
+
+export function setSystemLocale(locale: string): void {
+  _systemLocale = locale;
+}
+
+/** Format a number using the OS regional number format settings. */
+export function formatNumber(n: number): string {
+  return n.toLocaleString(_systemLocale);
+}
+
 /** Returns a human-readable relative time label (e.g. "3h ago", "2d ago"). */
 export function relativeAge(dateStr: string): string {
   const ms = Date.now() - new Date(dateStr).getTime();

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2615,6 +2615,9 @@ export interface JarvisApi {
 
 
 
+  // System locale
+  getSystemLocale(): Promise<string>;
+
   // GitHub rate limit
 
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -20,7 +20,7 @@ import { LocalFolderConfigPanel } from '../plugins/local-repos/LocalFolderConfig
 import { LocalFolderPanel } from '../plugins/local-repos/LocalFolderPanel';
 import { LocalSubfolderPanel } from '../plugins/local-repos/LocalSubfolderPanel';
 import { LocalRepoPanelView } from '../plugins/local-repos/LocalRepoPanelView';
-import { getReposUnder, hasDeepRepos } from '../plugins/shared/utils';
+import { getReposUnder, hasDeepRepos, setSystemLocale, formatNumber } from '../plugins/shared/utils';
 import { SecretsStep } from '../plugins/secrets/SecretsStep';
 import { SecretsScanPanel } from '../plugins/secrets/SecretsScanPanel';
 import { DashboardPanel } from '../plugins/dashboard/DashboardPanel';
@@ -139,6 +139,7 @@ function App() {
 
   // Initial status check
   useEffect(() => {
+    window.jarvis.getSystemLocale().then(setSystemLocale).catch(() => {/* use browser default */});
     (async () => {
       try {
         const status = await window.jarvis.getGitHubOAuthStatus();
@@ -1204,12 +1205,12 @@ function BackgroundStatusBar({
               class="bg-status-rate-limit"
               title={oauthBadge.error
                 ? `OAuth rate limit error: ${oauthBadge.error}`
-                : `OAuth: ${oauthBadge.resource!.remaining}/${oauthBadge.resource!.limit} calls remaining (resets ${new Date(oauthBadge.resource!.reset * 1000).toLocaleTimeString()})`}
+                : `OAuth: ${formatNumber(oauthBadge.resource!.remaining)}/${formatNumber(oauthBadge.resource!.limit)} calls remaining (resets ${new Date(oauthBadge.resource!.reset * 1000).toLocaleTimeString()})`}
               style={{ color: oauthBadge.error ? '#888' : (oauthBadge.resource ? rateLimitColor(oauthBadge.resource.remaining) : '#888') }}
             >
               {oauthBadge.error || !oauthBadge.resource
                 ? '⚡ OAuth –'
-                : `⚡ OAuth ${oauthBadge.resource.remaining.toLocaleString()}/${oauthBadge.resource.limit.toLocaleString()}${oauthBadge.resource.remaining < 500 ? ` · ${formatResetIn(oauthBadge.resource.reset)}` : ''}`}
+                : `⚡ OAuth ${formatNumber(oauthBadge.resource.remaining)}/${formatNumber(oauthBadge.resource.limit)}${oauthBadge.resource.remaining < 500 ? ` · ${formatResetIn(oauthBadge.resource.reset)}` : ''}`}
             </span>
           )}
           {oauthBadge && patBadge && (
@@ -1220,12 +1221,12 @@ function BackgroundStatusBar({
               class="bg-status-rate-limit"
               title={patBadge.error
                 ? `PAT rate limit error: ${patBadge.error}`
-                : `PAT: ${patBadge.resource!.remaining}/${patBadge.resource!.limit} calls remaining (resets ${new Date(patBadge.resource!.reset * 1000).toLocaleTimeString()})`}
+                : `PAT: ${formatNumber(patBadge.resource!.remaining)}/${formatNumber(patBadge.resource!.limit)} calls remaining (resets ${new Date(patBadge.resource!.reset * 1000).toLocaleTimeString()})`}
               style={{ color: patBadge.error ? '#888' : (patBadge.resource ? rateLimitColor(patBadge.resource.remaining) : '#888') }}
             >
               {patBadge.error || !patBadge.resource
                 ? '⚡ PAT –'
-                : `⚡ PAT ${patBadge.resource.remaining.toLocaleString()}/${patBadge.resource.limit.toLocaleString()}${patBadge.resource.remaining < 500 ? ` · ${formatResetIn(patBadge.resource.reset)}` : ''}`}
+                : `⚡ PAT ${formatNumber(patBadge.resource.remaining)}/${formatNumber(patBadge.resource.limit)}${patBadge.resource.remaining < 500 ? ` · ${formatResetIn(patBadge.resource.reset)}` : ''}`}
             </span>
           )}
         </div>

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -43,6 +43,7 @@ import { ipcMain } from 'electron';
 const EXPECTED_CHANNELS = [
   // config plugin
   'onboarding:status',
+  'app:get-system-locale',
   'app:get-preferences',
   'app:set-preferences',
   // ollama plugin


### PR DESCRIPTION
## Summary

- Adds `app:get-system-locale` IPC handler that exposes Electron's `app.getSystemLocale()` — this reads the actual Windows regional format settings (e.g. `.` as thousands separator), not just the UI display language
- Adds a shared `formatNumber()` utility in `src/plugins/shared/utils.ts` that uses the OS locale; locale is fetched once at app startup via `setSystemLocale()`
- Replaces all bare `.toLocaleString()` number calls across the renderer and plugin components with `formatNumber()` so every numeric display (OAuth/PAT rate-limit badges, repo counts, discovery progress) respects the user's OS settings

## Test plan

- [ ] Launch the app and verify the OAuth/PAT status bar shows e.g. `14.747/15.000` instead of `14,747/15,000` on a system with European number format (period as thousands separator)
- [ ] Verify repo counts in org panel, local repos panel, and discovery progress also use the correct thousands separator
- [ ] Verify the app still works correctly on a system with default `en-US` number format

🤖 Generated with [Claude Code](https://claude.com/claude-code)