### PR TITLE
Add build step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
Adds only the missing build step to the existing CI workflow.

Preserves the current workflow behavior:
- pinned action SHAs / versions
- pull_request branch coverage for all branches
- permissions block
- lint, tests, coverage, and coverage artifact upload

New step added:
- `npm run build` after `npm ci` and before lint/test.