### PR TITLE
Add handler unit tests and a leveled logger

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,10 @@ import { saveDatabase } from '../storage/database';
 
 import { stopBridgeServer } from '../plugins/browser-companion/server';
 
+import { setLogLevel } from '../services/logger';
+
+setLogLevel(app.isPackaged ? 'warn' : 'debug');
+
 
 
 let mainWindow: BrowserWindow | null = null;

--- a/src/plugins/groups/handler.ts
+++ b/src/plugins/groups/handler.ts
@@ -23,6 +23,7 @@ import {
 import type { RuddrProjectEntry } from '../../services/groups';
 import { sendCommand, getBridgeStatus } from '../browser-companion/server';
 import type { RuddrProjectMatch } from '../types';
+import { logger } from '../../services/logger';
 
 // ── Ruddr project list cache (in-memory, backed by DB for persistence) ──────────
 let ruddrProjectsCache: RuddrProjectEntry[] | null = null;
@@ -102,7 +103,7 @@ async function ensureRuddrCache(db: SqlJsDatabase): Promise<string | null> {
 
   let scrapeTabId: number | undefined = navData?.tabId;
   if (!finalUrl.includes('portfolio/projects')) {
-    console.log(`[Groups] Portfolio URL redirected to ${finalUrl} — trying my-projects fallback`);
+    logger.debug(`[Groups] Portfolio URL redirected to ${finalUrl} — trying my-projects fallback`);
     const fallbackNav = await sendCommand({ type: 'navigate', payload: { url: getRuddrMyProjectsUrl(db) } });
     if (!fallbackNav.ok) return `Fallback navigation failed: ${fallbackNav.error ?? 'unknown'}`;
     const fallbackData = fallbackNav.data as { url?: string; tabId?: number } | null;
@@ -126,7 +127,7 @@ async function ensureRuddrCache(db: SqlJsDatabase): Promise<string | null> {
     tabId: scrapeTabId,
     payload: { selector: RUDDR_PROJECT_SELECTOR, maxScrolls: 80, waitMs: 1500, includeHref: true, debug: true },
   }, 180_000).catch((err) => {
-    console.warn(`[Groups] scroll-extract failed: ${err instanceof Error ? err.message : String(err)}`);
+    logger.warn(`[Groups] scroll-extract failed: ${err instanceof Error ? err.message : String(err)}`);
     return { ok: false, error: err instanceof Error ? err.message : String(err) } as { ok: false; error: string };
   });
   if (!extractResp.ok) return `Extract failed: ${extractResp.error ?? 'unknown'}`;
@@ -136,7 +137,7 @@ async function ensureRuddrCache(db: SqlJsDatabase): Promise<string | null> {
   const items = Array.isArray(rawData) ? rawData : (rawData?.items ?? []);
   const debugLog = Array.isArray(rawData) ? null : rawData?.debugLog;
   if (debugLog && debugLog.length > 0) {
-    console.log(`[Groups] Ruddr scroll debug:\n  ${debugLog.join('\n  ')}`);
+    logger.debug(`[Groups] Ruddr scroll debug:\n  ${debugLog.join('\n  ')}`);
   }
   const freshProjects = (items ?? [])
     .map((i) => ({ name: (i.text ?? '').trim(), path: (i.href ?? '').split('?')[0].split('#')[0] }))
@@ -145,12 +146,12 @@ async function ensureRuddrCache(db: SqlJsDatabase): Promise<string | null> {
   const oldLen = ruddrProjectsCache?.length ?? 0;
   if (freshProjects.length === 0) {
     if (oldLen === 0) {
-      console.warn(`[Groups] Ruddr scroll returned 0 projects and cache is empty — scrape may have failed.`);
+      logger.warn(`[Groups] Ruddr scroll returned 0 projects and cache is empty — scrape may have failed.`);
       return 'ruddr_no_projects_found';
     }
-    console.warn(`[Groups] Ruddr scroll returned only ${freshProjects.length} projects — keeping old cache of ${oldLen}.`);
+    logger.warn(`[Groups] Ruddr scroll returned only ${freshProjects.length} projects — keeping old cache of ${oldLen}.`);
   } else if (oldLen > 0 && freshProjects.length < oldLen * 0.75) {
-    console.warn(`[Groups] Ruddr scroll returned only ${freshProjects.length} projects — keeping old cache of ${oldLen}.`);
+    logger.warn(`[Groups] Ruddr scroll returned only ${freshProjects.length} projects — keeping old cache of ${oldLen}.`);
   } else {
     // Merge notes from old DB entries into the fresh list before saving
     const oldEntries = loadRuddrProjectsFromDb(db);
@@ -167,16 +168,16 @@ async function ensureRuddrCache(db: SqlJsDatabase): Promise<string | null> {
 
     ruddrProjectsCache = mergedProjects;
     ruddrProjectsCacheTime = Date.now();
-    console.log(`[Groups] Ruddr projects cached: ${ruddrProjectsCache.length} entries`);
+    logger.debug(`[Groups] Ruddr projects cached: ${ruddrProjectsCache.length} entries`);
     try {
       saveRuddrProjectsToDb(db, mergedProjects);
       saveDatabase();
     } catch (err) {
-      console.warn('[Groups] Failed to persist Ruddr projects to DB:', err);
+      logger.warn('[Groups] Failed to persist Ruddr projects to DB:', err);
     }
 
     if (newProjects.length > 0) {
-      console.log(`[Groups] ${newProjects.length} new Ruddr project(s) found:`, newProjects.map((p) => p.name).join(', '));
+      logger.debug(`[Groups] ${newProjects.length} new Ruddr project(s) found:`, newProjects.map((p) => p.name).join(', '));
       _notifyNewProjects(newProjects);
     }
   }
@@ -192,12 +193,12 @@ export async function prewarmRuddrCache(db: SqlJsDatabase): Promise<void> {
     if (persisted.length > 0) {
       ruddrProjectsCache = persisted;
       ruddrProjectsCacheTime = Date.now();
-      console.log(`[Groups] Ruddr cache seeded from DB: ${persisted.length} projects`);
+      logger.debug(`[Groups] Ruddr cache seeded from DB: ${persisted.length} projects`);
     }
   }
   // Then try to refresh from browser if connected.
   const err = await ensureRuddrCache(db);
-  if (err) console.log(`[Groups] Ruddr pre-warm skipped: ${err}`);
+  if (err) logger.debug(`[Groups] Ruddr pre-warm skipped: ${err}`);
 }
 
 // ── Hourly Ruddr project refresh ─────────────────────────────────────────────
@@ -230,7 +231,7 @@ async function refreshLinkedProjectDetails(db: SqlJsDatabase): Promise<void> {
 
   if (toRefresh.length === 0) return;
 
-  console.log(`[Groups] Auto-refreshing details for ${toRefresh.length} linked project(s) missing note/cloud folder`);
+  logger.debug(`[Groups] Auto-refreshing details for ${toRefresh.length} linked project(s) missing note/cloud folder`);
   let updated = false;
 
   for (const entry of toRefresh) {
@@ -241,22 +242,22 @@ async function refreshLinkedProjectDetails(db: SqlJsDatabase): Promise<void> {
         ? entry.path.replace('/portfolio/projects/', '/portfolio/projects/edit/')
         : entry.path;
       const editUrl = `https://www.ruddr.io${editPath}`;
-      console.log(`[Groups] Refreshing "${entry.name}" → ${editUrl}`);
+      logger.debug(`[Groups] Refreshing "${entry.name}" → ${editUrl}`);
 
       const navResp = await sendCommand({ type: 'navigate', payload: { url: editUrl } });
-      console.log(`[Groups]   nav ok=${navResp.ok} data=${JSON.stringify(navResp.data)}`);
+      logger.debug(`[Groups]   nav ok=${navResp.ok} data=${JSON.stringify(navResp.data)}`);
       if (!navResp.ok) {
-        console.warn(`[Groups]   nav failed for "${entry.name}", skipping`);
+        logger.warn(`[Groups]   nav failed for "${entry.name}", skipping`);
         continue;
       }
 
       const navData = navResp.data as { url?: string; tabId?: number } | null;
       if ((navData?.url ?? '').includes('/login')) {
-        console.log('[Groups] Auto-refresh: Ruddr login required — stopping detail refresh');
+        logger.debug('[Groups] Auto-refresh: Ruddr login required — stopping detail refresh');
         break;
       }
 
-      console.log(`[Groups]   Sending read-form-fields (tabId=${navData?.tabId})`);
+      logger.debug(`[Groups]   Sending read-form-fields (tabId=${navData?.tabId})`);
       const fieldsResp = await sendCommand({
         type: 'read-form-fields',
         tabId: navData?.tabId,
@@ -265,16 +266,16 @@ async function refreshLinkedProjectDetails(db: SqlJsDatabase): Promise<void> {
           waitMs: 4000,
         },
       });
-      console.log(`[Groups]   fields ok=${fieldsResp.ok} data=${JSON.stringify(fieldsResp.data)} error=${fieldsResp.error ?? ''}`);
+      logger.debug(`[Groups]   fields ok=${fieldsResp.ok} data=${JSON.stringify(fieldsResp.data)} error=${fieldsResp.error ?? ''}`);
       if (!fieldsResp.ok) {
-        console.warn(`[Groups]   read-form-fields failed for "${entry.name}": ${fieldsResp.error ?? 'unknown'}, skipping`);
+        logger.warn(`[Groups]   read-form-fields failed for "${entry.name}": ${fieldsResp.error ?? 'unknown'}, skipping`);
         continue;
       }
 
       const raw = fieldsResp.data as Record<string, string | null> | null;
       const note = raw?.['textarea[name="description"]'] ?? null;
       const cloudFolderUrl = raw?.['input[name="cloudFolderUrl"]'] ?? null;
-      console.log(`[Groups]   note=${note ? `"${note.slice(0, 60)}…"` : 'null'}  cloudFolderUrl=${cloudFolderUrl ?? 'null'}`);
+      logger.debug(`[Groups]   note=${note ? `"${note.slice(0, 60)}…"` : 'null'}  cloudFolderUrl=${cloudFolderUrl ?? 'null'}`);
 
       if (note !== null || cloudFolderUrl !== null) {
         try {
@@ -290,13 +291,13 @@ async function refreshLinkedProjectDetails(db: SqlJsDatabase): Promise<void> {
           }
           saveDatabase();
           updated = true;
-          console.log(`[Groups]   DB updated for "${entry.name}"`);
+          logger.debug(`[Groups]   DB updated for "${entry.name}"`);
         } catch { /* non-fatal */ }
       } else {
-        console.log(`[Groups]   No values found for "${entry.name}" — both fields null`);
+        logger.debug(`[Groups]   No values found for "${entry.name}" — both fields null`);
       }
     } catch (err) {
-      console.warn(
+      logger.warn(
         `[Groups] Auto-refresh detail failed for "${entry.name}":`,
         err instanceof Error ? err.message : String(err),
       );
@@ -329,10 +330,10 @@ export function scheduleRuddrProjectsRefresh(db: SqlJsDatabase, getWindow: () =>
   setTimeout(async () => {
     const err = await ensureRuddrCache(db).catch((e: unknown) => String(e));
     if (err) {
-      console.log('[Groups] Hourly Ruddr refresh skipped:', err);
+      logger.debug('[Groups] Hourly Ruddr refresh skipped:', err);
     } else {
       refreshLinkedProjectDetails(db).catch((e: unknown) =>
-        console.warn('[Groups] Auto-refresh project details failed:', e instanceof Error ? e.message : String(e)),
+        logger.warn('[Groups] Auto-refresh project details failed:', e instanceof Error ? e.message : String(e)),
       );
     }
     setInterval(async () => {
@@ -340,10 +341,10 @@ export function scheduleRuddrProjectsRefresh(db: SqlJsDatabase, getWindow: () =>
       ruddrProjectsCacheTime = 0;
       const e = await ensureRuddrCache(db).catch((ex: unknown) => String(ex));
       if (e) {
-        console.log('[Groups] Hourly Ruddr refresh skipped:', e);
+        logger.debug('[Groups] Hourly Ruddr refresh skipped:', e);
       } else {
         refreshLinkedProjectDetails(db).catch((ex: unknown) =>
-          console.warn('[Groups] Auto-refresh project details failed:', ex instanceof Error ? ex.message : String(ex)),
+          logger.warn('[Groups] Auto-refresh project details failed:', ex instanceof Error ? ex.message : String(ex)),
         );
       }
     }, HOUR_MS);
@@ -585,7 +586,7 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
 
     if (!entry?.path) {
       const cacheSize = ruddrProjectsCache?.length ?? 0;
-      console.warn(`[Groups] Budget: no cache entry for "${trimmed}". Cache has ${cacheSize} entries.`);
+      logger.warn(`[Groups] Budget: no cache entry for "${trimmed}". Cache has ${cacheSize} entries.`);
       return {
         ok: false,
         error: cacheSize > 0 ? 'project_not_in_ruddr' : 'project_url_unknown',
@@ -682,7 +683,7 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
     if (err) return { ok: false, error: err };
     // Fire-and-forget: refresh note/cloud folder from the edit page for linked projects.
     refreshLinkedProjectDetails(db).catch((e: unknown) =>
-      console.warn('[Groups] Manual sync: project details refresh failed:', e instanceof Error ? e.message : String(e)),
+      logger.warn('[Groups] Manual sync: project details refresh failed:', e instanceof Error ? e.message : String(e)),
     );
     return { ok: true, count: ruddrProjectsCache?.length ?? 0 };
   });

--- a/src/services/github-discovery.ts
+++ b/src/services/github-discovery.ts
@@ -1,5 +1,6 @@
 import type { Database as SqlJsDatabase } from 'sql.js';
 import { saveDatabase } from '../storage/database';
+import { logger } from './logger';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const PER_PAGE = 100;
@@ -88,7 +89,7 @@ async function rateLimitAwarePause(state: DiscoveryState): Promise<void> {
   state.callsSinceLastPause++;
 
   if (state.callsSinceLastPause >= CALLS_PER_BATCH) {
-    console.log(`[Discovery] Pausing after ${state.callsSinceLastPause} API calls (batch cooldown)…`);
+    logger.debug(`[Discovery] Pausing after ${state.callsSinceLastPause} API calls (batch cooldown)…`);
     await sleep(BATCH_PAUSE_MS);
     state.callsSinceLastPause = 0;
   }
@@ -96,7 +97,7 @@ async function rateLimitAwarePause(state: DiscoveryState): Promise<void> {
   if (state.lastRateLimit && state.lastRateLimit.remaining < LOW_RATE_LIMIT_THRESHOLD) {
     const waitMs = state.lastRateLimit.reset * 1000 - Date.now() + 1000;
     if (waitMs > 0) {
-      console.log(
+      logger.debug(
         `[Discovery] Rate limit low (${state.lastRateLimit.remaining} remaining). ` +
           `Waiting ${Math.ceil(waitMs / 1000)}s until reset…`,
       );
@@ -132,7 +133,7 @@ async function githubGet<T>(
   const pageInfo = pageNum !== undefined && totalPages !== undefined
     ? ` — ${pageNum}/${totalPages} pages`
     : '';
-  console.log(
+  logger.debug(
     `[Discovery] ${url.replace(GITHUB_API_BASE, '')}${pageInfo} — ` +
       `rate limit: ${state.lastRateLimit.remaining}/${state.lastRateLimit.limit}`,
   );
@@ -141,7 +142,7 @@ async function githubGet<T>(
   if (response.status === 403 && state.lastRateLimit.remaining === 0) {
     const waitMs = state.lastRateLimit.reset * 1000 - Date.now() + 1000;
     if (waitMs > 0) {
-      console.log(`[Discovery] Rate limit exceeded. Waiting ${Math.ceil(waitMs / 1000)}s…`);
+      logger.debug(`[Discovery] Rate limit exceeded. Waiting ${Math.ceil(waitMs / 1000)}s…`);
       await sleep(waitMs);
     }
     state.callsSinceLastPause = 0;
@@ -230,7 +231,7 @@ async function fetchPagesSortedSince(
     if (sinceDate && result.data.length > 0) {
       const oldestOnPage = result.data[result.data.length - 1];
       if (oldestOnPage.updated_at && new Date(oldestOnPage.updated_at) < sinceDate) {
-        console.log(
+        logger.debug(
           `[Discovery] Early-stop after ${pagesFetched} page(s): oldest updated_at ${oldestOnPage.updated_at} < cutoff ${sinceDate.toISOString()}`,
         );
         break;
@@ -434,7 +435,7 @@ export async function runDiscovery(
 
   try {
     // ── Phase 1: Organizations ──────────────────────────────────────
-    console.log('[Discovery] Starting — fetching organizations…');
+    logger.debug('[Discovery] Starting — fetching organizations…');
     onProgress?.({ ...progress });
 
     const orgs = await fetchAllPages<{ login: string; description?: string | null }>(
@@ -444,7 +445,7 @@ export async function runDiscovery(
     );
 
     progress.orgsFound = orgs.length;
-    console.log(`[Discovery] Found ${orgs.length} organization(s)`);
+    logger.debug(`[Discovery] Found ${orgs.length} organization(s)`);
     onProgress?.({ ...progress });
 
     // Store orgs and map login → DB id
@@ -461,7 +462,7 @@ export async function runDiscovery(
     const oauthOrgLogins = new Set(orgs.map((o) => o.login.toLowerCase()));
     let patOnlyOrgs: { login: string; description?: string | null }[] = [];
     if (!state.aborted && pat) {
-      console.log('[Discovery] Checking for orgs visible only via PAT…');
+      logger.debug('[Discovery] Checking for orgs visible only via PAT…');
       try {
         const patOrgs = await fetchAllPages<{ login: string; description?: string | null }>(
           pat,
@@ -470,7 +471,7 @@ export async function runDiscovery(
         );
         patOnlyOrgs = patOrgs.filter((o) => !oauthOrgLogins.has(o.login.toLowerCase()));
         if (patOnlyOrgs.length > 0) {
-          console.log(
+          logger.debug(
             `[Discovery] Found ${patOnlyOrgs.length} org(s) only visible via PAT: ${patOnlyOrgs.map((o) => o.login).join(', ')}`,
           );
           for (const org of patOnlyOrgs) {
@@ -481,10 +482,10 @@ export async function runDiscovery(
           onProgress?.({ ...progress });
           saveDatabase();
         } else {
-          console.log('[Discovery] No additional orgs found via PAT');
+          logger.debug('[Discovery] No additional orgs found via PAT');
         }
       } catch (err) {
-        console.warn('[Discovery] PAT org check failed (non-fatal):', err);
+        logger.warn('[Discovery] PAT org check failed (non-fatal):', err);
       }
     }
 
@@ -498,12 +499,12 @@ export async function runDiscovery(
       if (state.aborted) break;
 
       if (disabledOrgs.has(org.login)) {
-        console.log(`[Discovery] Skipping disabled org: ${org.login}`);
+        logger.debug(`[Discovery] Skipping disabled org: ${org.login}`);
         continue;
       }
 
       progress.currentOrg = org.login;
-      console.log(`[Discovery] Fetching repos for org: ${org.login}`);
+      logger.debug(`[Discovery] Fetching repos for org: ${org.login}`);
       onProgress?.({ ...progress });
 
       const repos = await fetchAllPages<GitHubRepo>(
@@ -518,7 +519,7 @@ export async function runDiscovery(
       }
 
       progress.reposFound += repos.length;
-      console.log(`[Discovery]   ${org.login}: ${repos.length} repos (total: ${progress.reposFound})`);
+      logger.debug(`[Discovery]   ${org.login}: ${repos.length} repos (total: ${progress.reposFound})`);
       onProgress?.({ ...progress });
 
       saveDatabase();
@@ -529,12 +530,12 @@ export async function runDiscovery(
       if (state.aborted) break;
 
       if (disabledOrgs.has(org.login)) {
-        console.log(`[Discovery] Skipping disabled PAT-only org: ${org.login}`);
+        logger.debug(`[Discovery] Skipping disabled PAT-only org: ${org.login}`);
         continue;
       }
 
       progress.currentOrg = org.login;
-      console.log(`[Discovery] Fetching repos for PAT-only org: ${org.login}`);
+      logger.debug(`[Discovery] Fetching repos for PAT-only org: ${org.login}`);
       onProgress?.({ ...progress });
 
       try {
@@ -550,11 +551,11 @@ export async function runDiscovery(
         }
 
         progress.reposFound += repos.length;
-        console.log(`[Discovery]   ${org.login} (PAT): ${repos.length} repos (total: ${progress.reposFound})`);
+        logger.debug(`[Discovery]   ${org.login} (PAT): ${repos.length} repos (total: ${progress.reposFound})`);
         onProgress?.({ ...progress });
         saveDatabase();
       } catch (err) {
-        console.warn(`[Discovery] Skipping PAT-only org ${org.login} — ${err instanceof Error ? err.message : err}`);
+        logger.warn(`[Discovery] Skipping PAT-only org ${org.login} — ${err instanceof Error ? err.message : err}`);
       }
     }
 
@@ -562,7 +563,7 @@ export async function runDiscovery(
 
     // ── Phase 3: User-owned + collaborator + org-member repos
     if (!state.aborted) {
-      console.log('[Discovery] Fetching personal + collaborator + org-member repos…');
+      logger.debug('[Discovery] Fetching personal + collaborator + org-member repos…');
       progress.phase = 'user-repos';
       onProgress?.({ ...progress });
 
@@ -585,7 +586,7 @@ export async function runDiscovery(
         });
 
         if (externalRepos.length > 0) {
-          console.log(`[Discovery] Resolving collaboration reasons for ${externalRepos.length} external repos…`);
+          logger.debug(`[Discovery] Resolving collaboration reasons for ${externalRepos.length} external repos…`);
           collabReasons = await resolveCollaborationReasons(db, accessToken, userLogin, externalRepos, state);
         }
       }
@@ -613,11 +614,11 @@ export async function runDiscovery(
       }
 
       if (skippedDisabledOrg > 0) {
-        console.log(`[Discovery] Skipped ${skippedDisabledOrg} repos from disabled orgs in user-repos phase`);
+        logger.debug(`[Discovery] Skipped ${skippedDisabledOrg} repos from disabled orgs in user-repos phase`);
       }
 
       progress.reposFound += directRepos.length - skippedDisabledOrg;
-      console.log(`[Discovery] Personal + collaborator + org-member repos: ${directRepos.length} (total: ${progress.reposFound})`);
+      logger.debug(`[Discovery] Personal + collaborator + org-member repos: ${directRepos.length} (total: ${progress.reposFound})`);
       onProgress?.({ ...progress });
 
       saveDatabase();
@@ -640,16 +641,16 @@ export async function runDiscovery(
         ]);
         await runPatDiscovery(db, pat, state, progress, onProgress, userLogin, allScannedOrgLogins);
       } catch (err) {
-        console.error('[Discovery] PAT supplemental pass failed (non-fatal):', err);
+        logger.error('[Discovery] PAT supplemental pass failed (non-fatal):', err);
       }
     }
 
     progress.phase = 'done';
     onProgress?.({ ...progress });
-    console.log(`[Discovery] Complete — ${progress.orgsFound} orgs, ${progress.reposFound} repos`);
+    logger.debug(`[Discovery] Complete — ${progress.orgsFound} orgs, ${progress.reposFound} repos`);
   } catch (err) {
     if (!state.aborted) {
-      console.error('[Discovery] Error:', err);
+      logger.error('[Discovery] Error:', err);
     }
   }
 
@@ -679,7 +680,7 @@ export async function runLightweightRefresh(
 
   try {
     // Fetch current orgs
-    console.log('[LightRefresh] Checking for new organizations…');
+    logger.debug('[LightRefresh] Checking for new organizations…');
     onProgress?.({ ...progress });
 
     const orgs = await fetchAllPages<{ login: string; description?: string | null }>(
@@ -693,7 +694,7 @@ export async function runLightweightRefresh(
       upsertOrg(db, org);
     }
     saveDatabase();
-    console.log(`[LightRefresh] ${orgs.length} org(s) synced`);
+    logger.debug(`[LightRefresh] ${orgs.length} org(s) synced`);
     onProgress?.({ ...progress });
 
     const disabledOrgs = new Set(
@@ -703,7 +704,7 @@ export async function runLightweightRefresh(
     // Fetch personal + collaborator + org-member repos
     // Sort by updated desc so we can stop early once we've seen everything
     // newer than the last refresh — avoiding hundreds of pages of stale data.
-    console.log('[LightRefresh] Updating personal + collaborator + org-member repos…');
+    logger.debug('[LightRefresh] Updating personal + collaborator + org-member repos…');
     progress.phase = 'user-repos';
     onProgress?.({ ...progress });
 
@@ -733,7 +734,7 @@ export async function runLightweightRefresh(
       });
 
       if (externalRepos.length > 0) {
-        console.log(`[LightRefresh] Resolving collaboration reasons for ${externalRepos.length} external repos…`);
+        logger.debug(`[LightRefresh] Resolving collaboration reasons for ${externalRepos.length} external repos…`);
         collabReasons = await resolveCollaborationReasons(db, accessToken, userLogin, externalRepos, state);
       }
     }
@@ -761,13 +762,13 @@ export async function runLightweightRefresh(
     }
 
     if (skippedDisabledOrg > 0) {
-      console.log(`[LightRefresh] Skipped ${skippedDisabledOrg} repos from disabled orgs in user-repos phase`);
+      logger.debug(`[LightRefresh] Skipped ${skippedDisabledOrg} repos from disabled orgs in user-repos phase`);
     }
 
     progress.reposFound = directRepos.length - skippedDisabledOrg;
     setConfigValue(db, 'last_user_repos_refresh', new Date().toISOString());
     saveDatabase();
-    console.log(`[LightRefresh] ${directRepos.length} personal + collaborator + org-member repo(s) synced`);
+    logger.debug(`[LightRefresh] ${directRepos.length} personal + collaborator + org-member repo(s) synced`);
 
     // Fetch starred repos
     await fetchStarredRepos(db, accessToken, state, progress, onProgress);
@@ -778,14 +779,14 @@ export async function runLightweightRefresh(
         const oauthOrgLogins = new Set(orgs.map((o) => o.login.toLowerCase()));
         await runPatDiscovery(db, pat, state, progress, onProgress, userLogin, oauthOrgLogins);
       } catch (err) {
-        console.error('[LightRefresh] PAT supplemental pass failed (non-fatal):', err);
+        logger.error('[LightRefresh] PAT supplemental pass failed (non-fatal):', err);
       }
     }
 
     progress.phase = 'done';
     onProgress?.({ ...progress });
   } catch (err) {
-    console.error('[LightRefresh] Error:', err);
+    logger.error('[LightRefresh] Error:', err);
   }
 }
 
@@ -804,7 +805,7 @@ export async function fetchStarredRepos(
   progress: DiscoveryProgress,
   onProgress?: (progress: DiscoveryProgress) => void,
 ): Promise<void> {
-  console.log('[Discovery] Fetching starred repos…');
+  logger.debug('[Discovery] Fetching starred repos…');
   progress.phase = 'starred';
   onProgress?.({ ...progress });
 
@@ -825,7 +826,7 @@ export async function fetchStarredRepos(
   }
 
   progress.reposFound += starred.length;
-  console.log(`[Discovery] Starred repos: ${starred.length}`);
+  logger.debug(`[Discovery] Starred repos: ${starred.length}`);
   onProgress?.({ ...progress });
   saveDatabase();
 }
@@ -1000,7 +1001,7 @@ export async function runPatDiscovery(
     reposFound: 0,
   };
 
-  console.log('[PAT Discovery] Starting smart PAT pass…');
+  logger.debug('[PAT Discovery] Starting smart PAT pass…');
   prog.phase = 'pat-repos';
   onProgress?.({ ...prog });
 
@@ -1031,13 +1032,13 @@ export async function runPatDiscovery(
       (o) => !oauthOrgLogins.has(o.login.toLowerCase()),
     );
     if (oauthBlocked.length > 0) {
-      console.log(
+      logger.debug(
         `[PAT Discovery] Orgs blocked from OAuth (will rescan via PAT): ${oauthBlocked.map((o) => o.login).join(', ')}`,
       );
     }
   }
 
-  console.log(
+  logger.debug(
     `[PAT Discovery] ${patOrgs.length} org(s) via PAT, ` +
       `${existingOrgs.length} already indexed with repos, ` +
       `${orgsToScan.length} new/empty/OAuth-blocked org(s) to scan`,
@@ -1051,7 +1052,7 @@ export async function runPatDiscovery(
     prog.currentOrg = org.login;
     onProgress?.({ ...prog });
 
-    console.log(`[PAT Discovery] Fetching repos for org: ${org.login}`);
+    logger.debug(`[PAT Discovery] Fetching repos for org: ${org.login}`);
     try {
       const repos = await fetchAllPages<GitHubRepo>(
         pat,
@@ -1065,11 +1066,11 @@ export async function runPatDiscovery(
 
       prog.reposFound += repos.length;
       prog.orgsFound = (prog.orgsFound || 0) + 1;
-      console.log(`[PAT Discovery]   ${org.login}: ${repos.length} repos`);
+      logger.debug(`[PAT Discovery]   ${org.login}: ${repos.length} repos`);
       onProgress?.({ ...prog });
       saveDatabase();
     } catch (err) {
-      console.warn(`[PAT Discovery] Skipping org ${org.login} — ${err instanceof Error ? err.message : err}`);
+      logger.warn(`[PAT Discovery] Skipping org ${org.login} — ${err instanceof Error ? err.message : err}`);
     }
   }
   prog.currentOrg = undefined;
@@ -1078,7 +1079,7 @@ export async function runPatDiscovery(
   // affiliation=collaborator returns only repos where user is an
   // outside collaborator — much smaller than the full repo list.
   if (!st.aborted) {
-    console.log('[PAT Discovery] Fetching direct collaborator repos…');
+    logger.debug('[PAT Discovery] Fetching direct collaborator repos…');
     onProgress?.({ ...prog });
 
     const collabRepos = await fetchAllPages<GitHubRepo>(
@@ -1090,7 +1091,7 @@ export async function runPatDiscovery(
     // Resolve collaboration reasons for PAT collaborator repos
     let collabReasons: Map<string, string> | null = null;
     if (userLogin && !st.aborted && collabRepos.length > 0) {
-      console.log(`[PAT Discovery] Resolving collaboration reasons for ${collabRepos.length} collaborator repos…`);
+      logger.debug(`[PAT Discovery] Resolving collaboration reasons for ${collabRepos.length} collaborator repos…`);
       collabReasons = await resolveCollaborationReasons(db, pat, userLogin, collabRepos, st);
     }
 
@@ -1101,10 +1102,10 @@ export async function runPatDiscovery(
     }
 
     prog.reposFound += collabRepos.length;
-    console.log(`[PAT Discovery] Collaborator repos: ${collabRepos.length}`);
+    logger.debug(`[PAT Discovery] Collaborator repos: ${collabRepos.length}`);
     onProgress?.({ ...prog });
     saveDatabase();
   }
 
-  console.log(`[PAT Discovery] Complete — ${prog.orgsFound} new orgs, ${prog.reposFound} repos`);
+  logger.debug(`[PAT Discovery] Complete — ${prog.orgsFound} new orgs, ${prog.reposFound} repos`);
 }

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,0 +1,33 @@
+// ── Lightweight leveled logger wrapping console.* ────────────────────────────
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+const LEVEL_ORDER: Record<LogLevel, number> = { error: 0, warn: 1, info: 2, debug: 3 };
+
+let currentLevel: LogLevel = 'debug';
+
+export function setLogLevel(level: LogLevel): void {
+  currentLevel = level;
+}
+
+export function getLogLevel(): LogLevel {
+  return currentLevel;
+}
+
+function shouldLog(level: LogLevel): boolean {
+  return LEVEL_ORDER[level] <= LEVEL_ORDER[currentLevel];
+}
+
+export const logger = {
+  error(...args: unknown[]): void {
+    if (shouldLog('error')) console.error(...args);
+  },
+  warn(...args: unknown[]): void {
+    if (shouldLog('warn')) console.warn(...args);
+  },
+  info(...args: unknown[]): void {
+    if (shouldLog('info')) console.log(...args);
+  },
+  debug(...args: unknown[]): void {
+    if (shouldLog('debug')) console.log(...args);
+  },
+};

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -1,0 +1,174 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+/**
+ * Config plugin — IPC handler tests.
+ *
+ * Full-handler pattern: registers only the config handlers against a real
+ * in-memory DB, then invokes captured handlers directly to verify:
+ * - Onboarding status lookup
+ * - System locale passthrough
+ * - Preferences load/save + input validation
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import { getSchema } from '../../src/storage/schema';
+
+// ── Track registered handlers ─────────────────────────────────────────────────
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  app: {
+    isPackaged: false,
+    getSystemLocale: vi.fn().mockReturnValue('en-US'),
+  },
+}));
+
+vi.mock('../../src/agent/onboarding', () => ({
+  getOnboardingStatus: vi.fn().mockReturnValue({
+    ollama: 'pending',
+    local_repos: 'pending',
+    github_oauth: 'pending',
+  }),
+}));
+
+vi.mock('../../src/agent/config', () => ({
+  loadConfig: vi.fn().mockReturnValue({
+    preferences: { sortByNotifications: true },
+  }),
+  saveConfig: vi.fn(),
+}));
+
+import { registerHandlers } from '../../src/plugins/config/handler';
+import { getOnboardingStatus } from '../../src/agent/onboarding';
+import { loadConfig, saveConfig } from '../../src/agent/config';
+import { app } from 'electron';
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function callHandler(channel: string, ...args: unknown[]): unknown {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for channel "${channel}"`);
+  const fakeEvent = { sender: { id: 1, send: vi.fn(), isDestroyed: () => false } };
+  return handler(fakeEvent, ...args);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Config plugin — IPC handlers', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    process.env.JARVIS_ENCRYPTION_KEY = 'test-encryption-key-config-handler';
+    vi.clearAllMocks();
+    handlers.clear();
+
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+
+    registerHandlers(db, () => null);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── onboarding:status ─────────────────────────────────────────────────────
+
+  describe('onboarding:status', () => {
+    it('delegates to getOnboardingStatus', () => {
+      const result = callHandler('onboarding:status');
+      expect(getOnboardingStatus).toHaveBeenCalledWith(db);
+      expect(result).toEqual({
+        ollama: 'pending',
+        local_repos: 'pending',
+        github_oauth: 'pending',
+      });
+    });
+
+    it('returns an error object when the service throws', () => {
+      vi.mocked(getOnboardingStatus).mockImplementationOnce(() => {
+        throw new Error('db error');
+      });
+      const result = callHandler('onboarding:status') as Record<string, unknown>;
+      expect(result.ok).toBe(false);
+      expect(typeof result.error).toBe('string');
+    });
+  });
+
+  // ── app:get-system-locale ─────────────────────────────────────────────────
+
+  describe('app:get-system-locale', () => {
+    it('returns the system locale from electron', () => {
+      const result = callHandler('app:get-system-locale');
+      expect(app.getSystemLocale).toHaveBeenCalled();
+      expect(result).toBe('en-US');
+    });
+  });
+
+  // ── app:get-preferences ───────────────────────────────────────────────────
+
+  describe('app:get-preferences', () => {
+    it('returns preferences from the config file', () => {
+      const result = callHandler('app:get-preferences');
+      expect(loadConfig).toHaveBeenCalled();
+      expect(result).toEqual({ sortByNotifications: true });
+    });
+
+    it('returns an error object when loadConfig throws', () => {
+      vi.mocked(loadConfig).mockImplementationOnce(() => {
+        throw new Error('read error');
+      });
+      const result = callHandler('app:get-preferences') as Record<string, unknown>;
+      expect(result.ok).toBe(false);
+      expect(typeof result.error).toBe('string');
+    });
+  });
+
+  // ── app:set-preferences ───────────────────────────────────────────────────
+
+  describe('app:set-preferences', () => {
+    it('returns an error for a null prefs value', () => {
+      const result = callHandler('app:set-preferences', null);
+      expect(result).toEqual({ ok: false, error: 'Invalid preferences' });
+    });
+
+    it('returns an error for a non-object prefs value', () => {
+      const result = callHandler('app:set-preferences', 'nope');
+      expect(result).toEqual({ ok: false, error: 'Invalid preferences' });
+    });
+
+    it('returns an error for an array prefs value', () => {
+      const result = callHandler('app:set-preferences', []);
+      expect(result).toEqual({ ok: false, error: 'Invalid preferences' });
+    });
+
+    it('merges preferences and saves the config', () => {
+      const result = callHandler('app:set-preferences', { localSortByNotifs: true });
+      expect(result).toEqual({ ok: true });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preferences: expect.objectContaining({
+            sortByNotifications: true,
+            localSortByNotifs: true,
+          }),
+        }),
+      );
+    });
+
+    it('returns an error object when saveConfig throws', () => {
+      vi.mocked(saveConfig).mockImplementationOnce(() => {
+        throw new Error('write error');
+      });
+      const result = callHandler('app:set-preferences', { localSortByNotifs: true }) as Record<string, unknown>;
+      expect(result.ok).toBe(false);
+      expect(typeof result.error).toBe('string');
+    });
+  });
+});

--- a/tests/unit/discovery-handler.test.ts
+++ b/tests/unit/discovery-handler.test.ts
@@ -1,0 +1,221 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+/**
+ * Discovery plugin — IPC handler tests.
+ *
+ * Full-handler pattern: registers only the discovery handlers against a real
+ * in-memory DB, then invokes captured handlers directly (plus the exported
+ * `startDiscoveryIfAuthed` helper) to verify:
+ * - Discovery status reporting (idle vs. in-progress)
+ * - PAT-only discovery start + "no PAT configured" guard
+ * - startDiscoveryIfAuthed branch coverage (no auth, already running, stale
+ *   refresh, fresh data with missing starred repos, forced full discovery)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import { getSchema } from '../../src/storage/schema';
+
+// ── Track registered handlers ─────────────────────────────────────────────────
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  app: { isPackaged: false },
+}));
+
+vi.mock('../../src/storage/database', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/storage/database')>();
+  return {
+    ...actual,
+    saveDatabase: vi.fn(),
+    getConfigValue: vi.fn().mockReturnValue(null),
+    setConfigValue: vi.fn(),
+  };
+});
+
+vi.mock('../../src/services/github-oauth', () => ({
+  loadGitHubAuth: vi.fn().mockReturnValue(null),
+  loadGitHubPat: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/services/github-discovery', () => ({
+  runDiscovery: vi.fn().mockResolvedValue({}),
+  runLightweightRefresh: vi.fn().mockResolvedValue(undefined),
+  runPatDiscovery: vi.fn().mockResolvedValue(undefined),
+  fetchStarredRepos: vi.fn().mockResolvedValue(undefined),
+  getLastOrgIndexedAt: vi.fn().mockReturnValue(null),
+  listOrgs: vi.fn().mockReturnValue({ orgs: [], directRepoCount: 0, starredRepoCount: 0 }),
+}));
+
+import { registerHandlers, startDiscoveryIfAuthed } from '../../src/plugins/discovery/handler';
+import {
+  runDiscovery,
+  runLightweightRefresh,
+  runPatDiscovery,
+  fetchStarredRepos,
+  getLastOrgIndexedAt,
+  listOrgs,
+} from '../../src/services/github-discovery';
+import { loadGitHubAuth, loadGitHubPat } from '../../src/services/github-oauth';
+import { setActiveDiscovery, setLastDiscoveryProgress } from '../../src/plugins/discovery/state';
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function callHandler(channel: string, ...args: unknown[]): unknown {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for channel "${channel}"`);
+  const fakeEvent = { sender: { id: 1, send: vi.fn(), isDestroyed: () => false } };
+  return handler(fakeEvent, ...args);
+}
+
+function fakeWindow() {
+  return { webContents: { send: vi.fn() } } as unknown as Electron.BrowserWindow;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Discovery plugin — IPC handlers', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    process.env.JARVIS_ENCRYPTION_KEY = 'test-encryption-key-discovery-handler';
+    vi.clearAllMocks();
+    handlers.clear();
+    setActiveDiscovery(null);
+    setLastDiscoveryProgress(null);
+
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+
+    registerHandlers(db, () => null);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── github:discovery-status ───────────────────────────────────────────────
+
+  describe('github:discovery-status', () => {
+    it('falls back to listOrgs when no progress has been recorded yet', () => {
+      vi.mocked(listOrgs).mockReturnValueOnce({ orgs: [], directRepoCount: 0, starredRepoCount: 0 });
+      const result = callHandler('github:discovery-status') as Record<string, unknown>;
+      expect(result).toEqual({ running: false, progress: null, rateLimit: null });
+    });
+
+    it('reports a done progress when repos already exist and no live progress is tracked', () => {
+      vi.mocked(listOrgs).mockReturnValueOnce({
+        orgs: [{ login: 'acme', name: 'Acme', repoCount: 3 } as never],
+        directRepoCount: 1,
+        starredRepoCount: 0,
+      });
+      const result = callHandler('github:discovery-status') as Record<string, unknown>;
+      expect(result).toEqual({
+        running: false,
+        progress: { phase: 'done', orgsFound: 1, reposFound: 4 },
+        rateLimit: null,
+      });
+    });
+
+    it('reports recorded progress when a discovery run is in flight', () => {
+      setLastDiscoveryProgress({ phase: 'repos', orgsFound: 2, reposFound: 5 });
+      const result = callHandler('github:discovery-status') as Record<string, unknown>;
+      expect(result).toEqual({
+        running: false,
+        progress: { phase: 'repos', orgsFound: 2, reposFound: 5 },
+        rateLimit: null,
+      });
+    });
+  });
+
+  // ── github:start-discovery ────────────────────────────────────────────────
+
+  describe('github:start-discovery', () => {
+    it('returns started:true even when no auth is configured', () => {
+      const result = callHandler('github:start-discovery');
+      expect(result).toEqual({ started: true });
+    });
+  });
+
+  // ── github:start-pat-discovery ────────────────────────────────────────────
+
+  describe('github:start-pat-discovery', () => {
+    it('returns an error when no PAT is configured', () => {
+      vi.mocked(loadGitHubPat).mockReturnValueOnce(null);
+      const result = callHandler('github:start-pat-discovery');
+      expect(result).toEqual({ error: 'No PAT configured' });
+    });
+
+    it('starts PAT discovery when a PAT is configured', () => {
+      vi.mocked(loadGitHubPat).mockReturnValue('fake-pat');
+      vi.mocked(loadGitHubAuth).mockReturnValue({ login: 'octocat', accessToken: 'x', scopes: '', avatarUrl: null });
+      const result = callHandler('github:start-pat-discovery');
+      expect(result).toEqual({ started: true });
+      expect(runPatDiscovery).toHaveBeenCalledWith(db, 'fake-pat', undefined, undefined, expect.any(Function), 'octocat');
+    });
+  });
+
+  // ── startDiscoveryIfAuthed ─────────────────────────────────────────────────
+
+  describe('startDiscoveryIfAuthed', () => {
+    it('does nothing when there is no auth', () => {
+      vi.mocked(loadGitHubAuth).mockReturnValueOnce(null);
+      startDiscoveryIfAuthed(db, () => fakeWindow());
+      expect(runDiscovery).not.toHaveBeenCalled();
+      expect(runLightweightRefresh).not.toHaveBeenCalled();
+    });
+
+    it('skips when a discovery is already active and not aborted', () => {
+      vi.mocked(loadGitHubAuth).mockReturnValue({ login: 'octocat', accessToken: 'x', scopes: '', avatarUrl: null });
+      setActiveDiscovery({ callsSinceLastPause: 0, aborted: false, lastRateLimit: null });
+      startDiscoveryIfAuthed(db, () => fakeWindow());
+      expect(runDiscovery).not.toHaveBeenCalled();
+    });
+
+    it('runs a lightweight refresh when existing org data is stale', () => {
+      vi.mocked(loadGitHubAuth).mockReturnValue({ login: 'octocat', accessToken: 'x', scopes: '', avatarUrl: null });
+      vi.mocked(listOrgs).mockReturnValue({
+        orgs: [{ login: 'acme', name: 'Acme', repoCount: 3 } as never],
+        directRepoCount: 0,
+        starredRepoCount: 1,
+      });
+      vi.mocked(getLastOrgIndexedAt).mockReturnValue('2000-01-01 00:00:00');
+
+      startDiscoveryIfAuthed(db, () => fakeWindow());
+
+      expect(runLightweightRefresh).toHaveBeenCalled();
+      expect(runDiscovery).not.toHaveBeenCalled();
+    });
+
+    it('fetches starred repos when data is fresh but none are indexed yet', () => {
+      vi.mocked(loadGitHubAuth).mockReturnValue({ login: 'octocat', accessToken: 'x', scopes: '', avatarUrl: null });
+      vi.mocked(listOrgs).mockReturnValue({
+        orgs: [{ login: 'acme', name: 'Acme', repoCount: 3 } as never],
+        directRepoCount: 0,
+        starredRepoCount: 0,
+      });
+      vi.mocked(getLastOrgIndexedAt).mockReturnValue(new Date().toISOString().replace('T', ' ').slice(0, 19));
+
+      startDiscoveryIfAuthed(db, () => fakeWindow());
+
+      expect(fetchStarredRepos).toHaveBeenCalled();
+      expect(runLightweightRefresh).not.toHaveBeenCalled();
+      expect(runDiscovery).not.toHaveBeenCalled();
+    });
+
+    it('runs full discovery when forced with no existing orgs', () => {
+      vi.mocked(loadGitHubAuth).mockReturnValue({ login: 'octocat', accessToken: 'x', scopes: '', avatarUrl: null });
+      vi.mocked(listOrgs).mockReturnValue({ orgs: [], directRepoCount: 0, starredRepoCount: 0 });
+
+      startDiscoveryIfAuthed(db, () => fakeWindow(), true);
+
+      expect(runDiscovery).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger, setLogLevel, getLogLevel } from '../../src/services/logger';
+
+describe('logger', () => {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    console.log = vi.fn();
+    console.warn = vi.fn();
+    console.error = vi.fn();
+    setLogLevel('debug');
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+    setLogLevel('debug');
+  });
+
+  it('defaults to debug level', () => {
+    expect(getLogLevel()).toBe('debug');
+  });
+
+  it('logs everything at debug level', () => {
+    logger.error('e');
+    logger.warn('w');
+    logger.info('i');
+    logger.debug('d');
+    expect(console.error).toHaveBeenCalledWith('e');
+    expect(console.warn).toHaveBeenCalledWith('w');
+    expect(console.log).toHaveBeenCalledWith('i');
+    expect(console.log).toHaveBeenCalledWith('d');
+  });
+
+  it('suppresses info and debug at warn level', () => {
+    setLogLevel('warn');
+    logger.error('e');
+    logger.warn('w');
+    logger.info('i');
+    logger.debug('d');
+    expect(console.error).toHaveBeenCalledWith('e');
+    expect(console.warn).toHaveBeenCalledWith('w');
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('only logs errors at error level', () => {
+    setLogLevel('error');
+    logger.error('e');
+    logger.warn('w');
+    logger.info('i');
+    logger.debug('d');
+    expect(console.error).toHaveBeenCalledWith('e');
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('logs info and above but not debug at info level', () => {
+    setLogLevel('info');
+    logger.info('i');
+    logger.debug('d');
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith('i');
+  });
+});

--- a/tests/unit/orgs-handler.test.ts
+++ b/tests/unit/orgs-handler.test.ts
@@ -1,0 +1,124 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+/**
+ * Orgs plugin — IPC handler tests.
+ *
+ * Full-handler pattern: registers only the orgs handlers against a real
+ * in-memory DB, then invokes captured handlers directly to verify:
+ * - Org listing delegation + error path
+ * - Enable/disable discovery input validation and DB writes
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import { getSchema } from '../../src/storage/schema';
+
+// ── Track registered handlers ─────────────────────────────────────────────────
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  app: { isPackaged: false },
+}));
+
+vi.mock('../../src/storage/database', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/storage/database')>();
+  return { ...actual, saveDatabase: vi.fn() };
+});
+
+vi.mock('../../src/services/github-discovery', () => ({
+  listOrgs: vi.fn().mockReturnValue({ orgs: [], directRepoCount: 0, starredRepoCount: 0 }),
+  setOrgDiscoveryEnabled: vi.fn(),
+}));
+
+import { registerHandlers } from '../../src/plugins/orgs/handler';
+import { listOrgs, setOrgDiscoveryEnabled } from '../../src/services/github-discovery';
+import { saveDatabase } from '../../src/storage/database';
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function callHandler(channel: string, ...args: unknown[]): unknown {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for channel "${channel}"`);
+  const fakeEvent = { sender: { id: 1, send: vi.fn(), isDestroyed: () => false } };
+  return handler(fakeEvent, ...args);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Orgs plugin — IPC handlers', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    process.env.JARVIS_ENCRYPTION_KEY = 'test-encryption-key-orgs-handler';
+    vi.clearAllMocks();
+    handlers.clear();
+
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+
+    registerHandlers(db, () => null);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── github:list-orgs ──────────────────────────────────────────────────────
+
+  describe('github:list-orgs', () => {
+    it('delegates to listOrgs', () => {
+      const result = callHandler('github:list-orgs');
+      expect(listOrgs).toHaveBeenCalledWith(db);
+      expect(result).toEqual({ orgs: [], directRepoCount: 0, starredRepoCount: 0 });
+    });
+
+    it('returns an empty array when the service throws', () => {
+      vi.mocked(listOrgs).mockImplementationOnce(() => {
+        throw new Error('db error');
+      });
+      const result = callHandler('github:list-orgs');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── github:set-org-enabled ────────────────────────────────────────────────
+
+  describe('github:set-org-enabled', () => {
+    it('returns an error for a non-string orgLogin', () => {
+      const result = callHandler('github:set-org-enabled', 42, true);
+      expect(result).toEqual({ ok: false, error: 'Invalid orgLogin' });
+    });
+
+    it('returns an error for an empty orgLogin', () => {
+      const result = callHandler('github:set-org-enabled', '', true);
+      expect(result).toEqual({ ok: false, error: 'Invalid orgLogin' });
+    });
+
+    it('returns an error for a non-boolean enabled value', () => {
+      const result = callHandler('github:set-org-enabled', 'my-org', 'yes');
+      expect(result).toEqual({ ok: false, error: 'Invalid enabled value' });
+    });
+
+    it('sets discovery enabled and saves the database', () => {
+      const result = callHandler('github:set-org-enabled', 'my-org', false);
+      expect(result).toEqual({ ok: true });
+      expect(setOrgDiscoveryEnabled).toHaveBeenCalledWith(db, 'my-org', false);
+      expect(saveDatabase).toHaveBeenCalled();
+    });
+
+    it('returns an error object when the service throws', () => {
+      vi.mocked(setOrgDiscoveryEnabled).mockImplementationOnce(() => {
+        throw new Error('not found');
+      });
+      const result = callHandler('github:set-org-enabled', 'my-org', true) as Record<string, unknown>;
+      expect(result.ok).toBe(false);
+      expect(typeof result.error).toBe('string');
+    });
+  });
+});

--- a/tests/unit/repos-handler.test.ts
+++ b/tests/unit/repos-handler.test.ts
@@ -1,0 +1,162 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+/**
+ * Repos plugin — IPC handler tests.
+ *
+ * Full-handler pattern: registers only the repos handlers against a real
+ * in-memory DB seeded with github_orgs/github_repos rows, then invokes
+ * captured handlers directly to verify:
+ * - Search input validation and matching
+ * - Org-scoped repo listing (including "no org" repos)
+ * - Starred repo listing
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import { getSchema } from '../../src/storage/schema';
+
+// ── Track registered handlers ─────────────────────────────────────────────────
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  app: { isPackaged: false },
+}));
+
+import { registerHandlers } from '../../src/plugins/repos/handler';
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function callHandler(channel: string, ...args: unknown[]): unknown {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for channel "${channel}"`);
+  const fakeEvent = { sender: { id: 1, send: vi.fn(), isDestroyed: () => false } };
+  return handler(fakeEvent, ...args);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Repos plugin — IPC handlers', () => {
+  let db: SqlJsDatabase;
+
+  beforeEach(async () => {
+    process.env.JARVIS_ENCRYPTION_KEY = 'test-encryption-key-repos-handler';
+    vi.clearAllMocks();
+    handlers.clear();
+
+    const SQL = await initSqlJs();
+    db = new SQL.Database();
+    db.run(getSchema());
+
+    db.run(`INSERT INTO github_orgs (login, name, discovery_enabled) VALUES ('acme', 'Acme Inc', 1)`);
+    db.run(`INSERT INTO github_orgs (login, name, discovery_enabled) VALUES ('disabled-org', 'Disabled Org', 0)`);
+
+    db.run(
+      `INSERT INTO github_repos (org_id, full_name, name, description, language, private, fork, archived, starred, last_pushed_at)
+       VALUES (1, 'acme/widgets', 'widgets', 'Widget factory', 'TypeScript', 0, 0, 0, 0, '2026-01-01')`,
+    );
+    db.run(
+      `INSERT INTO github_repos (org_id, full_name, name, description, language, private, fork, archived, starred, last_pushed_at)
+       VALUES (2, 'disabled-org/hidden', 'hidden', 'Should not surface in search', 'Go', 0, 0, 0, 0, '2026-01-01')`,
+    );
+    db.run(
+      `INSERT INTO github_repos (org_id, full_name, name, description, language, private, fork, archived, starred, last_pushed_at)
+       VALUES (NULL, 'someone/starred-repo', 'starred-repo', 'A starred repo', 'JavaScript', 0, 0, 0, 1, '2026-02-01')`,
+    );
+
+    registerHandlers(db, () => null);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── github:search-repos ───────────────────────────────────────────────────
+
+  describe('github:search-repos', () => {
+    it('returns empty array for a non-string query', () => {
+      const result = callHandler('github:search-repos', 42);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array for a too-short query', () => {
+      const result = callHandler('github:search-repos', 'a');
+      expect(result).toEqual([]);
+    });
+
+    it('finds repos matching name', () => {
+      const result = callHandler('github:search-repos', 'widgets') as Array<{ full_name: string }>;
+      expect(result).toHaveLength(1);
+      expect(result[0].full_name).toBe('acme/widgets');
+    });
+
+    it('excludes repos belonging to orgs with discovery disabled', () => {
+      const result = callHandler('github:search-repos', 'hidden') as Array<{ full_name: string }>;
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when the query throws (invalid SQL surface)', () => {
+      const badDb = { prepare: () => { throw new Error('boom'); } } as unknown as SqlJsDatabase;
+      handlers.clear();
+      registerHandlers(badDb, () => null);
+      const result = callHandler('github:search-repos', 'widgets');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── github:list-repos-for-org ─────────────────────────────────────────────
+
+  describe('github:list-repos-for-org', () => {
+    it('returns an error for an invalid orgLogin type', () => {
+      const result = callHandler('github:list-repos-for-org', 42);
+      expect(result).toEqual({ ok: false, error: 'Invalid orgLogin' });
+    });
+
+    it('returns an error for an empty orgLogin', () => {
+      const result = callHandler('github:list-repos-for-org', '');
+      expect(result).toEqual({ ok: false, error: 'Invalid orgLogin' });
+    });
+
+    it('lists repos for a given org', () => {
+      const result = callHandler('github:list-repos-for-org', 'acme') as Array<{ full_name: string }>;
+      expect(result).toHaveLength(1);
+      expect(result[0].full_name).toBe('acme/widgets');
+    });
+
+    it('lists repos with no org when orgLogin is null', () => {
+      const result = callHandler('github:list-repos-for-org', null) as Array<{ full_name: string }>;
+      expect(result).toHaveLength(1);
+      expect(result[0].full_name).toBe('someone/starred-repo');
+    });
+
+    it('returns empty array when the query throws', () => {
+      const badDb = { prepare: () => { throw new Error('boom'); } } as unknown as SqlJsDatabase;
+      handlers.clear();
+      registerHandlers(badDb, () => null);
+      const result = callHandler('github:list-repos-for-org', 'acme');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── github:list-starred ───────────────────────────────────────────────────
+
+  describe('github:list-starred', () => {
+    it('returns only starred repos', () => {
+      const result = callHandler('github:list-starred') as Array<{ full_name: string }>;
+      expect(result).toHaveLength(1);
+      expect(result[0].full_name).toBe('someone/starred-repo');
+    });
+
+    it('returns empty array when the query throws', () => {
+      const badDb = { prepare: () => { throw new Error('boom'); } } as unknown as SqlJsDatabase;
+      handlers.clear();
+      registerHandlers(badDb, () => null);
+      const result = callHandler('github:list-starred');
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the "quick win" tasks from [#202](https://github.com/rajbos/Jarvis/issues/202) (Repository Quality Report — IPC Plugin Architecture Health):

- **Task 1 — Handler unit tests**: adds `tests/unit/config-handler.test.ts`, `tests/unit/orgs-handler.test.ts`, `tests/unit/repos-handler.test.ts`, and `tests/unit/discovery-handler.test.ts` (40 new tests) covering the four previously-untested plugin handlers — input validation, success paths, error paths, and (for discovery) the `startDiscoveryIfAuthed` branch logic.
- **Task 3 — Lightweight logger**: adds `src/services/logger.ts`, a small `error/warn/info/debug` leveled logger wrapping `console.*`. Wired up in `src/main/index.ts` to default to `warn` in packaged builds and `debug` in dev. Piloted on the two heaviest `console.*` emitters named in the report: `src/services/github-discovery.ts` (45 calls) and `src/plugins/groups/handler.ts` (29 calls).

Out of scope for this PR (left for a follow-up): splitting `types.ts` into per-domain modules, decomposing `DashboardPanel.tsx`/`index.tsx`, and adding negative-case tests to existing handler suites.

## Test plan

- [x] `npx vitest run` — 852/871 passing; the 19 failures are pre-existing `onenote-reader.test.ts` fixture issues (missing test-data files in `node_modules`), unrelated to this change
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all changed/added source files — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>