### PR TITLE
Group npm Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@ updates:
   groups:
     dev-dependencies:
       dependency-type: development
+      applies-to: version-updates
     production-dependencies:
       dependency-type: production
+      applies-to: version-updates
+    npm-security-updates:
+      applies-to: security-updates
+      patterns:
+      - "*"
   package-ecosystem: npm
   schedule:
     interval: weekly


### PR DESCRIPTION
## Summary
- Keeps existing npm production/dev dependency groups for version updates
- Explicitly scopes those groups to version updates with `applies-to: version-updates`
- Adds an npm security update group with `applies-to: security-updates` so security fixes like transitive `fast-uri` / `undici` updates are grouped instead of opened as individual PRs

## Validation
- Parsed `.github/dependabot.yml` successfully with Python YAML parser
