### PR TITLE
Centralize background tasks with main-process scheduler

### DIFF
--- a/src/main/background-tasks.ts
+++ b/src/main/background-tasks.ts
@@ -1,0 +1,137 @@
+import { ipcMain, type BrowserWindow } from 'electron';
+import type { Database as SqlJsDatabase } from 'sql.js';
+import { TaskScheduler } from './task-scheduler';
+import type { TaskRunRecord, TaskStatus } from './task-scheduler';
+import { getScanFolders } from '../services/local-discovery';
+import { startLocalScanIfNeeded } from '../plugins/local-repos/handler';
+import { runBootWorkflowCheck, syncGitHubNotifications, runAutoDismissSweep } from '../plugins/notifications/handler';
+import { refreshRuddrProjectsInBackground, prewarmRuddrCache } from '../plugins/groups/handler';
+
+export const LOCAL_DISCOVERY_INITIAL_DELAY_MS = 30_000;
+export const LOCAL_DISCOVERY_INTERVAL_MS = 60 * 60 * 1000;
+export const RUDDR_REFRESH_INITIAL_DELAY_MS = 30_000;
+export const RUDDR_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+export const GITHUB_NOTIFICATIONS_INITIAL_DELAY_MS = 60_000;
+export const GITHUB_NOTIFICATIONS_INTERVAL_MS = 5 * 60 * 1000;
+export const GITHUB_AUTO_DISMISS_INITIAL_DELAY_MS = 90_000;
+export const GITHUB_AUTO_DISMISS_INTERVAL_MS = 10 * 60 * 1000;
+
+let scheduler: TaskScheduler | null = null;
+
+function broadcastTaskUpdate(getWindow: () => BrowserWindow | null, record: TaskRunRecord): void {
+  const win = getWindow();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('tasks:run-complete', record);
+  }
+}
+
+function registerTask(
+  taskScheduler: TaskScheduler,
+  getWindow: () => BrowserWindow | null,
+  definition: Parameters<TaskScheduler['register']>[0],
+): void {
+  taskScheduler.register({
+    ...definition,
+    run: async () => {
+      const result = await definition.run();
+      return result;
+    },
+  });
+}
+
+export function createBackgroundTaskScheduler(
+  db: SqlJsDatabase,
+  getWindow: () => BrowserWindow | null,
+): TaskScheduler {
+  const taskScheduler = new TaskScheduler((record) => broadcastTaskUpdate(getWindow, record));
+
+  registerTask(taskScheduler, getWindow, {
+    id: 'github-workflow-cache-prewarm',
+    label: 'GitHub workflow cache prewarm',
+    run: async () => {
+      await runBootWorkflowCheck(db, getWindow);
+      return { ok: true };
+    },
+  });
+
+  registerTask(taskScheduler, getWindow, {
+    id: 'local-discovery',
+    label: 'Local repo discovery',
+    initialDelayMs: LOCAL_DISCOVERY_INITIAL_DELAY_MS,
+    intervalMs: LOCAL_DISCOVERY_INTERVAL_MS,
+    run: () => {
+      const folders = getScanFolders(db);
+      if (folders.length === 0) return { skipped: true, reason: 'No scan folders configured' };
+      const started = startLocalScanIfNeeded(db, getWindow);
+      return { started, folderCount: folders.length };
+    },
+  });
+
+  registerTask(taskScheduler, getWindow, {
+    id: 'ruddr-project-refresh',
+    label: 'Ruddr project refresh',
+    initialDelayMs: RUDDR_REFRESH_INITIAL_DELAY_MS,
+    intervalMs: RUDDR_REFRESH_INTERVAL_MS,
+    run: () => refreshRuddrProjectsInBackground(db, getWindow, true),
+  });
+
+  registerTask(taskScheduler, getWindow, {
+    id: 'github-notifications-sync',
+    label: 'GitHub notifications sync',
+    initialDelayMs: GITHUB_NOTIFICATIONS_INITIAL_DELAY_MS,
+    intervalMs: GITHUB_NOTIFICATIONS_INTERVAL_MS,
+    run: () => syncGitHubNotifications(db, getWindow),
+  });
+
+  registerTask(taskScheduler, getWindow, {
+    id: 'github-auto-dismiss',
+    label: 'GitHub auto-dismiss sweep',
+    initialDelayMs: GITHUB_AUTO_DISMISS_INITIAL_DELAY_MS,
+    intervalMs: GITHUB_AUTO_DISMISS_INTERVAL_MS,
+    run: () => runAutoDismissSweep(db, getWindow),
+  });
+
+  return taskScheduler;
+}
+
+export function startBackgroundTasks(
+  db: SqlJsDatabase,
+  getWindow: () => BrowserWindow | null,
+  options: { githubReady: boolean } = { githubReady: true },
+): TaskScheduler {
+  scheduler?.stop();
+  scheduler = createBackgroundTaskScheduler(db, getWindow);
+  scheduler.start();
+
+  void prewarmRuddrCache(db).catch((err: unknown) => {
+    console.warn('[Tasks] Ruddr cache pre-warm failed:', err instanceof Error ? err.message : String(err));
+  });
+
+  if (options.githubReady) {
+    void scheduler.runNow('github-workflow-cache-prewarm');
+  }
+
+  return scheduler;
+}
+
+export function stopBackgroundTasks(): void {
+  scheduler?.stop();
+  scheduler = null;
+}
+
+export function getBackgroundTaskScheduler(): TaskScheduler | null {
+  return scheduler;
+}
+
+export function registerTaskIpcHandlers(): void {
+  ipcMain.handle('tasks:list', (): TaskStatus[] => scheduler?.listTasks() ?? []);
+  ipcMain.handle('tasks:run-now', async (_event, taskId: string): Promise<TaskRunRecord | { ok: false; error: string }> => {
+    if (typeof taskId !== 'string' || taskId.length === 0) return { ok: false, error: 'Invalid taskId' };
+    if (!scheduler) return { ok: false, error: 'Task scheduler is not running' };
+    try {
+      return await scheduler.runNow(taskId);
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,8 @@ import { createOnboardingWindow, createSettingsWindow } from './windows';
 
 import { getOnboardingStatus, completeOnboardingStep } from '../agent/onboarding';
 
-import { registerIpcHandlers, startDiscoveryIfAuthed, scheduleLocalDiscovery, runBootWorkflowCheck, prewarmRuddrCache, scheduleRuddrProjectsRefresh } from './ipc-handlers';
+import { registerIpcHandlers, startDiscoveryIfAuthed } from './ipc-handlers';
+import { startBackgroundTasks, stopBackgroundTasks } from './background-tasks';
 
 import { checkOllama } from '../services/ollama';
 
@@ -170,32 +171,21 @@ async function initialize(): Promise<void> {
 
   // If GitHub auth is already set up, start background discovery
 
-  if (!needsOnboarding || onboarding.github_oauth === 'completed') {
+  const githubReady = !needsOnboarding || onboarding.github_oauth === 'completed';
+
+  if (githubReady) {
 
     startDiscoveryIfAuthed(db, () => mainWindow);
-
-    // Pre-warm workflow run cache so recovery status is ready when panels open
-
-    runBootWorkflowCheck(db, () => mainWindow).catch((err) => {
-
-      console.warn('[Boot] Workflow check failed:', err instanceof Error ? err.message : String(err));
-
-    });
 
   }
 
 
 
-  // Schedule periodic local-repo scanning
+  // Start centralized main-process background jobs. These continue to run even
 
-  scheduleLocalDiscovery(db, () => mainWindow);
+  // when renderer panels are not mounted.
 
-  // Pre-warm Ruddr projects cache after startup settles
-  prewarmRuddrCache(db).catch((err: unknown) => {
-    console.warn('[Boot] Ruddr cache pre-warm failed:', err instanceof Error ? err.message : String(err));
-  });
-  // Schedule hourly Ruddr project refresh and new-project notifications
-  scheduleRuddrProjectsRefresh(db, () => mainWindow);
+  startBackgroundTasks(db, () => mainWindow, { githubReady });
 
 
 
@@ -361,6 +351,8 @@ app.on('window-all-closed', () => {
 
 
 app.on('before-quit', () => {
+
+  stopBackgroundTasks();
 
   stopBridgeServer();
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -43,6 +43,7 @@ import { registerHandlers as registerGroupsHandlers } from '../plugins/groups/ha
 import { registerHandlers as registerOnedriveHandlers } from '../plugins/onedrive/handler';
 
 import { registerHandlers as registerBrowserCompanionHandlers } from '../plugins/browser-companion/handler';
+import { registerTaskIpcHandlers } from './background-tasks';
 
 
 
@@ -50,17 +51,6 @@ import { registerHandlers as registerBrowserCompanionHandlers } from '../plugins
 
 export { startDiscoveryIfAuthed } from '../plugins/discovery/handler';
 
-// Re-export scheduleLocalDiscovery so src/main/index.ts can call it on startup
-
-export { scheduleLocalDiscovery } from '../plugins/local-repos/handler';
-
-// Re-export runBootWorkflowCheck so src/main/index.ts can call it on startup
-
-export { runBootWorkflowCheck } from '../plugins/notifications/handler';
-// Re-export prewarmRuddrCache so src/main/index.ts can call it on startup
-export { prewarmRuddrCache } from '../plugins/groups/handler';
-// Re-export scheduleRuddrProjectsRefresh so src/main/index.ts can call it on startup
-export { scheduleRuddrProjectsRefresh } from '../plugins/groups/handler';
 
 
 
@@ -101,6 +91,8 @@ export function registerIpcHandlers(
   registerOnedriveHandlers(db, getWindow);
 
   registerBrowserCompanionHandlers(db, getWindow);
+
+  registerTaskIpcHandlers();
 
 }
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -310,4 +310,22 @@ contextBridge.exposeInMainWorld('jarvis', {
   logAutoDismiss: (entries: unknown[]) => ipcRenderer.invoke('github:log-auto-dismiss', entries),
   listAutoDismissLog: (limit?: number) => ipcRenderer.invoke('github:list-auto-dismiss-log', limit),
   getAutoDismissStats: () => ipcRenderer.invoke('github:auto-dismiss-stats'),
+  // Background tasks
+  listBackgroundTasks: () => ipcRenderer.invoke('tasks:list'),
+  runBackgroundTaskNow: (taskId: string) => ipcRenderer.invoke('tasks:run-now', taskId),
+  onBackgroundTaskComplete: (callback: (record: unknown) => void) => {
+    const listener = (_event: unknown, record: unknown) => callback(record);
+    ipcRenderer.on('tasks:run-complete', listener);
+    return () => { ipcRenderer.removeListener('tasks:run-complete', listener); };
+  },
+  onNotificationCountsUpdated: (callback: (counts: unknown) => void) => {
+    const listener = (_event: unknown, counts: unknown) => callback(counts);
+    ipcRenderer.on('github:notification-counts-updated', listener);
+    return () => { ipcRenderer.removeListener('github:notification-counts-updated', listener); };
+  },
+  onAutoDismissComplete: (callback: (payload: unknown) => void) => {
+    const listener = (_event: unknown, payload: unknown) => callback(payload);
+    ipcRenderer.on('github:auto-dismiss-complete', listener);
+    return () => { ipcRenderer.removeListener('github:auto-dismiss-complete', listener); };
+  },
 });

--- a/src/main/task-scheduler.ts
+++ b/src/main/task-scheduler.ts
@@ -1,0 +1,187 @@
+export type TaskRunStatus = 'success' | 'failed' | 'skipped';
+
+export interface TaskRunRecord {
+  taskId: string;
+  status: TaskRunStatus;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  result?: unknown;
+  error?: string;
+}
+
+export interface TaskStatus {
+  id: string;
+  label: string;
+  running: boolean;
+  intervalMs?: number;
+  initialDelayMs?: number;
+  nextRunAt?: string;
+  lastStartedAt?: string;
+  lastFinishedAt?: string;
+  lastDurationMs?: number;
+  lastStatus?: TaskRunStatus;
+  lastError?: string;
+  lastResult?: unknown;
+}
+
+export interface TaskDefinition {
+  id: string;
+  label: string;
+  initialDelayMs?: number;
+  intervalMs?: number;
+  run: () => Promise<unknown> | unknown;
+}
+
+interface RegisteredTask extends TaskDefinition {
+  running: boolean;
+  timer?: ReturnType<typeof setTimeout>;
+  nextRunAt?: string;
+  lastRun?: TaskRunRecord;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class TaskScheduler {
+  private readonly tasks = new Map<string, RegisteredTask>();
+  private started = false;
+
+  constructor(private readonly onRunComplete?: (record: TaskRunRecord) => void) {}
+
+  register(definition: TaskDefinition): void {
+    if (this.tasks.has(definition.id)) {
+      throw new Error(`Task already registered: ${definition.id}`);
+    }
+    this.tasks.set(definition.id, {
+      ...definition,
+      running: false,
+    });
+
+    if (this.started && definition.intervalMs !== undefined) {
+      this.scheduleNext(definition.id, definition.initialDelayMs ?? definition.intervalMs);
+    }
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    for (const task of this.tasks.values()) {
+      if (task.intervalMs !== undefined) {
+        this.scheduleNext(task.id, task.initialDelayMs ?? task.intervalMs);
+      }
+    }
+  }
+
+  stop(): void {
+    this.started = false;
+    for (const task of this.tasks.values()) {
+      if (task.timer) clearTimeout(task.timer);
+      task.timer = undefined;
+      task.nextRunAt = undefined;
+    }
+  }
+
+  listTasks(): TaskStatus[] {
+    return [...this.tasks.values()].map((task) => this.toStatus(task));
+  }
+
+  getTask(id: string): TaskStatus | null {
+    const task = this.tasks.get(id);
+    return task ? this.toStatus(task) : null;
+  }
+
+  async runNow(id: string): Promise<TaskRunRecord> {
+    const task = this.tasks.get(id);
+    if (!task) throw new Error(`Unknown task: ${id}`);
+    return this.runTask(task);
+  }
+
+  private scheduleNext(id: string, delayMs: number): void {
+    const task = this.tasks.get(id);
+    if (!task || !this.started || task.intervalMs === undefined) return;
+
+    if (task.timer) clearTimeout(task.timer);
+    const safeDelay = Math.max(0, delayMs);
+    task.nextRunAt = new Date(Date.now() + safeDelay).toISOString();
+    task.timer = setTimeout(() => {
+      task.timer = undefined;
+      task.nextRunAt = undefined;
+      void this.runTask(task).finally(() => {
+        if (this.started && task.intervalMs !== undefined) {
+          this.scheduleNext(task.id, task.intervalMs);
+        }
+      });
+    }, safeDelay);
+  }
+
+  private async runTask(task: RegisteredTask): Promise<TaskRunRecord> {
+    if (task.running) {
+      const skippedAt = nowIso();
+      return {
+        taskId: task.id,
+        status: 'skipped',
+        startedAt: skippedAt,
+        finishedAt: skippedAt,
+        durationMs: 0,
+        error: 'Task already running',
+      };
+    }
+
+    task.running = true;
+    const startedAtMs = Date.now();
+    const startedAt = nowIso();
+    try {
+      const result = await task.run();
+      const finishedAt = nowIso();
+      const record: TaskRunRecord = {
+        taskId: task.id,
+        status: 'success',
+        startedAt,
+        finishedAt,
+        durationMs: Date.now() - startedAtMs,
+        result,
+      };
+      task.lastRun = record;
+      this.onRunComplete?.(record);
+      return record;
+    } catch (err) {
+      const finishedAt = nowIso();
+      const record: TaskRunRecord = {
+        taskId: task.id,
+        status: 'failed',
+        startedAt,
+        finishedAt,
+        durationMs: Date.now() - startedAtMs,
+        error: errorMessage(err),
+      };
+      task.lastRun = record;
+      this.onRunComplete?.(record);
+      return record;
+    } finally {
+      task.running = false;
+    }
+  }
+
+  private toStatus(task: RegisteredTask): TaskStatus {
+    return {
+      id: task.id,
+      label: task.label,
+      running: task.running,
+      intervalMs: task.intervalMs,
+      initialDelayMs: task.initialDelayMs,
+      nextRunAt: task.nextRunAt,
+      lastStartedAt: task.lastRun?.startedAt,
+      lastFinishedAt: task.lastRun?.finishedAt,
+      lastDurationMs: task.lastRun?.durationMs,
+      lastStatus: task.lastRun?.status,
+      lastError: task.lastRun?.error,
+      lastResult: task.lastRun?.result,
+    };
+  }
+}

--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+import { useState, useEffect, useCallback } from 'preact/hooks';
 import type {
   DashboardSummary,
   RepoHealthStatus,
   HealthWarning,
   StoredNotification,
-  AutoDismissLogInput,
+  BackgroundTaskStatus,
 } from '../types';
 import { AgentSelector } from '../agents/AgentSelector';
 // ── Failure hint helpers ──────────────────────────────────────────────────────────
@@ -29,236 +29,12 @@ function extractErrorHint(logExcerpt: string | null): string | null {
   }
   return null;
 }
-// ── Auto-dismiss pipeline ─────────────────────────────────────────────────────
-// Replaces RecoverableBanner and ClosedPrBanner with fully-automatic dismissal.
-// Runs once after the dashboard summary loads.
-
-interface AutoDismissStepResult {
-  id: string;
-  label: string;
-  dismissed: number;
-}
+// ── Auto-dismiss summary banner ───────────────────────────────────────────────
 
 interface AutoDismissRunResult {
-  steps: AutoDismissStepResult[];
+  steps: Array<{ id: string; label: string; dismissed: number }>;
   total: number;
 }
-
-/**
- * Module-level cooldown so repeated tab switches (which remount DashboardPanel)
- * don't re-trigger the pipeline more often than this interval. Notifications for
- * already-closed issues/PRs can surface hours or days after the close (e.g. a new
- * mention on an old closed issue), so a single run-once-per-session sweep misses them.
- */
-const AUTO_DISMISS_INTERVAL_MS = 10 * 60 * 1000;
-let lastAutoDismissRunAt = 0;
-
-async function runRecoverableStep(repoFullNames: string[]): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
-  const logEntries: AutoDismissLogInput[] = [];
-  let dismissed = 0;
-  for (const repoFullName of repoFullNames) {
-    try {
-      const notifs = await window.jarvis.listNotificationsForRepo(repoFullName);
-      const ciNotifs = notifs.filter((n) => n.subject_type === 'CheckSuite' || n.subject_type === 'WorkflowRun');
-      if (ciNotifs.length === 0) continue;
-
-      let summary = await window.jarvis.githubGetWorkflowSummary(repoFullName);
-      if (summary.total_runs === 0) {
-        await window.jarvis.githubFetchWorkflowRuns(repoFullName);
-        summary = await window.jarvis.githubGetWorkflowSummary(repoFullName);
-      }
-
-      const byWorkflow = new Map<string, StoredNotification[]>();
-      for (const n of ciNotifs) {
-        const name = n.subject_title.match(/^(.+?)\s+workflow\s+run/i)?.[1]?.trim() ?? n.subject_title;
-        if (!byWorkflow.has(name)) byWorkflow.set(name, []);
-        byWorkflow.get(name)!.push(n);
-      }
-
-      for (const [workflowName, wNotifs] of byWorkflow) {
-        const branch = wNotifs[0].subject_title.match(/\bfor\s+(\S+)\s+branch\b/i)?.[1] ?? null;
-        const latestNotifTime = Math.max(...wNotifs.map((n) => new Date(n.updated_at).getTime()));
-        const recovered = summary.recent_runs.some(
-          (r) =>
-            r.workflow_name === workflowName &&
-            (branch === null || r.head_branch === branch) &&
-            r.conclusion === 'success' &&
-            new Date(r.run_started_at).getTime() > latestNotifTime,
-        );
-        if (recovered) {
-          for (const n of wNotifs) {
-            try {
-              await window.jarvis.dismissNotification(n.id);
-              logEntries.push({
-                notification_id: n.id,
-                reason: 'recovered_workflow',
-                repo_full_name: repoFullName,
-                subject_title: n.subject_title,
-                subject_type: n.subject_type,
-              });
-              dismissed++;
-            } catch { /* skip individual */ }
-          }
-        }
-      }
-    } catch { /* non-fatal per repo */ }
-  }
-  return { dismissed, logEntries };
-}
-
-async function runClosedPrStep(): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
-  const logEntries: AutoDismissLogInput[] = [];
-  let dismissed = 0;
-  try {
-    const allPrNotifs = await window.jarvis.listPrNotifications();
-    const byUrl = new Map<string, StoredNotification[]>();
-    for (const n of allPrNotifs) {
-      if (!n.subject_url) continue;
-      if (!byUrl.has(n.subject_url)) byUrl.set(n.subject_url, []);
-      byUrl.get(n.subject_url)!.push(n);
-    }
-    const urlEntries = [...byUrl.entries()];
-    const CONCURRENCY = 8;
-    const BATCH_SIZE = 200;
-    for (let offset = 0; offset < urlEntries.length; offset += BATCH_SIZE) {
-      const batch = urlEntries.slice(offset, offset + BATCH_SIZE);
-      let nextIdx = 0;
-      const worker = async () => {
-        while (nextIdx < batch.length) {
-          const idx = nextIdx++;
-          const [url, urlNotifs] = batch[idx];
-          try {
-            const result = await window.jarvis.githubGetPrState(url);
-            if (!result || result.state === 'open') continue;
-            const { state, isDependabot, closedByMe } = result;
-            if (!isDependabot && !closedByMe) continue;
-            const reason: AutoDismissLogInput['reason'] =
-              isDependabot ? 'closed_pr_dependabot'
-              : state === 'merged' ? 'closed_pr_merged_me'
-              : 'closed_pr_closed_me';
-            for (const n of urlNotifs) {
-              try {
-                await window.jarvis.dismissNotification(n.id);
-                logEntries.push({
-                  notification_id: n.id,
-                  reason,
-                  repo_full_name: n.repo_full_name,
-                  subject_title: n.subject_title,
-                  subject_type: n.subject_type,
-                });
-                dismissed++;
-              } catch { /* skip individual */ }
-            }
-          } catch { /* skip individual PR */ }
-        }
-      };
-      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, batch.length) }, worker));
-    }
-  } catch { /* non-fatal */ }
-  return { dismissed, logEntries };
-}
-
-async function runClosedIssueStep(): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
-  const logEntries: AutoDismissLogInput[] = [];
-  let dismissed = 0;
-  try {
-    const allIssueNotifs = await window.jarvis.listIssueNotifications();
-    const byUrl = new Map<string, StoredNotification[]>();
-    for (const n of allIssueNotifs) {
-      if (!n.subject_url) continue;
-      if (!byUrl.has(n.subject_url)) byUrl.set(n.subject_url, []);
-      byUrl.get(n.subject_url)!.push(n);
-    }
-    const urlEntries = [...byUrl.entries()];
-    const CONCURRENCY = 8;
-    const BATCH_SIZE = 200;
-    for (let offset = 0; offset < urlEntries.length; offset += BATCH_SIZE) {
-      const batch = urlEntries.slice(offset, offset + BATCH_SIZE);
-      let nextIdx = 0;
-      const worker = async () => {
-        while (nextIdx < batch.length) {
-          const idx = nextIdx++;
-          const [url, urlNotifs] = batch[idx];
-          try {
-            const result = await window.jarvis.githubGetIssueState(url);
-            if (!result || result.state !== 'closed') continue;
-            const { closedByMe, closedViaMergedPr } = result;
-            if (!closedByMe && !closedViaMergedPr) continue;
-            const reason: AutoDismissLogInput['reason'] =
-              closedViaMergedPr ? 'closed_issue_via_pr' : 'closed_issue_me';
-            for (const n of urlNotifs) {
-              try {
-                await window.jarvis.dismissNotification(n.id);
-                logEntries.push({
-                  notification_id: n.id,
-                  reason,
-                  repo_full_name: n.repo_full_name,
-                  subject_title: n.subject_title,
-                  subject_type: n.subject_type,
-                });
-                dismissed++;
-              } catch { /* skip individual */ }
-            }
-          } catch { /* skip individual issue */ }
-        }
-      };
-      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, batch.length) }, worker));
-    }
-  } catch { /* non-fatal */ }
-  return { dismissed, logEntries };
-}
-
-async function runDeletedBranchStep(): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
-  const logEntries: AutoDismissLogInput[] = [];
-  let dismissed = 0;
-  try {
-    const notifs = await window.jarvis.checkDeletedBranches();
-    for (const n of notifs) {
-      try {
-        await window.jarvis.dismissNotification(n.id);
-        logEntries.push({
-          notification_id: n.id,
-          reason: 'deleted_branch',
-          repo_full_name: n.repo_full_name,
-          subject_title: n.subject_title,
-          subject_type: n.subject_type,
-        });
-        dismissed++;
-      } catch { /* skip individual */ }
-    }
-  } catch { /* non-fatal */ }
-  return { dismissed, logEntries };
-}
-
-async function runAutoDismissPipeline(
-  repoFullNames: string[],
-): Promise<{ result: AutoDismissRunResult; logEntries: AutoDismissLogInput[] }> {
-  const steps: AutoDismissStepResult[] = [];
-  const allLog: AutoDismissLogInput[] = [];
-
-  const [rec, pr, issue, delBranch] = await Promise.all([
-    runRecoverableStep(repoFullNames),
-    runClosedPrStep(),
-    runClosedIssueStep(),
-    runDeletedBranchStep(),
-  ]);
-
-  steps.push({ id: 'recovered-workflows', label: 'Recovered workflows', dismissed: rec.dismissed });
-  allLog.push(...rec.logEntries);
-  steps.push({ id: 'closed-prs', label: 'Closed / merged PRs', dismissed: pr.dismissed });
-  allLog.push(...pr.logEntries);
-  steps.push({ id: 'closed-issues', label: 'Closed issues', dismissed: issue.dismissed });
-  allLog.push(...issue.logEntries);
-  steps.push({ id: 'deleted-branches', label: 'Deleted branches', dismissed: delBranch.dismissed });
-  allLog.push(...delBranch.logEntries);
-
-  return {
-    result: { steps, total: steps.reduce((s, r) => s + r.dismissed, 0) },
-    logEntries: allLog,
-  };
-}
-
-// ── Auto-dismiss summary banner ───────────────────────────────────────────────
 
 function AutoDismissSummaryBanner({
   result,
@@ -294,6 +70,33 @@ function AutoDismissSummaryBanner({
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
+
+function BackgroundTasksPanel({ tasks, onRunNow }: { tasks: BackgroundTaskStatus[]; onRunNow: (taskId: string) => void }) {
+  if (tasks.length === 0) return null;
+  return (
+    <div class="dash-auto-dismiss-mini">
+      <span class="dash-auto-dismiss-mini-label">
+        Background tasks: {tasks.map((task) => {
+          const status = task.running ? 'running' : task.lastStatus ?? 'waiting';
+          return `${task.label} (${status})`;
+        }).join(' · ')}
+      </span>
+      <div class="dash-sort-controls">
+        {tasks.map((task) => (
+          <button
+            key={task.id}
+            class="dash-auto-dismiss-mini-btn"
+            disabled={task.running}
+            onClick={() => onRunNow(task.id)}
+            title={task.lastError ? `Last error: ${task.lastError}` : `Run ${task.label} now`}
+          >
+            {task.running ? 'Running…' : `Run ${task.label}`}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function WarningIcon({ kind }: { kind: HealthWarning['kind'] }) {
   switch (kind) {
@@ -1170,6 +973,7 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
   const [autoDismissAcknowledged, setAutoDismissAcknowledged] = useState(false);
   const [autoDismissDone, setAutoDismissDone] = useState(false);
   const [pipelineStatus, setPipelineStatus] = useState<'idle' | 'running' | 'done'>('idle');
+  const [backgroundTasks, setBackgroundTasks] = useState<BackgroundTaskStatus[]>([]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -1189,40 +993,35 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
 
   useEffect(() => { void load(); }, [load]);
 
-  // Keep a ref to the latest summary so the periodic timer below always reads
-  // fresh repo/notification data without needing to reset on every summary change.
-  const summaryRef = useRef<DashboardSummary | null>(null);
-  useEffect(() => { summaryRef.current = summary; }, [summary]);
+  const loadBackgroundTasks = useCallback(async () => {
+    try {
+      setBackgroundTasks(await window.jarvis.listBackgroundTasks());
+    } catch (err) {
+      console.warn('[Dashboard] Could not load background tasks:', err);
+    }
+  }, []);
 
-  const runAutoDismissIfDue = useCallback(() => {
-    const currentSummary = summaryRef.current;
-    if (!currentSummary || Date.now() - lastAutoDismissRunAt < AUTO_DISMISS_INTERVAL_MS) return;
-    lastAutoDismissRunAt = Date.now();
-    setPipelineStatus('running');
-    const repoFullNames = currentSummary.repos
-      .filter((r) => r.notificationCount > 0 && r.linkedGithubRepo !== null)
-      .map((r) => r.linkedGithubRepo!);
-    void runAutoDismissPipeline(repoFullNames).then(async ({ result, logEntries }) => {
-      if (logEntries.length > 0) {
-        try { await window.jarvis.logAutoDismiss(logEntries); } catch { /* non-fatal */ }
-        void load(); // refresh summary counts after dismissals
-      }
+  useEffect(() => {
+    void loadBackgroundTasks();
+    return window.jarvis.onBackgroundTaskComplete(() => { void loadBackgroundTasks(); });
+  }, [loadBackgroundTasks]);
+
+  const runBackgroundTaskNow = useCallback((taskId: string) => {
+    setBackgroundTasks((tasks) => tasks.map((task) => task.id === taskId ? { ...task, running: true } : task));
+    void window.jarvis.runBackgroundTaskNow(taskId).then(() => loadBackgroundTasks());
+  }, [loadBackgroundTasks]);
+
+  // The main process owns the recurring auto-dismiss scheduler so it continues
+  // while this dashboard panel is not mounted. The dashboard only reflects the
+  // most recent result and refreshes summary counts after dismissals.
+  useEffect(() => {
+    return window.jarvis.onAutoDismissComplete(({ result, logEntries }) => {
+      if (logEntries.length > 0) void load();
       if (result.total > 0) setAutoDismissResult(result);
       setAutoDismissDone(true);
       setPipelineStatus('done');
     });
   }, [load]);
-
-  // Run the auto-dismiss pipeline once summary is first available, then keep
-  // re-checking every AUTO_DISMISS_INTERVAL_MS so notifications for issues/PRs
-  // that get closed (or resurface as unread) mid-session are still swept up,
-  // not just at app start.
-  useEffect(() => {
-    if (!summary) return;
-    runAutoDismissIfDue();
-    const intervalId = setInterval(runAutoDismissIfDue, AUTO_DISMISS_INTERVAL_MS);
-    return () => clearInterval(intervalId);
-  }, [summary, runAutoDismissIfDue]);
 
   useEffect(() => {
     if (!summary || !currentUserLogin || !autoDismissDone) {
@@ -1428,6 +1227,8 @@ export function DashboardPanel({ dismissedNotifIds, onOpenHistory }: { dismissed
         active={cardFilter}
         onSelect={setCardFilter}
       />
+
+      <BackgroundTasksPanel tasks={backgroundTasks} onRunNow={runBackgroundTaskNow} />
 
       {/* Pipeline in-progress banner — shown while auto-dismiss is checking notifications */}
       {pipelineStatus === 'running' && (

--- a/src/plugins/dashboard/handler.ts
+++ b/src/plugins/dashboard/handler.ts
@@ -195,7 +195,7 @@ export function registerHandlers(
       let totalNotifications = 0;
       let totalFailedRuns = 0;
 
-      for (const [dedupKey, entries] of dedupKeyToEntries) {
+      for (const [_dedupKey, entries] of dedupKeyToEntries) {
         // Pick the entry with the most recent lastCommitAt as the representative
         const bestEntry = entries.reduce((best, current) => {
           // If current has a more recent commit, it becomes the best

--- a/src/plugins/groups/handler.ts
+++ b/src/plugins/groups/handler.ts
@@ -315,8 +315,12 @@ async function refreshLinkedProjectDetails(db: SqlJsDatabase): Promise<void> {
   }
 }
 
-/** Schedules an hourly refresh of the Ruddr project list. Emits a renderer event when new projects are found. */
-export function scheduleRuddrProjectsRefresh(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
+/** Refreshes the Ruddr project list for the main-process task scheduler. */
+export async function refreshRuddrProjectsInBackground(
+  db: SqlJsDatabase,
+  getWindow: () => BrowserWindow | null,
+  forceFresh = false,
+): Promise<{ ok: boolean; skipped?: boolean; error?: string }> {
   _getWindowFn = getWindow;
   _notifyNewProjects = (projects: RuddrProjectEntry[]) => {
     const win = getWindow();
@@ -325,30 +329,17 @@ export function scheduleRuddrProjectsRefresh(db: SqlJsDatabase, getWindow: () =>
     }
   };
 
-  const HOUR_MS = 60 * 60 * 1000;
-  // First run after 30 seconds (let the app settle and browser extension connect).
-  setTimeout(async () => {
-    const err = await ensureRuddrCache(db).catch((e: unknown) => String(e));
-    if (err) {
-      logger.debug('[Groups] Hourly Ruddr refresh skipped:', err);
-    } else {
-      refreshLinkedProjectDetails(db).catch((e: unknown) =>
-        logger.warn('[Groups] Auto-refresh project details failed:', e instanceof Error ? e.message : String(e)),
-      );
-    }
-    setInterval(async () => {
-      // Force a fresh scrape by resetting the cache time so ensureRuddrCache re-fetches
-      ruddrProjectsCacheTime = 0;
-      const e = await ensureRuddrCache(db).catch((ex: unknown) => String(ex));
-      if (e) {
-        logger.debug('[Groups] Hourly Ruddr refresh skipped:', e);
-      } else {
-        refreshLinkedProjectDetails(db).catch((ex: unknown) =>
-          logger.warn('[Groups] Auto-refresh project details failed:', ex instanceof Error ? ex.message : String(ex)),
-        );
-      }
-    }, HOUR_MS);
-  }, 30_000);
+  if (forceFresh) ruddrProjectsCacheTime = 0;
+  const err = await ensureRuddrCache(db).catch((e: unknown) => String(e));
+  if (err) {
+    logger.debug('[Groups] Scheduled Ruddr refresh skipped:', err);
+    return { ok: true, skipped: true, error: err };
+  }
+
+  await refreshLinkedProjectDetails(db).catch((e: unknown) =>
+    logger.warn('[Groups] Auto-refresh project details failed:', e instanceof Error ? e.message : String(e)),
+  );
+  return { ok: true };
 }
 
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {

--- a/src/plugins/local-repos/handler.ts
+++ b/src/plugins/local-repos/handler.ts
@@ -153,16 +153,16 @@ export function startLocalScanIfNeeded(
   db: SqlJsDatabase,
   getWindow: () => BrowserWindow | null,
   force = false,
-): void {
+): boolean {
   if (localScanRunning && !force) {
     console.log('[LocalScan] Already running, skipping');
-    return;
+    return false;
   }
 
   const folders = getScanFolders(db);
   if (folders.length === 0) {
     console.log('[LocalScan] No scan folders configured, skipping');
-    return;
+    return false;
   }
 
   console.log('[LocalScan] Starting scan of', folders.length, 'folder(s)');
@@ -181,23 +181,5 @@ export function startLocalScanIfNeeded(
     localScanRunning = false;
     console.error('[LocalScan] Failed:', err);
   });
-}
-
-const LOCAL_SCAN_INITIAL_DELAY_MS = 30_000;       // 30 seconds after boot
-const LOCAL_SCAN_INTERVAL_MS = 60 * 60 * 1_000;  // 1 hour
-
-/**
- * Schedule the periodic local-repo scan.
- * First run is delayed to avoid blocking startup; subsequent runs are hourly.
- */
-export function scheduleLocalDiscovery(
-  db: SqlJsDatabase,
-  getWindow: () => BrowserWindow | null,
-): void {
-  setTimeout(() => {
-    startLocalScanIfNeeded(db, getWindow);
-    setInterval(() => {
-      startLocalScanIfNeeded(db, getWindow);
-    }, LOCAL_SCAN_INTERVAL_MS);
-  }, LOCAL_SCAN_INITIAL_DELAY_MS);
+  return true;
 }

--- a/src/plugins/notifications/AutoDismissHistoryPanel.tsx
+++ b/src/plugins/notifications/AutoDismissHistoryPanel.tsx
@@ -81,7 +81,6 @@ function BarChart({ data, granularity }: {
   // Bars distributed evenly across the plot area
   const barUnit = plotW / n;
   const barW = Math.min(barUnit * 0.7, 100);
-  const plotTop = padT;
   const plotBottom = padT + plotH;
   const plotHeight = plotH;
 

--- a/src/plugins/notifications/handler.ts
+++ b/src/plugins/notifications/handler.ts
@@ -22,7 +22,7 @@ import {
 } from '../../services/github-notifications';
 import { loadGitHubAuth } from '../../services/github-oauth';
 import { saveDatabase } from '../../storage/database';
-import { fetchAndStoreWorkflowData } from '../../services/github-workflows';
+import { fetchAndStoreWorkflowData, getWorkflowSummaryForRepo } from '../../services/github-workflows';
 import { isWorkflowDataFresh } from './workflow-cache';
 
 // ── Boot workflow check constants ─────────────────────────────────────────────
@@ -57,15 +57,301 @@ async function fetchTokenRateLimitRemaining(token: string): Promise<number | nul
   }
 }
 
+
+export interface AutoDismissStepResult {
+  id: string;
+  label: string;
+  dismissed: number;
+}
+
+export interface AutoDismissRunResult {
+  steps: AutoDismissStepResult[];
+  total: number;
+}
+
+export interface AutoDismissSweepResult {
+  ok: boolean;
+  skipped?: boolean;
+  reason?: string;
+  counts?: ReturnType<typeof getNotificationCounts>;
+  result?: AutoDismissRunResult;
+  logEntries?: AutoDismissLogInput[];
+}
+
+export async function syncGitHubNotifications(
+  db: SqlJsDatabase,
+  getWindow: () => BrowserWindow | null,
+): Promise<{ ok: boolean; skipped?: boolean; error?: string; counts?: ReturnType<typeof getNotificationCounts> }> {
+  const auth = loadGitHubAuth(db);
+  if (!auth) return { ok: true, skipped: true, error: 'Not authenticated' };
+  const notifications = await fetchNotifications(auth.accessToken);
+  storeNotifications(db, notifications);
+  saveDatabase();
+  const counts = getNotificationCounts(db);
+  const win = getWindow();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('github:notification-counts-updated', counts);
+  }
+  return { ok: true, counts };
+}
+
+async function fetchPrState(
+  accessToken: string,
+  currentLogin: string,
+  subjectUrl: string,
+): Promise<{ state: 'open' | 'closed' | 'merged'; isDependabot: boolean; closedByMe: boolean } | null> {
+  if (!/^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+\/pulls\/\d+$/.test(subjectUrl)) return null;
+  try {
+    const res = await fetch(subjectUrl, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!res.ok) return null;
+    const pr = (await res.json()) as {
+      state: string;
+      merged: boolean;
+      user: { login: string } | null;
+      merged_by: { login: string } | null;
+    };
+    const authorLogin = (pr.user?.login ?? '').toLowerCase();
+    const isDependabot = authorLogin.includes('dependabot');
+    const myLogin = currentLogin.toLowerCase();
+    if (pr.merged) {
+      return { state: 'merged', isDependabot, closedByMe: (pr.merged_by?.login ?? '').toLowerCase() === myLogin };
+    }
+    if (pr.state === 'closed') {
+      return { state: 'closed', isDependabot, closedByMe: authorLogin === myLogin };
+    }
+    return { state: 'open', isDependabot, closedByMe: false };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchIssueState(
+  accessToken: string,
+  currentLogin: string,
+  subjectUrl: string,
+): Promise<{ state: 'open' | 'closed'; closedByMe: boolean; closedViaMergedPr: boolean } | null> {
+  if (!/^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(subjectUrl)) return null;
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  try {
+    const issueRes = await fetch(subjectUrl, { headers });
+    if (!issueRes.ok) return null;
+    const issue = (await issueRes.json()) as { state: string };
+    if (issue.state !== 'closed') return { state: 'open', closedByMe: false, closedViaMergedPr: false };
+
+    const eventsRes = await fetch(`${subjectUrl}/events`, { headers });
+    let closedByMe = false;
+    let closedViaMergedPr = false;
+    if (eventsRes.ok) {
+      const events = (await eventsRes.json()) as Array<{
+        event: string;
+        actor: { login: string } | null;
+        commit_id: string | null;
+      }>;
+      const closedEvent = [...events].reverse().find((e) => e.event === 'closed');
+      if (closedEvent) {
+        closedByMe = (closedEvent.actor?.login ?? '').toLowerCase() === currentLogin.toLowerCase();
+        closedViaMergedPr = closedEvent.commit_id !== null && closedEvent.commit_id !== '';
+      }
+    }
+    return { state: 'closed', closedByMe, closedViaMergedPr };
+  } catch {
+    return null;
+  }
+}
+
+function logAutoDismissEntries(db: SqlJsDatabase, entries: AutoDismissLogInput[]): void {
+  if (entries.length === 0) return;
+  const sql =
+    `INSERT INTO auto_dismiss_log (notification_id, dismissed_at, reason, repo_full_name, subject_title, subject_type)
+     VALUES (?, datetime('now'), ?, ?, ?, ?)`;
+  for (const e of entries) {
+    if (typeof e.notification_id !== 'string' || typeof e.reason !== 'string') continue;
+    db.run(sql, [
+      e.notification_id,
+      e.reason,
+      typeof e.repo_full_name === 'string' ? e.repo_full_name : null,
+      typeof e.subject_title === 'string' ? e.subject_title : null,
+      typeof e.subject_type === 'string' ? e.subject_type : null,
+    ]);
+  }
+}
+
+async function dismissStoredNotification(
+  db: SqlJsDatabase,
+  accessToken: string,
+  n: { id: string },
+): Promise<boolean> {
+  try {
+    await markNotificationRead(accessToken, n.id);
+  } catch (err) {
+    console.warn('[AutoDismiss] Could not mark notification as read on GitHub:', err instanceof Error ? err.message : String(err));
+  }
+  deleteNotification(db, n.id);
+  return true;
+}
+
+async function runRecoverableStep(db: SqlJsDatabase, accessToken: string, repoFullNames: string[]): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
+  const logEntries: AutoDismissLogInput[] = [];
+  let dismissed = 0;
+  for (const repoFullName of repoFullNames) {
+    try {
+      const notifs = listNotificationsForRepo(db, repoFullName);
+      const ciNotifs = notifs.filter((n) => n.subject_type === 'CheckSuite' || n.subject_type === 'WorkflowRun');
+      if (ciNotifs.length === 0) continue;
+
+      let summary = getWorkflowSummaryForRepo(db, repoFullName);
+      if (summary.total_runs === 0) {
+        await fetchAndStoreWorkflowData(db, accessToken, repoFullName);
+        summary = getWorkflowSummaryForRepo(db, repoFullName);
+      }
+
+      const byWorkflow = new Map<string, typeof ciNotifs>();
+      for (const n of ciNotifs) {
+        const name = n.subject_title.match(/^(.+?)\s+workflow\s+run/i)?.[1]?.trim() ?? n.subject_title;
+        if (!byWorkflow.has(name)) byWorkflow.set(name, []);
+        byWorkflow.get(name)!.push(n);
+      }
+
+      for (const [workflowName, wNotifs] of byWorkflow) {
+        const branch = wNotifs[0].subject_title.match(/\bfor\s+(\S+)\s+branch\b/i)?.[1] ?? null;
+        const latestNotifTime = Math.max(...wNotifs.map((n) => new Date(n.updated_at).getTime()));
+        const recovered = summary.recent_runs.some(
+          (r) =>
+            r.workflow_name === workflowName &&
+            (branch === null || r.head_branch === branch) &&
+            r.conclusion === 'success' &&
+            new Date(r.run_started_at).getTime() > latestNotifTime,
+        );
+        if (!recovered) continue;
+        for (const n of wNotifs) {
+          if (await dismissStoredNotification(db, accessToken, n)) {
+            logEntries.push({ notification_id: n.id, reason: 'recovered_workflow', repo_full_name: repoFullName, subject_title: n.subject_title, subject_type: n.subject_type });
+            dismissed++;
+          }
+        }
+      }
+    } catch { /* non-fatal per repo */ }
+  }
+  return { dismissed, logEntries };
+}
+
+async function runClosedPrStep(db: SqlJsDatabase, accessToken: string, currentLogin: string): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
+  const logEntries: AutoDismissLogInput[] = [];
+  let dismissed = 0;
+  const byUrl = new Map<string, ReturnType<typeof listPrNotifications>>();
+  for (const n of listPrNotifications(db)) {
+    if (!n.subject_url) continue;
+    if (!byUrl.has(n.subject_url)) byUrl.set(n.subject_url, []);
+    byUrl.get(n.subject_url)!.push(n);
+  }
+  for (const [url, urlNotifs] of byUrl) {
+    const result = await fetchPrState(accessToken, currentLogin, url);
+    if (!result || result.state === 'open') continue;
+    const { state, isDependabot, closedByMe } = result;
+    if (!isDependabot && !closedByMe) continue;
+    const reason: AutoDismissLogInput['reason'] = isDependabot ? 'closed_pr_dependabot' : state === 'merged' ? 'closed_pr_merged_me' : 'closed_pr_closed_me';
+    for (const n of urlNotifs) {
+      if (await dismissStoredNotification(db, accessToken, n)) {
+        logEntries.push({ notification_id: n.id, reason, repo_full_name: n.repo_full_name, subject_title: n.subject_title, subject_type: n.subject_type });
+        dismissed++;
+      }
+    }
+  }
+  return { dismissed, logEntries };
+}
+
+async function runClosedIssueStep(db: SqlJsDatabase, accessToken: string, currentLogin: string): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
+  const logEntries: AutoDismissLogInput[] = [];
+  let dismissed = 0;
+  const byUrl = new Map<string, ReturnType<typeof listIssueNotifications>>();
+  for (const n of listIssueNotifications(db)) {
+    if (!n.subject_url) continue;
+    if (!byUrl.has(n.subject_url)) byUrl.set(n.subject_url, []);
+    byUrl.get(n.subject_url)!.push(n);
+  }
+  for (const [url, urlNotifs] of byUrl) {
+    const result = await fetchIssueState(accessToken, currentLogin, url);
+    if (!result || result.state !== 'closed') continue;
+    const { closedByMe, closedViaMergedPr } = result;
+    if (!closedByMe && !closedViaMergedPr) continue;
+    const reason: AutoDismissLogInput['reason'] = closedViaMergedPr ? 'closed_issue_via_pr' : 'closed_issue_me';
+    for (const n of urlNotifs) {
+      if (await dismissStoredNotification(db, accessToken, n)) {
+        logEntries.push({ notification_id: n.id, reason, repo_full_name: n.repo_full_name, subject_title: n.subject_title, subject_type: n.subject_type });
+        dismissed++;
+      }
+    }
+  }
+  return { dismissed, logEntries };
+}
+
+async function runDeletedBranchStep(db: SqlJsDatabase, accessToken: string): Promise<{ dismissed: number; logEntries: AutoDismissLogInput[] }> {
+  const logEntries: AutoDismissLogInput[] = [];
+  let dismissed = 0;
+  const notifs = await listDeletedBranchNotifications(db, accessToken);
+  for (const n of notifs) {
+    if (await dismissStoredNotification(db, accessToken, n)) {
+      logEntries.push({ notification_id: n.id, reason: 'deleted_branch', repo_full_name: n.repo_full_name, subject_title: n.subject_title, subject_type: n.subject_type });
+      dismissed++;
+    }
+  }
+  return { dismissed, logEntries };
+}
+
+export async function runAutoDismissSweep(
+  db: SqlJsDatabase,
+  getWindow: () => BrowserWindow | null,
+): Promise<AutoDismissSweepResult> {
+  const auth = loadGitHubAuth(db);
+  if (!auth) return { ok: true, skipped: true, reason: 'Not authenticated' };
+
+  const counts = getNotificationCounts(db);
+  const repoFullNames = Object.entries(counts.perRepo)
+    .filter(([, count]) => count > 0)
+    .map(([repo]) => repo);
+
+  const [rec, pr, issue, delBranch] = await Promise.all([
+    runRecoverableStep(db, auth.accessToken, repoFullNames),
+    runClosedPrStep(db, auth.accessToken, auth.login),
+    runClosedIssueStep(db, auth.accessToken, auth.login),
+    runDeletedBranchStep(db, auth.accessToken),
+  ]);
+
+  const steps: AutoDismissStepResult[] = [
+    { id: 'recovered-workflows', label: 'Recovered workflows', dismissed: rec.dismissed },
+    { id: 'closed-prs', label: 'Closed / merged PRs', dismissed: pr.dismissed },
+    { id: 'closed-issues', label: 'Closed issues', dismissed: issue.dismissed },
+    { id: 'deleted-branches', label: 'Deleted branches', dismissed: delBranch.dismissed },
+  ];
+  const logEntries = [...rec.logEntries, ...pr.logEntries, ...issue.logEntries, ...delBranch.logEntries];
+  logAutoDismissEntries(db, logEntries);
+  if (logEntries.length > 0) saveDatabase();
+
+  const result = { steps, total: steps.reduce((sum, step) => sum + step.dismissed, 0) };
+  const win = getWindow();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('github:auto-dismiss-complete', { result, logEntries });
+    if (logEntries.length > 0) win.webContents.send('github:notification-counts-updated', getNotificationCounts(db));
+  }
+  return { ok: true, counts, result, logEntries };
+}
+
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('github:fetch-notifications', async () => {
-    const auth = loadGitHubAuth(db);
-    if (!auth) return { ok: false, error: 'Not authenticated' };
     try {
-      const notifications = await fetchNotifications(auth.accessToken);
-      storeNotifications(db, notifications);
-      saveDatabase();
-      return getNotificationCounts(db);
+      const result = await syncGitHubNotifications(db, _getWindow);
+      if (result.skipped) return { ok: false, error: result.error ?? 'Skipped' };
+      return result.counts ?? getNotificationCounts(db);
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
@@ -165,19 +451,8 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
 
   ipcMain.handle('github:log-auto-dismiss', (_event, entries: AutoDismissLogInput[]) => {
     if (!Array.isArray(entries) || entries.length === 0) return;
-    const sql =
-      `INSERT INTO auto_dismiss_log (notification_id, dismissed_at, reason, repo_full_name, subject_title, subject_type)
-       VALUES (?, datetime('now'), ?, ?, ?, ?)`;
-    for (const e of entries) {
-      if (typeof e.notification_id !== 'string' || typeof e.reason !== 'string') continue;
-      db.run(sql, [
-        e.notification_id,
-        e.reason,
-        typeof e.repo_full_name === 'string' ? e.repo_full_name : null,
-        typeof e.subject_title === 'string' ? e.subject_title : null,
-        typeof e.subject_type === 'string' ? e.subject_type : null,
-      ]);
-    }
+    const valid = entries.filter((e) => typeof e.notification_id === 'string' && typeof e.reason === 'string');
+    logAutoDismissEntries(db, valid);
     saveDatabase();
   });
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2015,6 +2015,44 @@ export type {
 
 
 
+
+export type BackgroundTaskRunStatus = 'success' | 'failed' | 'skipped';
+
+export interface BackgroundTaskRunRecord {
+  taskId: string;
+  status: BackgroundTaskRunStatus;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  result?: unknown;
+  error?: string;
+}
+
+export interface BackgroundTaskStatus {
+  id: string;
+  label: string;
+  running: boolean;
+  intervalMs?: number;
+  initialDelayMs?: number;
+  nextRunAt?: string;
+  lastStartedAt?: string;
+  lastFinishedAt?: string;
+  lastDurationMs?: number;
+  lastStatus?: BackgroundTaskRunStatus;
+  lastError?: string;
+  lastResult?: unknown;
+}
+
+export interface AutoDismissRunResult {
+  steps: Array<{ id: string; label: string; dismissed: number }>;
+  total: number;
+}
+
+export interface AutoDismissCompletePayload {
+  result: AutoDismissRunResult;
+  logEntries: AutoDismissLogInput[];
+}
+
 export interface JarvisApi {
 
 
@@ -2636,6 +2674,13 @@ export interface JarvisApi {
   logAutoDismiss(entries: AutoDismissLogInput[]): Promise<void>;
   listAutoDismissLog(limit?: number): Promise<AutoDismissLogEntry[]>;
   getAutoDismissStats(): Promise<AutoDismissStats>;
+
+  // Background tasks
+  listBackgroundTasks(): Promise<BackgroundTaskStatus[]>;
+  runBackgroundTaskNow(taskId: string): Promise<BackgroundTaskRunRecord | { ok: false; error: string }>;
+  onBackgroundTaskComplete(cb: (record: BackgroundTaskRunRecord) => void): () => void;
+  onNotificationCountsUpdated(cb: (counts: NotificationCounts) => void): () => void;
+  onAutoDismissComplete(cb: (payload: AutoDismissCompletePayload) => void): () => void;
 
 
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -390,12 +390,13 @@ function App() {
     }
   }, [oauthStatus?.authenticated]);
 
-  // 5-minute auto-refresh timer
+  // Main-process background task pushes updated counts even when panels are not mounted.
   useEffect(() => {
-    if (!oauthStatus?.authenticated) return;
-    const id = window.setInterval(() => { void doFetchNotifications(); }, 5 * 60 * 1000);
-    return () => window.clearInterval(id);
-  }, [oauthStatus?.authenticated, doFetchNotifications]);
+    return window.jarvis.onNotificationCountsUpdated((counts) => {
+      setNotifCounts(counts);
+      setNotifFetching(false);
+    });
+  }, []);
 
   // 2-minute rate limit refresh
   useEffect(() => {

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -180,6 +180,9 @@ const EXPECTED_CHANNELS = [
   'browser:list-tabs',
   'browser:get-page-content',
   'browser:focus-window',
+  // background tasks
+  'tasks:list',
+  'tasks:run-now',
 ] as const;
 
 describe('IPC handler registration', () => {

--- a/tests/unit/task-scheduler.test.ts
+++ b/tests/unit/task-scheduler.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TaskScheduler } from '../../src/main/task-scheduler';
+
+describe('TaskScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs a registered task immediately and records success metadata', async () => {
+    const run = vi.fn(async () => ({ ok: true, count: 2 }));
+    const scheduler = new TaskScheduler();
+    scheduler.register({ id: 'demo', label: 'Demo task', run });
+
+    const result = await scheduler.runNow('demo');
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('success');
+    expect(result.taskId).toBe('demo');
+    expect(result.result).toEqual({ ok: true, count: 2 });
+    expect(result.finishedAt).toBeTruthy();
+    expect(scheduler.listTasks()[0]).toMatchObject({
+      id: 'demo',
+      label: 'Demo task',
+      running: false,
+      lastStatus: 'success',
+      lastResult: { ok: true, count: 2 },
+    });
+  });
+
+  it('records failed runs without throwing from runNow', async () => {
+    const run = vi.fn(async () => { throw new Error('boom'); });
+    const scheduler = new TaskScheduler();
+    scheduler.register({ id: 'failing', label: 'Failing task', run });
+
+    const result = await scheduler.runNow('failing');
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('boom');
+    expect(scheduler.getTask('failing')?.lastStatus).toBe('failed');
+    expect(scheduler.getTask('failing')?.lastError).toBe('boom');
+  });
+
+  it('skips overlapping runs of the same task', async () => {
+    let release!: () => void;
+    const run = vi.fn(() => new Promise<void>((resolve) => { release = resolve; }));
+    const scheduler = new TaskScheduler();
+    scheduler.register({ id: 'slow', label: 'Slow task', run });
+
+    const first = scheduler.runNow('slow');
+    await Promise.resolve();
+    const second = await scheduler.runNow('slow');
+
+    expect(second.status).toBe('skipped');
+    expect(second.error).toBe('Task already running');
+    expect(run).toHaveBeenCalledTimes(1);
+
+    release();
+    await first;
+    expect(scheduler.getTask('slow')?.running).toBe(false);
+  });
+
+  it('runs recurring tasks after initial delay and interval', async () => {
+    const run = vi.fn(async () => undefined);
+    const scheduler = new TaskScheduler();
+    scheduler.register({
+      id: 'recurring',
+      label: 'Recurring task',
+      initialDelayMs: 1000,
+      intervalMs: 5000,
+      run,
+    });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(run).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws for duplicate task ids and unknown runNow ids', async () => {
+    const scheduler = new TaskScheduler();
+    scheduler.register({ id: 'x', label: 'X', run: async () => undefined });
+
+    expect(() => scheduler.register({ id: 'x', label: 'Duplicate', run: async () => undefined })).toThrow(/already registered/);
+    await expect(scheduler.runNow('missing')).rejects.toThrow(/Unknown task/);
+  });
+});


### PR DESCRIPTION
Adds a main-process task scheduler and migrates local discovery, Ruddr refresh, notification sync, workflow cache prewarm, and auto-dismiss sweeps into centralized background jobs.