### PR TITLE
Use shield icon for vulnerability alert notifications

### DIFF
--- a/src/plugins/dashboard/DashboardPanel.tsx
+++ b/src/plugins/dashboard/DashboardPanel.tsx
@@ -88,6 +88,7 @@ function subjectTypeIcon(subjectType: string): string {
     case 'Commit': return '📝';
     case 'Discussion': return '💬';
     case 'CheckSuite': return '⚙️';
+    case 'RepositoryVulnerabilityAlert': return '🛡️';
     default: return '📌';
   }
 }

--- a/src/plugins/notifications/NotifRepoPanel.tsx
+++ b/src/plugins/notifications/NotifRepoPanel.tsx
@@ -64,6 +64,7 @@ const TYPE_ICON: Record<string, string> = {
   Commit: '\uD83D\uDCBE',
   Discussion: '\uD83D\uDCAC',
   CheckSuite: '\u274C',
+  RepositoryVulnerabilityAlert: '\uD83D\uDEE1\uFE0F',
 };
 
 // ── Workflow grouping ─────────────────────────────────────────────────────────

--- a/src/plugins/notifications/OrgNotifPanel.tsx
+++ b/src/plugins/notifications/OrgNotifPanel.tsx
@@ -9,6 +9,7 @@ const TYPE_ICON: Record<string, string> = {
   Commit: '\uD83D\uDCBE',
   Discussion: '\uD83D\uDCAC',
   CheckSuite: '\u2705',
+  RepositoryVulnerabilityAlert: '\uD83D\uDEE1\uFE0F',
 };
 
 async function openNotifUrl(n: StoredNotification): Promise<void> {


### PR DESCRIPTION
Dependabot security vulnerability notifications ("Your repository has dependencies with security vulnerabilities") have subject_type `RepositoryVulnerabilityAlert`, which was missing from every notification icon map. They fell back to a generic bullet `•` in the notification panels and a pin `📌` on the dashboard, instead of a proper type icon like all other notifications.

This adds a shield icon (`🛡️`) for `RepositoryVulnerabilityAlert` in all three places that map subject types to icons:

- `NotifRepoPanel.tsx` (per-repo notification panel)
- `OrgNotifPanel.tsx` (org notification panel)
- `DashboardPanel.tsx` (dashboard `subjectTypeIcon`)

Verified with `npm run build` and `npm test` (931 tests passing).