### PR TITLE
Dashboard design polish: layout, typography, delight (impeccable pass)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ test_output.txt
 
 # User-specific runtime config (may contain secrets)
 AppData/
+
+# Impeccable design skill local cache
+.impeccable/

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Rob (and similarly-minded developers/power users) who maintain many GitHub repositories at once. They use Jarvis during focused work sessions to triage notifications, check CI/workflow health, and jump into repos that need attention. Context is a busy desktop environment — the app runs alongside an editor and terminal, so information density and fast scanning matter more than visual flourish.
+
+## Product Purpose
+
+Jarvis is a locally-hosted assistant for GitHub repository maintenance: it surfaces notifications, failed runs, and local repo state across dozens of repos in one dashboard, so the user can quickly spot what needs attention and act on it (dismiss, analyse, open) without leaving the app. Success = the user can tell "what's on fire" and "what's fine" within seconds, and clear their queue with minimal clicks.
+
+## Brand Personality
+
+Efficient, technical, no-nonsense — a mission-control panel for repos, not a consumer dashboard. Dark, calm, information-dense; confidence comes from clarity and control, not decoration.
+
+## Anti-references
+
+Generic cream/light SaaS admin templates, bouncy consumer-app motion, decorative gradients or glassmorphism, anything that adds visual noise to an already data-dense triage screen.
+
+## Design Principles
+
+- Density with clarity: pack in real data, but use spacing and hierarchy so status is scannable at a glance, not a wall of rows.
+- Status is the hero: color and weight should draw the eye to what needs attention (failed runs, unread notifications) before anything else.
+- Consistent, predictable structure: same card/row/badge vocabulary everywhere so muscle memory works across tabs.
+- Actions stay close to context: dismiss/analyse/open live inline next to the item they act on, not in a separate panel.
+- Respect the user's flow: no unnecessary motion or confirmation friction for routine triage actions.
+
+## Accessibility & Inclusion
+
+Standard WCAG AA contrast on the dark theme (body text ≥4.5:1, large/status text ≥3:1). Keyboard-navigable list/panel interactions. Respect `prefers-reduced-motion` for any transitions. No additional accessibility requirements stated by the user.

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -460,6 +460,9 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
   const [workflowPathMap, setWorkflowPathMap] = useState<Map<string, string | null>>(new Map());
   const [dismissingGroup, setDismissingGroup] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  // Ids currently mid-dismiss-animation — kept in the list one beat longer so the
