### PR TITLE
fix: re-run auto-dismiss notification sweep every 10 minutes

### DIFF
--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -44,8 +44,14 @@ interface AutoDismissRunResult {
   total: number;
 }
 
-/** Module-level flag so the pipeline only runs once per app session (survives remounts). */
-let autoDismissRanGlobally = false;
+/**
+ * Module-level cooldown so repeated tab switches (which remount DashboardPanel)
+ * don't re-trigger the pipeline more often than this interval. Notifications for
+ * already-closed issues/PRs can surface hours or days after the close (e.g. a new
+ * mention on an old closed issue), so a single run-once-per-session sweep misses them.
+ */
+const AUTO_DISMISS_INTERVAL_MS = 10 * 60 * 1000;
+let lastAutoDismissRunAt = 0;
 
 async function runRecoverableStep(repoFullNames: string[]): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
   const logEntries: AutoDismissLogInput[] = [];
@@ -1154,12 +1160,17 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
 
   useEffect(() => { void load(); }, [load]);
 
-  // Run the auto-dismiss pipeline once per session after summary is first available
-  useEffect(() => {
-    if (!summary || autoDismissRanGlobally) return;
-    autoDismissRanGlobally = true;
+  // Keep a ref to the latest summary so the periodic timer below always reads
+  // fresh repo/notification data without needing to reset on every summary change.
+  const summaryRef = useRef<DashboardSummary | null>(null);
+  useEffect(() => { summaryRef.current = summary; }, [summary]);
+
+  const runAutoDismissIfDue = useCallback(() => {
+    const currentSummary = summaryRef.current;
+    if (!currentSummary || Date.now() - lastAutoDismissRunAt < AUTO_DISMISS_INTERVAL_MS) return;
+    lastAutoDismissRunAt = Date.now();
     setPipelineStatus('running');
-    const repoFullNames = summary.repos
+    const repoFullNames = currentSummary.repos
       .filter((r) => r.notificationCount > 0 && r.linkedGithubRepo !== null)
       .map((r) => r.linkedGithubRepo!);
     void runAutoDismissPipeline(repoFullNames).then(async ({ result, logEntries }) => {
@@ -1171,7 +1182,18 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
       setAutoDismissDone(true);
       setPipelineStatus('done');
     });
-  }, [summary, load]);
+  }, [load]);
+
+  // Run the auto-dismiss pipeline once summary is first available, then keep
+  // re-checking every AUTO_DISMISS_INTERVAL_MS so notifications for issues/PRs
+  // that get closed (or resurface as unread) mid-session are still swept up,
+  // not just at app start.
+  useEffect(() => {
+    if (!summary) return;
+    runAutoDismissIfDue();
+    const intervalId = setInterval(runAutoDismissIfDue, AUTO_DISMISS_INTERVAL_MS);
+    return () => clearInterval(intervalId);
+  }, [summary, runAutoDismissIfDue]);
 
   useEffect(() => {
     if (!summary || !currentUserLogin || !autoDismissDone) {


### PR DESCRIPTION
## Summary of Changes

The "People First" dashboard card was showing notifications for issues that had already been closed. Root cause: the auto-dismiss sweep that checks whether issue/PR notifications should be cleared (`runAutoDismissPipeline` in `DashboardPanel.tsx`) only ran once per app session, gated by a module-level `autoDismissRanGlobally` flag.

Investigating the live DB (`auto_dismiss_log`) showed the sweep *did* run and correctly dismissed some closed-issue notifications early in the session — but several notifications for the same already-closed issues resurfaced as "unread" *after* that one sweep had already run (GitHub re-notifies on old, closed issue threads when there's new activity, e.g. a bot mentioning them again). Since the sweep never ran again, those stayed stuck until the app was restarted.

This PR replaces the one-shot flag with a 10-minute cooldown (`AUTO_DISMISS_INTERVAL_MS`), so the pipeline still runs immediately when the dashboard first loads, but also keeps re-checking every 10 minutes for as long as the Dashboard tab is open, using a `useRef` to always read the latest repo/notification list without resetting the interval on every summary update.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. Open the Repo Dashboard tab and let the initial auto-dismiss sweep complete (as before).
2. Close an issue/PR that has a notification in Jarvis (or wait for GitHub to resurface an already-closed issue's notification as unread, e.g. via a new mention).
3. Leave the Dashboard tab open for ~10 minutes (or reduce `AUTO_DISMISS_INTERVAL_MS` locally for a faster check) and confirm the notification gets swept without needing to restart the app.
4. Verify switching away from and back to the Dashboard tab doesn't cause the sweep to spam-run (cooldown persists across remounts via the module-level `lastAutoDismissRunAt`).

## Checklist

- [x] Tests pass (`npm test` — ran `tests/unit/notifications-handler.test.ts` and `tests/unit/github-notifications.test.ts`, plus `tsc --noEmit`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed