### PR TITLE
Add Claude Code skill pointers for existing GitHub Copilot skills

### DIFF
--- a/.claude/skills/check-db/SKILL.md
+++ b/.claude/skills/check-db/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: check-db
+description: Inspect the live Jarvis SQLite database to check the schema migration version and list all tables. Use this when verifying a migration ran correctly, checking what tables exist before writing a new migration, confirming the user_version matches the expected schema, or debugging "table not found" errors at runtime.
+---
+
+Full instructions for this skill live in [.github/skills/check-db/SKILL.md](../../../.github/skills/check-db/SKILL.md). Read that file for complete guidance before proceeding.

--- a/.claude/skills/onenote-caching/SKILL.md
+++ b/.claude/skills/onenote-caching/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: onenote-caching
+description: Cache live OneNote notebook pages from SharePoint via COM API with automatic fallback to local backup files. Use this when adding OneNote pages to groups, debugging cache misses, or handling large notebook hierarchies that exceed buffer limits.
+---
+
+Full instructions for this skill live in [.github/skills/onenote-caching/SKILL.md](../../../.github/skills/onenote-caching/SKILL.md). Read that file for complete guidance before proceeding.

--- a/.claude/skills/project-budget-actuals/SKILL.md
+++ b/.claude/skills/project-budget-actuals/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: project-budget-actuals
+description: Query customer project information and budget/actuals data. Retrieve linked projects, budgets, costs, and financial status for any customer group. Use this when analyzing project economics, budget tracking, or cost performance for customer engagements.
+---
+
+Full instructions for this skill live in [.github/skills/project-budget-actuals/SKILL.md](../../../.github/skills/project-budget-actuals/SKILL.md). Read that file for complete guidance before proceeding.


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/check-db`, `.claude/skills/onenote-caching`, and `.claude/skills/project-budget-actuals`, each a thin `SKILL.md` with the same `name`/`description` frontmatter as the corresponding Copilot skill in `.github/skills/`.
- Each pointer file's body directs Claude Code to read the full instructions from the matching `.github/skills/<name>/SKILL.md`, so the content stays maintained in one place while both Copilot and Claude Code can discover and trigger the same skills.

## Test plan
- [x] Verified `.github/skills/*` skill folders exist and frontmatter (`name`, `description`) was copied accurately
- [ ] Confirm Claude Code picks up and triggers these skills as expected in a live session