+  // row can fade/collapse out instead of vanishing instantly.
+  const [dismissingIds, setDismissingIds] = useState<ReadonlySet<string>>(new Set());
 
   useEffect(() => {
     if (!successMsg) return;
@@ -552,18 +555,26 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
   }, [notifications]);
 
   const handleDismiss = async (id: string) => {
+    setDismissingIds((prev) => new Set(prev).add(id));
     try {
       await window.jarvis.dismissNotification(id);
-      setNotifications((prev) => prev?.filter((n) => n.id !== id) ?? null);
       setSuccessMsg('✓ Notification dismissed');
     } catch (err) {
       console.error('[Dashboard] Failed to dismiss notification:', err);
+      setDismissingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+      return;
     }
+    // Let the exit transition play before actually removing the row.
+    setTimeout(() => {
+      setNotifications((prev) => prev?.filter((n) => n.id !== id) ?? null);
+      setDismissingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    }, 180);
   };
 
   const handleDismissGroup = async (workflowName: string | null, ids: string[]) => {
     const key = workflowName ?? '__other__';
     setDismissingGroup(key);
+    setDismissingIds((prev) => { const next = new Set(prev); for (const id of ids) next.add(id); return next; });
     let dismissed = 0;
     for (const id of ids) {
       try {
@@ -573,7 +584,10 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
         console.error('[Dashboard] Failed to dismiss notification:', err);
       }
     }
-    setNotifications((prev) => prev?.filter((n) => !ids.includes(n.id)) ?? null);
+    setTimeout(() => {
+      setNotifications((prev) => prev?.filter((n) => !ids.includes(n.id)) ?? null);
+      setDismissingIds((prev) => { const next = new Set(prev); for (const id of ids) next.delete(id); return next; });
+    }, 180);
     setDismissingGroup(null);
     if (dismissed > 0) {
       setSuccessMsg(`✓ ${dismissed} notification${dismissed > 1 ? 's' : ''} dismissed`);
@@ -623,7 +637,7 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
   const { groups, isGrouped } = groupDashNotifications(visible);
 
   const renderRow = (n: StoredNotification) => (
-    <div key={n.id} class="dash-notif-item">
+    <div key={n.id} class={`dash-notif-item${dismissingIds.has(n.id) ? ' dash-notif-item--dismissing' : ''}`}>
       <span class="dash-notif-icon" title={n.subject_type}>{subjectTypeIcon(n.subject_type)}</span>
       <div class="dash-notif-body">
         <span class="dash-notif-title">{n.subject_title}</span>
@@ -641,6 +655,7 @@ function NotificationList({ repoFullName, dismissedNotifIds }: { repoFullName: s
         <button
           class="dash-action-btn dash-notif-btn"
           onClick={(e) => { e.stopPropagation(); void handleDismiss(n.id); }}
+          disabled={dismissingIds.has(n.id)}
           title="Dismiss notification"
         >✕</button>
       </div>
@@ -1132,6 +1147,12 @@ function emptyMessage(card: CardFilter): string {
   }
 }
 
+// Whether the empty state for this filter is genuinely good news (queue cleared)
+// vs. just neutral/empty (e.g. "no healthy repos" is not something to celebrate).
+function isEmptyStatePositive(card: CardFilter): boolean {
+  return card === 'warnings' || card === 'notifications' || card === 'failed-runs' || card === 'all';
+}
+
 // ── Main Dashboard ────────────────────────────────────────────────────────────
 
 export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissedNotifIds?: ReadonlySet<string>; onOpenHistory?: () => void }) {
@@ -1477,7 +1498,7 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
         ) : (
           <div class="dash-repo-list">
           {sorted.length === 0 && (
-            <div class="dash-empty">{emptyMessage(cardFilter)}</div>
+            <div class={`dash-empty${isEmptyStatePositive(cardFilter) ? ' dash-empty--positive' : ''}`}>{emptyMessage(cardFilter)}</div>
           )}
           {sorted.map((repo) => (
             <RepoHealthRow

--- a/src/renderer/chat.css
+++ b/src/renderer/chat.css
@@ -40,7 +40,7 @@ body {
 }
 
 .chat-model-badge {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   font-family: 'Consolas', 'Courier New', monospace;
   background: #0a3d1f;
   color: #51cf66;
@@ -65,7 +65,7 @@ body {
   border: 1px solid transparent;
   border-radius: 4px;
   color: #445;
-  font-size: 0.95rem;
+  font-size: 1rem;
   padding: 0.15rem 0.3rem;
   line-height: 1;
   cursor: pointer;
@@ -115,7 +115,7 @@ body {
   justify-content: center;
   gap: 0.5rem;
   color: #667;
-  font-size: 0.88rem;
+  font-size: 1rem;
   text-align: center;
   padding: 2rem;
 }
@@ -127,7 +127,7 @@ body {
 
 .chat-empty p {
   color: #778;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   max-width: 280px;
 }
 
@@ -136,7 +136,7 @@ body {
   max-width: 85%;
   border-radius: 12px;
   padding: 0.65rem 0.95rem;
-  font-size: 0.88rem;
+  font-size: 1rem;
   line-height: 1.55;
   word-break: break-word;
 }
@@ -161,7 +161,7 @@ body {
   display: inline-block;
   color: #339af0;
   animation: blink 0.9s step-end infinite;
-  font-size: 0.9rem;
+  font-size: 1rem;
   line-height: 1;
   vertical-align: baseline;
   margin-left: 1px;
@@ -180,7 +180,7 @@ body {
   padding: 0.6rem 0.85rem;
   overflow-x: auto;
   font-family: 'Consolas', 'Courier New', monospace;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   margin: 0.5rem 0;
   white-space: pre;
   line-height: 1.45;
@@ -204,7 +204,7 @@ body {
 .message-content h5 {
   color: #a8c8f0;
   margin: 0.4rem 0 0.2rem;
-  font-size: 0.9rem;
+  font-size: 1rem;
 }
 
 /* -- Error bubble ------------------------------------------------*/
@@ -215,7 +215,7 @@ body {
   border: 1px solid #7a0000;
   border-radius: 6px;
   padding: 0.45rem 0.85rem;
-  font-size: 0.83rem;
+  font-size: 0.9375rem;
   max-width: 90%;
   text-align: center;
 }
@@ -239,7 +239,7 @@ body {
   border-radius: 8px;
   padding: 0.55rem 0.75rem;
   font-family: inherit;
-  font-size: 0.88rem;
+  font-size: 1rem;
   resize: none;
   outline: none;
   line-height: 1.45;
@@ -267,7 +267,7 @@ body {
   border: none;
   border-radius: 8px;
   padding: 0.55rem 1rem;
-  font-size: 0.88rem;
+  font-size: 1rem;
   cursor: pointer;
   transition: background 0.15s;
   flex-shrink: 0;
@@ -287,7 +287,7 @@ body {
 
 /* -- Hint text below input ---------------------------------------*/
 .chat-input-hint {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #445;
   padding: 0 0.85rem 0.4rem;
   background: #16213e;
@@ -303,7 +303,7 @@ body {
   padding: 0.4rem 1rem;
   background: #0f3460;
   border-bottom: 1px solid #1a4a8a;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #a8c8ff;
   flex-shrink: 0;
 }

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -476,7 +476,12 @@ button:disabled {
 }
 
 .dash-repo-warn {
-  border-left: 3px solid #e9a045;
+  border-color: rgba(233, 160, 69, 0.4);
+  background: linear-gradient(180deg, rgba(233, 160, 69, 0.05), transparent 40%), #16213e;
+}
+
+.dash-repo-warn:hover {
+  border-color: rgba(233, 160, 69, 0.6);
 }
 
 .dash-repo-main {
@@ -976,12 +981,12 @@ button:disabled {
 }
 
 .dash-triage-item--people {
-  border-left: 3px solid #4eca8a;
+  border-color: rgba(78, 202, 138, 0.35);
+  background: rgba(78, 202, 138, 0.04);
 }
 
 .dash-triage-item--bot-self {
-  border-left: 3px solid #6a7b95;
-  opacity: 0.9;
+  opacity: 0.75;
 }
 
 .dash-triage-item-main {
@@ -1137,9 +1142,8 @@ button:disabled {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  background: #16213e;
-  border: 1px solid #0f3460;
-  border-left: 3px solid #e94560;
+  background: rgba(233, 69, 96, 0.05);
+  border: 1px solid rgba(233, 69, 96, 0.35);
   border-radius: 6px;
   padding: 0.55rem 0.9rem;
   cursor: pointer;
@@ -3693,9 +3697,18 @@ h5.ec-heading { font-size: 0.85rem; }
   gap: 0.35rem;
 }
 
-.agent-finding--ignore { border-left: 3px solid #51cf66; }
-.agent-finding--investigate { border-left: 3px solid #ffd43b; }
-.agent-finding--action_required { border-left: 3px solid #e94560; }
+.agent-finding--ignore {
+  border-color: rgba(81, 207, 102, 0.35);
+  background: rgba(81, 207, 102, 0.04);
+}
+.agent-finding--investigate {
+  border-color: rgba(255, 212, 59, 0.35);
+  background: rgba(255, 212, 59, 0.04);
+}
+.agent-finding--action_required {
+  border-color: rgba(233, 69, 96, 0.4);
+  background: rgba(233, 69, 96, 0.05);
+}
 
 .agent-finding-header {
   display: flex;
@@ -3972,7 +3985,7 @@ h5.ec-heading { font-size: 0.85rem; }
   align-items: center;
   gap: 0.6rem;
   padding: 0.3rem 0.9rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
   background: transparent;
 }
 

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -23,16 +23,29 @@ button {
   border-radius: 6px;
   font-size: 1rem;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.2s, transform 0.1s cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 button:hover {
   background: #c23152;
 }
 
+button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
 button:disabled {
   background: #555;
   cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button {
+    transition: background 0.2s;
+  }
+  button:active:not(:disabled) {
+    transform: none;
+  }
 }
 
 .status-badge {
@@ -169,6 +182,18 @@ button:disabled {
 .dash-card-clickable:hover {
   background: #1a2a4e;
   transform: translateY(-1px);
+}
+
+.dash-card-clickable:active {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dash-card-clickable,
+  .dash-card-clickable:hover,
+  .dash-card-clickable:active {
+    transform: none;
+  }
 }
 
 .dash-card-selected {
@@ -753,12 +778,33 @@ button:disabled {
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid transparent;
-  transition: background 0.15s, border-color 0.15s;
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  transition: background 0.15s, border-color 0.15s,
+    opacity 0.18s cubic-bezier(0.25, 1, 0.5, 1),
+    transform 0.18s cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .dash-notif-item:hover {
   background: rgba(255, 255, 255, 0.04);
   border-color: #0f3460;
+}
+
+/* Dismissed rows fade + settle out before they're removed from the list —
+   a quick, quiet confirmation that the action landed. */
+.dash-notif-item--dismissing {
+  opacity: 0;
+  transform: translateX(6px) scale(0.98);
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dash-notif-item {
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .dash-notif-item--dismissing {
+    transform: none;
+  }
 }
 
 .dash-notif-item + .dash-notif-item {
@@ -1208,6 +1254,25 @@ button:disabled {
   color: #6a6a7a;
   padding: 2rem 0;
   font-size: 1rem;
+}
+
+/* Genuine good news (queue cleared) earns a quiet acknowledgment: a touch of
+   color and a brief settle-in, not a full celebration. */
+.dash-empty--positive {
+  color: #6fbf8a;
+  font-weight: 500;
+  animation: dash-empty-in 0.32s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+@keyframes dash-empty-in {
+  from { opacity: 0; transform: translateY(4px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dash-empty--positive {
+    animation: none;
+  }
 }
 
 .dash-footer {

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -21,7 +21,7 @@ button {
   border: none;
   padding: 0.6rem 1.2rem;
   border-radius: 6px;
-  font-size: 0.9rem;
+  font-size: 1rem;
   cursor: pointer;
   transition: background 0.2s;
 }
@@ -36,7 +36,7 @@ button:disabled {
 }
 
 .status-badge {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   padding: 2px 8px;
   border-radius: 10px;
   font-weight: 600;
@@ -57,7 +57,7 @@ button:disabled {
   border-bottom: 2px solid transparent;
   padding: 0.6rem 1.4rem;
   margin-bottom: -2px;
-  font-size: 0.95rem;
+  font-size: 1rem;
   cursor: pointer;
   transition: color 0.2s, border-color 0.2s;
   border-radius: 0;
@@ -88,7 +88,7 @@ button:disabled {
 }
 
 .dash-header h2 {
-  font-size: 1.2rem;
+  font-size: 1.25rem;
   color: #e0e0e0;
   margin: 0;
 }
@@ -100,7 +100,7 @@ button:disabled {
 }
 
 .dash-updated {
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   color: #6a6a7a;
 }
 
@@ -109,7 +109,7 @@ button:disabled {
   border: 1px solid #0f3460;
   color: #e0e0e0;
   padding: 0.35rem 0.8rem;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   border-radius: 6px;
   cursor: pointer;
   transition: background 0.2s;
@@ -188,7 +188,7 @@ button:disabled {
   position: absolute;
   top: 8px;
   right: 8px;
-  font-size: 0.95rem;
+  font-size: 1rem;
   line-height: 1;
   color: #ffffff;
   background: rgba(255,255,255,0.06);
@@ -246,7 +246,7 @@ button:disabled {
 }
 
 .dash-card-label {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #8a8a9a;
   margin-top: 0.25rem;
 }
@@ -269,7 +269,7 @@ button:disabled {
 }
 
 .dash-recoverable-icon {
-  font-size: 1.1rem;
+  font-size: 1.125rem;
   color: #4eca8a;
   flex-shrink: 0;
 }
@@ -283,13 +283,13 @@ button:disabled {
 }
 
 .dash-recoverable-title {
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #4eca8a;
 }
 
 .dash-recoverable-detail {
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   color: #5a9a74;
   white-space: nowrap;
   overflow: hidden;
@@ -301,7 +301,7 @@ button:disabled {
   border: 1px solid #1a7a44;
   color: #4eca8a;
   border-radius: 6px;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   font-weight: 600;
   line-height: 1.4;
   padding: 0.25rem 0.75rem;
@@ -329,7 +329,7 @@ button:disabled {
   border: 1px solid #1a4a6a;
   color: #5a9fd4;
   border-radius: 6px;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   font-weight: 600;
   line-height: 1.4;
   padding: 0.25rem 0.75rem;
@@ -371,7 +371,7 @@ button:disabled {
 }
 
 .dash-sort-label {
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   color: #6a6a8a;
   margin-right: 0.1rem;
 }
@@ -381,7 +381,7 @@ button:disabled {
   border: 1px solid #0f3460;
   color: #8a8a9a;
   padding: 0.2rem 0.55rem;
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
@@ -409,7 +409,7 @@ button:disabled {
   border: 1px solid #0f3460;
   color: #8a8a9a;
   padding: 0.25rem 0.65rem;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.2s;
@@ -432,7 +432,7 @@ button:disabled {
 }
 
 .dash-sort-label {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #6a6a7a;
   margin-right: 0.1rem;
 }
@@ -495,11 +495,11 @@ button:disabled {
 .dash-repo-name {
   font-weight: 600;
   color: #e0e0e0;
-  font-size: 0.92rem;
+  font-size: 1rem;
 }
 
 .dash-repo-branch {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #8a8a9a;
   background: rgba(255,255,255,0.05);
   padding: 1px 6px;
@@ -511,7 +511,7 @@ button:disabled {
 }
 
 .dash-repo-link {
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   color: #6a6a7a;
 }
 
@@ -522,7 +522,7 @@ button:disabled {
 }
 
 .dash-warning-pill {
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   padding: 2px 8px;
   border-radius: 10px;
   background: rgba(233, 160, 69, 0.12);
@@ -550,7 +550,7 @@ button:disabled {
 }
 
 .dash-ok-pill {
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   padding: 2px 8px;
   border-radius: 10px;
   background: rgba(76, 175, 80, 0.1);
@@ -558,7 +558,7 @@ button:disabled {
 }
 
 .dash-pill-count {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   margin-right: 8px;
   font-weight: 600;
   color: #c8c8c8;
@@ -566,7 +566,7 @@ button:disabled {
 
 /* Chevron expand indicator */
 .dash-repo-chevron {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   color: #6a6a7a;
   width: 1em;
   flex-shrink: 0;
@@ -597,7 +597,7 @@ button:disabled {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #c8c8c8;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -611,7 +611,7 @@ button:disabled {
 
 .dash-detail-chip.dash-detail-path {
   font-family: 'Consolas', 'Courier New', monospace;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #8a8a9a;
   max-width: 400px;
 }
@@ -649,7 +649,7 @@ button:disabled {
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   line-height: 1.35;
 }
 
@@ -669,7 +669,7 @@ button:disabled {
   border: 1px solid #0f3460;
   color: #c8c8c8;
   padding: 0.3rem 0.7rem;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   border-radius: 5px;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
@@ -685,7 +685,7 @@ button:disabled {
   margin-left: auto;
   flex-shrink: 0;
   padding: 0.2rem 0.55rem;
-  font-size: 0.76rem;
+  font-size: 0.875rem;
 }
 
 .dash-action-btn:disabled {
@@ -720,13 +720,13 @@ button:disabled {
 /* Notification list inside expanded repo */
 .dash-notif-loading,
 .dash-notif-empty {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #6a6a7a;
   padding: 0.4rem 0;
 }
 
 .dash-notif-success {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #4caf88;
   padding: 0.25rem 0.4rem;
   margin-bottom: 0.35rem;
@@ -739,7 +739,7 @@ button:disabled {
 }
 
 .dash-notif-header {
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #c8c8c8;
   margin-bottom: 0.4rem;
@@ -767,7 +767,7 @@ button:disabled {
 
 .dash-notif-icon {
   flex-shrink: 0;
-  font-size: 0.9rem;
+  font-size: 1rem;
   line-height: 1.4;
 }
 
@@ -780,7 +780,7 @@ button:disabled {
 }
 
 .dash-notif-title {
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   color: #d0d0e0;
   line-height: 1.3;
   overflow: hidden;
@@ -792,7 +792,7 @@ button:disabled {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
 }
 
 .dash-notif-reason {
@@ -835,7 +835,7 @@ button:disabled {
 
 .dash-notif-btn {
   padding: 0.15rem 0.4rem;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   min-width: unset;
 }
 
@@ -851,7 +851,7 @@ button:disabled {
   padding: 0.25rem 0.5rem;
   background: #0c1a2e;
   border-radius: 4px 4px 0 0;
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: #8bafd8;
   margin-bottom: 0.15rem;
@@ -877,7 +877,7 @@ button:disabled {
   color: #5a9fd4;
   border-radius: 4px;
   padding: 0 0.3rem;
-  font-size: 0.66rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   vertical-align: middle;
 }
@@ -887,7 +887,7 @@ button:disabled {
   color: #7ab3f5;
   border-radius: 10px;
   padding: 0.1rem 0.4rem;
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   flex-shrink: 0;
   line-height: 1.4;
@@ -912,7 +912,7 @@ button:disabled {
 }
 
 .dash-triage-kicker {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   color: #6f9bd0;
   text-transform: uppercase;
   letter-spacing: 0;
@@ -921,7 +921,7 @@ button:disabled {
 
 .dash-triage-title {
   color: #d8e4f2;
-  font-size: 0.92rem;
+  font-size: 1rem;
   font-weight: 700;
   margin-top: 0.15rem;
 }
@@ -942,7 +942,7 @@ button:disabled {
   color: #9aa8bd;
   border-radius: 5px;
   padding: 0.28rem 0.55rem;
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   font-weight: 700;
   cursor: pointer;
   white-space: nowrap;
@@ -1002,7 +1002,7 @@ button:disabled {
 
 .dash-triage-item-title {
   color: #d7deeb;
-  font-size: 0.86rem;
+  font-size: 0.9375rem;
   font-weight: 650;
   line-height: 1.35;
   overflow-wrap: anywhere;
@@ -1015,7 +1015,7 @@ button:disabled {
   flex-wrap: wrap;
   margin-top: 0.28rem;
   color: #7f8ca3;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
 }
 
 .dash-triage-repo {
@@ -1032,7 +1032,7 @@ button:disabled {
   background: rgba(0, 0, 0, 0.16);
   border-radius: 6px;
   color: #8793a8;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   line-height: 1.35;
 }
 
@@ -1046,7 +1046,7 @@ button:disabled {
 }
 
 .dash-group-status {
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   border-radius: 4px;
   padding: 0.1rem 0.4rem;
   line-height: 1.4;
@@ -1076,7 +1076,7 @@ button:disabled {
   border: 1px solid #1a7a44;
   color: #4eca8a;
   border-radius: 5px;
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   line-height: 1.4;
   padding: 0.1rem 0.45rem;
   cursor: pointer;
@@ -1102,7 +1102,7 @@ button:disabled {
   border: 1px solid #2a5298;
   color: #6ba3e8;
   border-radius: 5px;
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   line-height: 1.4;
   padding: 0.1rem 0.45rem;
   cursor: pointer;
@@ -1148,7 +1148,7 @@ button:disabled {
   padding: 0.55rem 0.9rem;
   cursor: pointer;
   transition: background 0.15s;
-  font-size: 0.84rem;
+  font-size: 0.9375rem;
 }
 
 .dash-failed-run:hover {
@@ -1160,7 +1160,7 @@ button:disabled {
   border: 1px solid #0f3460;
   color: #4590e9;
   padding: 0.35rem 0.8rem;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   border-radius: 4px;
   cursor: pointer;
   margin-top: 0.5rem;
@@ -1185,12 +1185,12 @@ button:disabled {
 
 .dash-run-branch {
   color: #8a8a9a;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
 }
 
 .dash-run-time {
   color: #6a6a7a;
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   min-width: 50px;
   text-align: right;
 }
@@ -1200,20 +1200,20 @@ button:disabled {
   text-align: center;
   color: #8a8a9a;
   padding: 3rem 0;
-  font-size: 0.95rem;
+  font-size: 1rem;
 }
 
 .dash-empty {
   text-align: center;
   color: #6a6a7a;
   padding: 2rem 0;
-  font-size: 0.9rem;
+  font-size: 1rem;
 }
 
 .dash-footer {
   text-align: right;
   color: #5a5a6a;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   margin-top: 0.5rem;
 }
 
@@ -1227,7 +1227,7 @@ button:disabled {
   padding: 0 5px;
   background: #e94560;
   color: #fff;
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   border-radius: 9px;
   flex-shrink: 0;
@@ -1241,7 +1241,7 @@ button:disabled {
 }
 
 .notif-badge-large {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   min-width: 22px;
   height: 22px;
   padding: 0 7px;
@@ -1263,7 +1263,7 @@ button:disabled {
 }
 
 .notif-refresh-btn {
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: #8892b0;
   cursor: pointer;
   padding: 0 0.15rem;
@@ -1291,7 +1291,7 @@ button:disabled {
   gap: 0.5rem;
   padding: 1.5rem 0.75rem;
   color: #8892b0;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
 }
 
 .repo-panel-spinner {
@@ -1317,7 +1317,7 @@ button:disabled {
 }
 
 .notif-involvement-direct {
-  font-size: 0.65rem;
+  font-size: 0.8125rem;
   padding: 2px 5px;
   border-radius: 3px;
   background: #2a1a5e;
@@ -1327,7 +1327,7 @@ button:disabled {
 }
 
 .notif-involvement-following {
-  font-size: 0.65rem;
+  font-size: 0.8125rem;
   padding: 2px 5px;
   border-radius: 3px;
   background: #1a2e1a;
@@ -1354,7 +1354,7 @@ button:disabled {
   background: none;
   border: none;
   color: #e0e0e0;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   text-align: left;
   padding: 0.4rem 0.75rem;
   cursor: pointer;
@@ -1372,7 +1372,7 @@ button:disabled {
 }
 
 .org-repos-count {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #8892b0;
 }
 
@@ -1416,7 +1416,7 @@ button:disabled {
 }
 
 .user-info .login {
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: #c8c8c8;
 }
 
@@ -1494,7 +1494,7 @@ body.onboarding {
 }
 
 .step h2 {
-  font-size: 1.1rem;
+  font-size: 1.125rem;
   margin-bottom: 0.5rem;
   display: flex;
   align-items: center;
@@ -1502,7 +1502,7 @@ body.onboarding {
 }
 
 .step p {
-  font-size: 0.9rem;
+  font-size: 1rem;
   color: #d4d4d4;
   margin-bottom: 1rem;
 }
@@ -1522,7 +1522,7 @@ body.onboarding {
 
 .code-instructions {
   text-align: center;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: #c8c8c8;
 }
 
@@ -1544,7 +1544,7 @@ body.onboarding {
   background: #0f3460;
   border-radius: 6px;
   margin-bottom: 0.35rem;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   cursor: pointer;
   transition: background 0.1s;
 }
@@ -1568,7 +1568,7 @@ body.onboarding {
 }
 
 .org-item .org-meta {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #c8c8c8;
   text-align: right;
   width: 6rem;
@@ -1647,7 +1647,7 @@ body.onboarding {
 }
 
 .org-panel-header {
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   margin-bottom: 0.5rem;
   color: #e0e0e0;
@@ -1677,7 +1677,7 @@ body.onboarding {
 }
 
 .repo-panel-title {
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #e0e0e0;
 }
@@ -1686,7 +1686,7 @@ body.onboarding {
   background: none;
   border: none;
   color: #999;
-  font-size: 1.1rem;
+  font-size: 1.125rem;
   cursor: pointer;
   padding: 0 0.35rem;
   line-height: 1;
@@ -1702,7 +1702,7 @@ body.onboarding {
 }
 
 .filter-label {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #c8c8c8;
   cursor: pointer;
   display: flex;
@@ -1719,7 +1719,7 @@ body.onboarding {
   background: #0f3460;
   border-radius: 6px;
   margin-bottom: 0.35rem;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   cursor: pointer;
   transition: background 0.1s;
 }
@@ -1737,7 +1737,7 @@ body.onboarding {
 
 .repo-card-desc {
   color: #c8c8c8;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   margin-bottom: 0.3rem;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -1754,7 +1754,7 @@ body.onboarding {
 }
 
 .repo-card-badge {
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   padding: 1px 5px;
   border-radius: 4px;
   background: #0a2d4d;
@@ -1767,12 +1767,12 @@ body.onboarding {
 }
 
 .repo-card-lang {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #c8c8c8;
 }
 
 .repo-card-date {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #b0b8c8;
 }
 
@@ -1865,7 +1865,7 @@ body.onboarding {
 }
 
 .sri-name {
-  font-size: 0.9rem;
+  font-size: 1rem;
   font-weight: 600;
   color: #e0e0e0;
   white-space: nowrap;
@@ -1874,7 +1874,7 @@ body.onboarding {
 }
 
 .sri-org {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #99a;
   white-space: nowrap;
   overflow: hidden;
@@ -1889,12 +1889,12 @@ body.onboarding {
 }
 
 .sri-lang {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #b0b0b0;
 }
 
 .sri-badge {
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   padding: 1px 5px;
   border-radius: 4px;
   background: #0a2d4d;
@@ -1903,7 +1903,7 @@ body.onboarding {
 
 .search-empty {
   padding: 0.75rem 0.9rem;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: #99a;
   text-align: center;
 }
@@ -1967,7 +1967,7 @@ body.onboarding {
   padding: 0.4rem 0.65rem;
   background: #0f3460;
   border-radius: 6px;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
 }
 
 .local-folder-path {
@@ -1977,11 +1977,11 @@ body.onboarding {
   overflow: hidden;
   text-overflow: ellipsis;
   font-family: 'Consolas', 'Courier New', monospace;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
 }
 
 .local-folder-count {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #c8c8c8;
   flex-shrink: 0;
 }
@@ -2004,7 +2004,7 @@ body.onboarding {
 
 /* ── Local repo card extras ───────────────────────────────────────────────── */
 .local-linked-badge {
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   padding: 1px 5px;
   border-radius: 4px;
   background: #0a3d1f;
@@ -2013,7 +2013,7 @@ body.onboarding {
 
 /* ── Local sort select ───────────────────────────────────────────────────── */
 .local-panel-count {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #8892b0;
   margin-left: 0.4rem;
   flex-shrink: 0;
@@ -2026,7 +2026,7 @@ body.onboarding {
   border: 1px solid #1a4a8a;
   border-radius: 4px;
   padding: 0.15rem 0.4rem;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   outline: none;
   cursor: pointer;
 }
@@ -2037,7 +2037,7 @@ body.onboarding {
 
 /* ── Favorite star ───────────────────────────────────────────────────────── */
 .fav-star {
-  font-size: 0.95rem;
+  font-size: 1rem;
   color: #556;
   cursor: pointer;
   flex-shrink: 0;
@@ -2141,7 +2141,7 @@ body.onboarding {
   background: #0f3460;
   border-radius: 5px;
   padding: 0.4rem 0.7rem;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   min-width: 0;
 }
 
@@ -2153,7 +2153,7 @@ body.onboarding {
 
 .ollama-model-meta {
   color: #99aabb;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   background: #16213e;
   border-radius: 3px;
   padding: 0.1rem 0.4rem;
@@ -2170,7 +2170,7 @@ body.onboarding {
   border: 1px solid #1a4a8a;
   border-radius: 4px;
   padding: 0.15rem 0.55rem;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   margin-left: auto;
@@ -2241,12 +2241,12 @@ body.onboarding {
 
 .ec-title {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 1rem;
   flex: 1;
 }
 
 .ec-model-badge {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   background: #0a3d1f;
   color: #51cf66;
   border: 1px solid #2b8a3e;
@@ -2278,7 +2278,7 @@ body.onboarding {
   background: none;
   border: none;
   color: #99a;
-  font-size: 1.2rem;
+  font-size: 1.25rem;
   padding: 0 0.25rem;
   cursor: pointer;
   line-height: 1;
@@ -2300,7 +2300,7 @@ body.onboarding {
 
 .ec-empty {
   color: #667;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   text-align: center;
   margin-top: 2rem;
   line-height: 1.5;
@@ -2309,7 +2309,7 @@ body.onboarding {
 .ec-bubble {
   padding: 0.5rem 0.75rem;
   border-radius: 8px;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   line-height: 1.55;
   max-width: 95%;
   word-break: break-word;
@@ -2348,7 +2348,7 @@ body.onboarding {
   border-radius: 4px;
   padding: 0.5rem;
   overflow-x: auto;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   margin: 0.25rem 0;
   white-space: pre;
 }
@@ -2367,14 +2367,14 @@ body.onboarding {
   font-weight: 600;
   line-height: 1.3;
 }
-h3.ec-heading { font-size: 0.95rem; }
-h4.ec-heading { font-size: 0.9rem; }
-h5.ec-heading { font-size: 0.85rem; }
+h3.ec-heading { font-size: 1rem; }
+h4.ec-heading { font-size: 1rem; }
+h5.ec-heading { font-size: 0.9375rem; }
 
 .ec-list {
   margin: 0.2rem 0 0.3rem 1.2rem;
   padding: 0;
-  font-size: 0.88rem;
+  font-size: 1rem;
   line-height: 1.5;
 }
 .ec-list li { margin-bottom: 0.1rem; }
@@ -2387,7 +2387,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .ec-error {
   color: #ff6b6b;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   padding: 0.4rem 0.6rem;
   background: #3a1a1a;
   border-radius: 6px;
@@ -2409,7 +2409,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #2a2a4a;
   border-radius: 6px;
   padding: 0.4rem 0.6rem;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   resize: none;
   font-family: inherit;
   line-height: 1.4;
@@ -2472,7 +2472,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 50%;
   width: 2.4rem;
   height: 2.4rem;
-  font-size: 1.1rem;
+  font-size: 1.125rem;
   cursor: pointer;
   padding: 0;
   line-height: 1;
@@ -2491,7 +2491,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #5a3ab8;
   color: #b4a4f8;
   border-radius: 5px;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   padding: 2px 8px;
   cursor: pointer;
   margin-right: 0.25rem;
@@ -2523,7 +2523,7 @@ h5.ec-heading { font-size: 0.85rem; }
   gap: 0.4rem;
   padding: 0.35rem 0.75rem;
   background: #0c1a2e;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: #8bafd8;
   user-select: none;
@@ -2544,7 +2544,7 @@ h5.ec-heading { font-size: 0.85rem; }
   color: #7ab3f5;
   border-radius: 10px;
   padding: 0.1rem 0.45rem;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   flex-shrink: 0;
   line-height: 1.4;
@@ -2558,14 +2558,14 @@ h5.ec-heading { font-size: 0.85rem; }
   color: #5a9fd4;
   border-radius: 4px;
   padding: 0 0.35rem;
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   vertical-align: middle;
 }
 
 /* ── Workflow group recovery status & dismiss-all button ─────────────────── */
 .notif-group-status {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   border-radius: 4px;
   padding: 0.1rem 0.45rem;
   line-height: 1.4;
@@ -2592,7 +2592,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #1a7a44;
   color: #4eca8a;
   border-radius: 5px;
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   line-height: 1.4;
   padding: 0.1rem 0.5rem;
   cursor: pointer;
@@ -2621,7 +2621,7 @@ h5.ec-heading { font-size: 0.85rem; }
   padding: 0.3rem 0.75rem 0.3rem 2.1rem;
   background: #1a0c0c;
   border-bottom: 1px solid #3a1a1a;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
 }
 .notif-failure-hint-job,
 .dash-failure-hint-job {
@@ -2637,7 +2637,7 @@ h5.ec-heading { font-size: 0.85rem; }
   padding: 0.2rem 0.5rem;
   border-radius: 0 3px 3px 0;
   font-family: ui-monospace, 'Cascadia Code', Consolas, monospace;
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   white-space: pre-wrap;
   word-break: break-all;
   line-height: 1.5;
@@ -2650,7 +2650,7 @@ h5.ec-heading { font-size: 0.85rem; }
   background: #2a1a4e;
   border-radius: 4px;
   padding: 0 0.35rem;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
 }
 
 /* ── Agent Selector Modal ─────────────────────────────────────────────────── */
@@ -2704,14 +2704,14 @@ h5.ec-heading { font-size: 0.85rem; }
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
 }
 .agent-scope-label { color: #8892b0; }
 .agent-scope-value { color: #e0e0e0; font-family: monospace; background: #0f3460; padding: 1px 6px; border-radius: 4px; }
 
 .agent-selector-loading, .agent-selector-empty {
   color: #8892b0;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
 }
 
 .agent-selector-field {
@@ -2721,7 +2721,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .agent-selector-label {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #8892b0;
   font-weight: 600;
 }
@@ -2732,11 +2732,11 @@ h5.ec-heading { font-size: 0.85rem; }
   color: #e0e0e0;
   border-radius: 5px;
   padding: 0.4rem 0.6rem;
-  font-size: 0.88rem;
+  font-size: 1rem;
 }
 
 .agent-selector-description {
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   color: #c8c8c8;
   font-style: italic;
   margin: 0;
@@ -2753,7 +2753,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .agent-workflow-hint {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #8892b0;
   margin: 0;
 }
@@ -2769,7 +2769,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #1a4a8a;
   color: #e0e0e0;
   border-radius: 5px;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   padding: 0.3rem 0.7rem;
   cursor: pointer;
   align-self: flex-start;
@@ -2781,7 +2781,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .agent-selector-error {
   color: #e94560;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   background: #240c14;
   border: 1px solid #e94560;
   border-radius: 5px;
@@ -2801,7 +2801,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 5px;
   padding: 0.4rem 0.9rem;
   cursor: pointer;
-  font-size: 0.88rem;
+  font-size: 1rem;
   transition: background 0.15s;
 }
 .agent-cancel-btn:hover:not(:disabled) { background: #0f3460; color: #e0e0e0; }
@@ -2813,7 +2813,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 5px;
   padding: 0.4rem 0.9rem;
   cursor: pointer;
-  font-size: 0.88rem;
+  font-size: 1rem;
   font-weight: 600;
   transition: background 0.15s;
 }
@@ -2850,7 +2850,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-header h2 {
   margin: 0;
-  font-size: 1.15rem;
+  font-size: 1.125rem;
   font-weight: 600;
   flex: 1;
 }
@@ -2861,7 +2861,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #1e2d5a;
   border-radius: 6px;
   color: #8898cc;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   cursor: pointer;
   white-space: nowrap;
   transition: border-color 0.15s, color 0.15s;
@@ -2901,7 +2901,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-card-name {
   font-weight: 600;
-  font-size: 0.98rem;
+  font-size: 1rem;
   color: #e0e0e0;
   white-space: nowrap;
   overflow: hidden;
@@ -2918,7 +2918,7 @@ h5.ec-heading { font-size: 0.85rem; }
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.84rem;
+  font-size: 0.9375rem;
   color: #a0a8c0;
 }
 
@@ -2959,12 +2959,12 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-ruddr-icon {
   flex-shrink: 0;
-  font-size: 0.9rem;
+  font-size: 1rem;
 }
 
 .groups-dash-ruddr-name {
   flex: 1;
-  font-size: 0.83rem;
+  font-size: 0.9375rem;
   color: #8ab4f8;
   font-weight: 500;
   white-space: nowrap;
@@ -2977,7 +2977,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: none;
   color: #6a748a;
   cursor: pointer;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0 0.2rem;
   line-height: 1;
   transition: color 0.15s;
@@ -2989,7 +2989,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: none;
   color: #6a748a;
   cursor: pointer;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   padding: 0 0.2rem;
   line-height: 1;
   transition: color 0.15s;
@@ -3002,7 +3002,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: none;
   color: #5a7a9a;
   cursor: pointer;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   padding: 0 0.2rem;
   line-height: 1;
   transition: color 0.15s;
@@ -3014,7 +3014,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: none;
   color: #5a7a9a;
   cursor: pointer;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   padding: 0 0.2rem;
   line-height: 1;
   transition: color 0.15s;
@@ -3022,21 +3022,21 @@ h5.ec-heading { font-size: 0.85rem; }
 .groups-dash-ruddr-edit-btn:hover { color: #8ab0d0; }
 
 .groups-dash-note-empty {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   color: #5a7a9a;
   opacity: 0.75;
   margin-right: 0.4rem;
 }
 
 .groups-dash-note-text {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   color: #e0e0e0;
 }
 
 /* Budget section container */
 .groups-dash-budget-section {
   padding: 0.2rem 0 0.35rem 0;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
 }
 
 /* Table-like row for billable / budget / left */
@@ -3064,7 +3064,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-budget-val {
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 1rem;
   color: #c8d8f0;
   line-height: 1.2;
   white-space: nowrap;
@@ -3078,7 +3078,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .groups-dash-budget-lbl {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
   color: #8a9aaa;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -3108,7 +3108,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 4px;
   color: #8ab4f8;
   cursor: pointer;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   padding: 0.3rem 0.6rem;
   text-align: left;
   transition: background 0.15s, border-color 0.15s;
@@ -3124,7 +3124,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .groups-dash-ruddr-error {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #e06060;
   padding: 0.2rem 0;
 }
@@ -3142,12 +3142,12 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-ruddr-login-icon {
   flex-shrink: 0;
-  font-size: 0.9rem;
+  font-size: 1rem;
 }
 
 .groups-dash-ruddr-login-msg {
   flex: 1;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #c8a8f8;
 }
 
@@ -3157,7 +3157,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 4px;
   color: #c8a8f8;
   cursor: pointer;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.2rem 0.55rem;
   flex-shrink: 0;
   transition: background 0.15s;
@@ -3171,7 +3171,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 4px;
   color: #a0a8c8;
   cursor: pointer;
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   margin-left: 0.5rem;
   padding: 0.15rem 0.45rem;
   transition: background 0.15s, color 0.15s;
@@ -3195,7 +3195,7 @@ h5.ec-heading { font-size: 0.85rem; }
   background: #1a2038;
   color: #9098b8;
   display: flex;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   justify-content: space-between;
   padding: 0.3rem 0.5rem;
 }
@@ -3205,7 +3205,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: none;
   color: #7880a0;
   cursor: pointer;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   line-height: 1;
   padding: 0 0.15rem;
 }
@@ -3216,7 +3216,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: none;
   border-bottom: 1px solid #2e3450;
   color: #d0d8f8;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   outline: none;
   padding: 0.3rem 0.5rem;
   width: 100%;
@@ -3240,7 +3240,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-ruddr-manual-item-name {
   flex: 1;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3248,7 +3248,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-ruddr-manual-empty {
   color: #606880;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.4rem 0.5rem;
   text-align: center;
 }
@@ -3273,13 +3273,13 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .groups-dash-ruddr-match-name {
   flex: 1;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   color: #c8d8f8;
   word-break: break-word;
 }
 
 .groups-dash-ruddr-match-score {
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   color: #5a7ab0;
   flex-shrink: 0;
   min-width: 2.5rem;
@@ -3293,7 +3293,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 4px;
   color: #8ab4f8;
   cursor: pointer;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.2rem 0.55rem;
   flex-shrink: 0;
   transition: background 0.15s;
@@ -3355,14 +3355,14 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .ruddr-projects-panel__header h3 {
   margin: 0;
-  font-size: 0.88rem;
+  font-size: 1rem;
   font-weight: 600;
   color: #c8d0f0;
   flex: 1;
 }
 
 .ruddr-projects-panel__count {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #6878a8;
 }
 
@@ -3373,7 +3373,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #1e2d5a;
   border-radius: 4px;
   color: #c8d0f0;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   padding: 0.28rem 0.5rem;
   outline: none;
 }
@@ -3384,7 +3384,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .ruddr-projects-panel__loading,
 .ruddr-projects-panel__empty {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #6878a8;
   padding: 0.2rem 0;
 }
@@ -3419,7 +3419,7 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .ruddr-projects-panel__name {
   flex: 1;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   color: #d0d8f0;
   line-height: 1.3;
   word-break: break-word;
@@ -3427,7 +3427,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .ruddr-projects-panel__date {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #5868a0;
   margin-top: 0.1rem;
 }
@@ -3440,7 +3440,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 3px;
   color: #5870a8;
   cursor: pointer;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   line-height: 1;
   padding: 0.1rem 0.3rem;
   transition: background 0.15s, color 0.15s;
@@ -3474,7 +3474,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #2a3a60;
   border-radius: 3px;
   color: #d0d8f0;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   outline: none;
   padding: 0.25rem 0.4rem;
 }
@@ -3483,7 +3483,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .ruddr-projects-panel__create-error {
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   color: #e07060;
 }
 
@@ -3499,7 +3499,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 3px;
   color: #8ab4f8;
   cursor: pointer;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.2rem 0.5rem;
   transition: background 0.15s;
 }
@@ -3517,7 +3517,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border-radius: 3px;
   color: #7880a0;
   cursor: pointer;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.2rem 0.4rem;
   transition: color 0.15s;
 }
@@ -3531,7 +3531,7 @@ h5.ec-heading { font-size: 0.85rem; }
   background: #1a0a40;
   border-bottom: 1px solid #3d2a8a;
   color: #b4a4f8;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.3rem 0.8rem;
   display: flex;
   align-items: center;
@@ -3596,7 +3596,7 @@ h5.ec-heading { font-size: 0.85rem; }
   background: transparent;
   border: none;
   color: #5580a8;
-  font-size: 11px;
+  font-size: 0.8125rem;
   cursor: pointer;
   font-family: inherit;
 }
@@ -3613,7 +3613,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .ec-debug-label {
-  font-size: 10px;
+  font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: #5580a8;
@@ -3624,7 +3624,7 @@ h5.ec-heading { font-size: 0.85rem; }
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
-  font-size: 11px;
+  font-size: 0.8125rem;
   color: #99b8cc;
   background: #0c1a28;
   border: 1px solid #1a3060;
@@ -3655,19 +3655,19 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .agent-approval-title {
-  font-size: 0.88rem;
+  font-size: 1rem;
   font-weight: 700;
   color: #e0e0e0;
 }
 
 .agent-approval-meta {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #8892b0;
   font-family: monospace;
 }
 
 .agent-findings-section-title {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   font-weight: 700;
   color: #8892b0;
   text-transform: uppercase;
@@ -3682,7 +3682,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .agent-no-findings {
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   color: #8892b0;
   font-style: italic;
 }
@@ -3718,13 +3718,13 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .agent-finding-subject {
   flex: 1;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #e0e0e0;
 }
 
 .agent-finding-badge {
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   padding: 1px 6px;
   border-radius: 4px;
   font-weight: 700;
@@ -3735,13 +3735,13 @@ h5.ec-heading { font-size: 0.85rem; }
 .agent-finding-badge--action_required { background: #3d0a14; color: #e94560; }
 
 .agent-finding-reason {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #c8c8c8;
   margin: 0;
 }
 
 .agent-finding-pattern {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #8892b0;
   margin: 0;
   font-style: italic;
@@ -3758,7 +3758,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .agent-finding-issue-title {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #c8c8c8;
 }
 
@@ -3766,7 +3766,7 @@ h5.ec-heading { font-size: 0.85rem; }
   background: none;
   border: none;
   color: #339af0;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   cursor: pointer;
   padding: 0;
   text-align: left;
@@ -3774,7 +3774,7 @@ h5.ec-heading { font-size: 0.85rem; }
 .agent-toggle-body-btn:hover { text-decoration: underline; }
 
 .agent-issue-body {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #c8c8c8;
   background: #0f3460;
   border-radius: 4px;
@@ -3793,7 +3793,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .agent-action-label {
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: #ccd6f6;
   font-weight: 500;
   flex: 1;
@@ -3809,7 +3809,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #51cf66;
   color: #51cf66;
   border-radius: 5px;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.25rem 0.6rem;
   cursor: pointer;
   transition: background 0.15s;
@@ -3822,7 +3822,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #8892b0;
   color: #8892b0;
   border-radius: 5px;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   padding: 0.25rem 0.6rem;
   cursor: pointer;
   transition: background 0.15s;
@@ -3831,7 +3831,7 @@ h5.ec-heading { font-size: 0.85rem; }
 .agent-reject-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .agent-finding-state {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #8892b0;
   font-style: italic;
 }
@@ -3928,7 +3928,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .bg-status-text {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #8892b0;
   letter-spacing: 0.02em;
   white-space: nowrap;
@@ -3958,14 +3958,14 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .bg-status-rate-sep {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: rgba(255, 255, 255, 0.25);
   user-select: none;
   flex-shrink: 0;
 }
 
 .bg-status-rate-limit {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   white-space: nowrap;
@@ -3990,7 +3990,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .dash-auto-dismiss-mini-label {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #7ab3f5;
 }
 
@@ -3999,7 +3999,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #1e3a5a;
   color: #7ab3f5;
   border-radius: 4px;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   padding: 0.1rem 0.45rem;
   cursor: pointer;
   transition: color 0.12s, border-color 0.12s;
@@ -4068,13 +4068,13 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .adh-title {
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #7ab3f5;
 }
 
 .adh-subtitle {
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   color: #8ab4e8;
 }
 
@@ -4090,7 +4090,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #1e3a5a;
   color: #7ab3f5;
   border-radius: 5px;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   padding: 0.2rem 0.6rem;
   cursor: pointer;
   transition: background 0.12s;
@@ -4111,7 +4111,7 @@ h5.ec-heading { font-size: 0.85rem; }
   background: transparent;
   border: none;
   color: #4a6a9a;
-  font-size: 1.1rem;
+  font-size: 1.125rem;
   line-height: 1;
   cursor: pointer;
   padding: 0.1rem 0.3rem;
@@ -4127,7 +4127,7 @@ h5.ec-heading { font-size: 0.85rem; }
 .adh-empty {
   padding: 1rem;
   color: #8ab4e8;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   text-align: center;
 }
 
@@ -4152,7 +4152,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .adh-entry-icon {
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   flex-shrink: 0;
   padding-top: 0.1rem;
   color: #4eca8a;
@@ -4166,7 +4166,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .adh-entry-title {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #c8d8ff;
   white-space: nowrap;
   overflow: hidden;
@@ -4181,12 +4181,12 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .adh-entry-repo {
-  font-size: 0.74rem;
+  font-size: 0.875rem;
   color: #8ab4e8;
 }
 
 .adh-entry-reason {
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   color: #5a9a74;
   background: #0d2a1a;
   border-radius: 3px;
@@ -4194,7 +4194,7 @@ h5.ec-heading { font-size: 0.85rem; }
 }
 
 .adh-entry-date {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #6a9ac0;
 }
 
@@ -4219,7 +4219,7 @@ h5.ec-heading { font-size: 0.85rem; }
   border: 1px solid #1e3a5a;
   color: #7ab3f5;
   border-radius: 5px;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   padding: 0.2rem 0.6rem;
   cursor: pointer;
   transition: background 0.12s;
@@ -4251,12 +4251,12 @@ h5.ec-heading { font-size: 0.85rem; }
 
 .adh-chart-empty {
   color: #8ab4e8;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   padding: 0.75rem 0;
 }
 
 .adh-chart-note {
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   color: #6a9ac0;
   margin-top: 0.4rem;
   text-align: right;

--- a/src/renderer/settings.css
+++ b/src/renderer/settings.css
@@ -13,7 +13,7 @@ body {
 }
 
 h1 {
-  font-size: 1.2rem;
+  font-size: 1.25rem;
   margin-bottom: 1rem;
   color: #e94560;
   font-weight: 700;
@@ -34,12 +34,12 @@ h1 {
   color: #b0b8c8;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
 }
 
 label {
   display: block;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: #c8c8c8;
   margin-bottom: 0.4rem;
 }
@@ -52,7 +52,7 @@ input[type="password"] {
   border: 1px solid #444;
   background: #1a1a2e;
   color: #e0e0e0;
-  font-size: 0.83rem;
+  font-size: 0.9375rem;
 }
 
 .btn-row {
@@ -69,7 +69,7 @@ button {
   border: none;
   padding: 0.35rem 0.8rem;
   border-radius: 6px;
-  font-size: 0.82rem;
+  font-size: 0.9375rem;
   cursor: pointer;
   transition: background 0.15s;
   white-space: nowrap;
@@ -117,21 +117,21 @@ button:disabled {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: #6fbf73;
   margin-bottom: 0.5rem;
 }
 
 .pat-error {
   color: #e94560;
-  font-size: 0.8rem;
+  font-size: 0.9375rem;
   margin-top: 0.35rem;
   min-height: 1.1em;
 }
 
 .hint {
   color: #8899aa;
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   margin-top: 0.5rem;
   line-height: 1.4;
 }
@@ -166,13 +166,13 @@ code {
 }
 
 .user-card-name {
-  font-size: 0.88rem;
+  font-size: 1rem;
   font-weight: 600;
   color: #e0e0e0;
 }
 
 .user-card-login {
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   color: #b0b8c8;
 }
 
@@ -193,7 +193,7 @@ code {
   border: 1px solid #334;
   color: #b0b8c8;
   padding: 0.25rem 0.65rem;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   border-radius: 4px;
   cursor: pointer;
 }
@@ -216,7 +216,7 @@ code {
   border-radius: 6px;
   color: #c8d8e8;
   font-family: 'Consolas', 'Fira Mono', monospace;
-  font-size: 0.77rem;
+  font-size: 0.875rem;
   line-height: 1.5;
   padding: 0.6rem 0.75rem;
   resize: vertical;


### PR DESCRIPTION
## Summary of Changes

Three iterative design passes on the Repo Dashboard UI using the `impeccable` skill, each verified with a full build + test run and committed separately:

1. **Layout** - Removed the "side-stripe border" anti-pattern (colored `border-left` accents) from warning/failure/finding cards across `onboarding.css`, replacing them with full-border tints + subtle background washes. Tightened spacing rhythm on notification dismiss controls. Also added `PRODUCT.md` at the repo root capturing the app's design register (mission-control / no-nonsense product tool, dark theme, anti-glassmorphism) so future design passes have a consistent reference.
2. **Typeset** - Consolidated a "muddy" font-size scale (~22 near-duplicate values between 0.65rem-1rem, several under the 13px readability floor) down to a clean, purposeful scale across `onboarding.css`, `settings.css`, and `chat.css`. Fixes the "text is really small" readability complaint.
3. **Delight** - Added a small set of subtle, professional touches consistent with the product's no-nonsense personality (no confetti, no playful copy, no bouncy motion):
   - Notification rows fade+settle out (180ms) before removal instead of vanishing instantly.
   - Global `button:active` press feedback (`translateY(1px)`).
   - Empty-state acknowledgment: only genuinely good-news filters (all-clear, inbox-zero, all-green runs) get a quiet green tint + gentle entrance animation; neutral empty states (e.g. "no healthy repos") stay neutral so they don't misrepresent the result.
   - All new animations respect `prefers-reduced-motion`.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Tests

## How to Test

1. Run `npm run build` and `npm test` (871/871 tests passing).
2. Open the Repo Dashboard and check notification cards/warnings/failed-run tiles for full-border (not side-stripe) accents.
3. Compare text sizes across the dashboard for improved readability.
4. Dismiss a notification to see the fade-out transition; click a filter tile to see press feedback; clear all warnings/notifications to see the quiet green empty-state acknowledgment (vs. neutral for filters like "healthy" with zero results).

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated (if applicable) - added `PRODUCT.md`
- [x] No secrets or sensitive data committed

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>