### PR TITLE
Add Claude rate limit tracking with status-bar ticker

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@
 12. [GitHub Maintenance Module](#12-github-maintenance-module)
 13. [Configuration](#13-configuration)
 14. [Recommended Approach](#14-recommended-approach)
+15. [Claude Rate Limit Awareness](#15-claude-rate-limit-awareness)
 
 ---
 
@@ -46,6 +47,7 @@
 | R16 | Cross-repo activity summaries | Find latest PRs/issues across orgs, generate weekly summaries |
 | R17 | Work journal / thought capture | Track things the user has been thinking about or working on |
 | R18 | Full SQLite encryption | Encrypt sensitive data at rest to prevent exfiltration |
+| R19 | Claude rate limit awareness | Reuse local Claude Code OAuth credentials to track Pro/Max subscription usage limits, with a status-bar countdown when limited |
 
 ---
 
@@ -1389,6 +1391,31 @@ jarvis/
 | **Phase 10** | Secrets scanning + fork analysis | Scan for exposed secrets, analyze fork upstream divergence |
 | **Phase 11** | Container isolation | Optional sandboxed execution for security-sensitive tasks |
 | **Phase 12** | Advanced maintenance tasks | Stale repo detection, dependency audits, branch cleanup |
+
+---
+
+## 15. Claude Rate Limit Awareness
+
+Jarvis can track the user's Claude **subscription** (Pro/Max) usage limits — not to be confused with Anthropic Console API keys, which have separate pay-as-you-go limits.
+
+### Credential Source
+
+The app reuses the OAuth credentials that Claude Code stores locally in `~/.claude/.credentials.json` (`claudeAiOauth.accessToken` / `refreshToken` / `expiresAt`). Refreshed tokens are cached encrypted in the Jarvis config store — Claude Code's own file is never modified.
+
+### Probing the Limit
+
+A minimal `POST /v1/messages` probe (`max_tokens: 1`, cheapest Haiku model, `anthropic-beta: oauth-2025-04-20`) returns the unified rate-limit headers:
+
+- `anthropic-ratelimit-unified-5h-utilization` / `-5h-reset` — rolling 5-hour window
+- `anthropic-ratelimit-unified-7d-utilization` / `-7d-reset` — rolling 7-day window
+- HTTP 429 + `retry-after` when a window is exhausted (rejected probes don't consume quota)
+
+When both windows are exhausted the binding reset is the *later* of the two — both must lift before the account is usable again.
+
+### UI
+
+- **Setup tab**: a "Claude AI" step tile (plugin: `src/plugins/claude/`) shows connection status and opens a detail panel with per-window utilization and reset times.
+- **Status bar**: a ticker badge next to the GitHub rate-limit badges. Green with 5h utilization when healthy; pulsing red countdown (`⏳ Claude limited · resets in …`) while limited. Polled every 2 minutes, tightening to 30s while limited.
 
 ---
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -43,6 +43,9 @@ import { registerHandlers as registerGroupsHandlers } from '../plugins/groups/ha
 import { registerHandlers as registerOnedriveHandlers } from '../plugins/onedrive/handler';
 
 import { registerHandlers as registerBrowserCompanionHandlers } from '../plugins/browser-companion/handler';
+
+import { registerHandlers as registerClaudeHandlers } from '../plugins/claude/handler';
+
 import { registerTaskIpcHandlers } from './background-tasks';
 
 
@@ -91,6 +94,8 @@ export function registerIpcHandlers(
   registerOnedriveHandlers(db, getWindow);
 
   registerBrowserCompanionHandlers(db, getWindow);
+
+  registerClaudeHandlers(db, getWindow);
 
   registerTaskIpcHandlers();
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -306,6 +306,10 @@ contextBridge.exposeInMainWorld('jarvis', {
   getSystemLocale: () => ipcRenderer.invoke('app:get-system-locale'),
   // GitHub rate limit
   getGitHubRateLimit: () => ipcRenderer.invoke('github:get-rate-limit'),
+  // Claude (Claude Code OAuth) rate limit
+  getClaudeStatus: () => ipcRenderer.invoke('claude:status'),
+  getClaudeRateLimit: () => ipcRenderer.invoke('claude:rate-limit'),
+  disconnectClaude: () => ipcRenderer.invoke('claude:disconnect'),
   // Auto-dismiss log
   logAutoDismiss: (entries: unknown[]) => ipcRenderer.invoke('github:log-auto-dismiss', entries),
   listAutoDismissLog: (limit?: number) => ipcRenderer.invoke('github:list-auto-dismiss-log', limit),

--- a/src/plugins/claude/ClaudePanel.tsx
+++ b/src/plugins/claude/ClaudePanel.tsx
@@ -1,0 +1,93 @@
+import type { ClaudeStatus, ClaudeRateLimit, ClaudeRateLimitWindow } from '../types';
+import { formatDurationUntil } from '../shared/utils';
+
+interface ClaudePanelProps {
+  status: ClaudeStatus;
+  rateLimit: ClaudeRateLimit | null;
+  refreshing: boolean;
+  onRefresh: () => void;
+  onDisconnect: () => void;
+  onClose: () => void;
+}
+
+function WindowRow({ label, win }: { label: string; win: ClaudeRateLimitWindow | null }) {
+  if (!win) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.82rem', color: '#99aabb', marginBottom: '0.35rem' }}>
+        <span>{label}</span>
+        <span style={{ color: '#667' }}>no data</span>
+      </div>
+    );
+  }
+  const pct = win.utilization !== null ? Math.round(win.utilization * 100) : null;
+  const color = win.limited ? '#f44336' : pct !== null && pct >= 80 ? '#ff9800' : '#4caf50';
+  return (
+    <div style={{ marginBottom: '0.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.82rem', color: '#99aabb' }}>
+        <span>{label}</span>
+        <span style={{ color, fontWeight: 600 }}>
+          {win.limited ? 'exhausted' : pct !== null ? `${pct}% used` : 'ok'}
+        </span>
+      </div>
+      {win.reset !== null && (
+        <div style={{ fontSize: '0.75rem', color: '#667' }}>
+          {formatDurationUntil(win.reset)} · {new Date(win.reset * 1000).toLocaleTimeString()}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ClaudePanel({ status, rateLimit, refreshing, onRefresh, onDisconnect, onClose }: ClaudePanelProps) {
+  const plan = status.subscriptionType ?? 'unknown plan';
+  return (
+    <div class="org-panel ollama-panel">
+      <div class="org-panel-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span>Claude AI</span>
+        <button class="repo-panel-close" title="Close" onClick={onClose}>&times;</button>
+      </div>
+      <div style={{ fontSize: '0.82rem', color: '#99aabb', marginBottom: '0.75rem' }}>
+        Subscription: <code style={{ background: '#0f3460', padding: '0.1rem 0.4rem', borderRadius: '3px' }}>{plan}</code>
+        {' '}via Claude Code credentials
+      </div>
+
+      {rateLimit?.error && (
+        <div style={{ fontSize: '0.8rem', color: '#ff9800', marginBottom: '0.6rem' }}>
+          Last check failed: {rateLimit.error}
+        </div>
+      )}
+
+      {rateLimit?.limited && (
+        <div style={{ fontSize: '0.85rem', color: '#f44336', fontWeight: 600, marginBottom: '0.6rem' }}>
+          ⏳ Rate limited{rateLimit.resetAt !== null ? ` — ${formatDurationUntil(rateLimit.resetAt)}` : ''}
+        </div>
+      )}
+
+      <WindowRow label="5-hour window" win={rateLimit?.fiveHour ?? null} />
+      <WindowRow label="7-day window" win={rateLimit?.sevenDay ?? null} />
+
+      {rateLimit?.fetchedAt && (
+        <div style={{ fontSize: '0.72rem', color: '#556', marginBottom: '0.75rem' }}>
+          Last checked {new Date(rateLimit.fetchedAt).toLocaleTimeString()}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <button
+          style={{ fontSize: '0.78rem', padding: '0.25rem 0.75rem', background: '#0f3460', color: '#7ab3ff', border: '1px solid #2b5c9e', borderRadius: '5px', cursor: 'pointer' }}
+          disabled={refreshing}
+          onClick={onRefresh}
+        >
+          {refreshing ? 'Checking…' : '↻ Check now'}
+        </button>
+        <button
+          style={{ fontSize: '0.78rem', padding: '0.25rem 0.75rem', background: '#3d0a0a', color: '#ff8080', border: '1px solid #8a2b2b', borderRadius: '5px', cursor: 'pointer' }}
+          title="Clear the cached token Jarvis keeps for refreshes. Claude Code's own credentials are not touched."
+          onClick={onDisconnect}
+        >
+          Forget cached token
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/claude/ClaudeStep.tsx
+++ b/src/plugins/claude/ClaudeStep.tsx
@@ -1,0 +1,51 @@
+import { StatusBadge } from '../shared/StatusBadge';
+import type { ClaudeStatus, ClaudeRateLimit } from '../types';
+
+interface ClaudeStepProps {
+  status: ClaudeStatus | null;
+  rateLimit: ClaudeRateLimit | null;
+  onToggle: () => void;
+}
+
+export function ClaudeStep({ status, rateLimit, onToggle }: ClaudeStepProps) {
+  let badgeStatus: 'pending' | 'completed' | 'in-progress' = 'in-progress';
+  let badgeLabel = 'Checking...';
+  let detail = 'Looking for Claude Code credentials…';
+
+  if (status !== null) {
+    if (status.connected) {
+      const plan = status.subscriptionType ? ` (${status.subscriptionType})` : '';
+      if (rateLimit?.limited) {
+        badgeStatus = 'pending';
+        badgeLabel = 'Rate limited';
+        detail = 'Claude usage limit reached — see the ticker below for the reset time.';
+      } else {
+        badgeStatus = 'completed';
+        badgeLabel = 'Connected';
+        detail = `Using your Claude${plan} account via Claude Code credentials — click for rate limit details`;
+      }
+    } else {
+      badgeStatus = 'pending';
+      badgeLabel = 'Not found';
+      detail = status.error ?? 'Claude Code credentials not found.';
+    }
+  }
+
+  return (
+    <div
+      class={`step${status?.connected ? ' ollama-step-clickable' : ''}`}
+      id="claude-step"
+      onClick={status?.connected ? onToggle : undefined}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.4rem' }}>
+        <h2 style={{ marginBottom: 0 }}>
+          Claude AI <StatusBadge status={badgeStatus} label={badgeLabel} />
+        </h2>
+        {status?.connected && (
+          <span style={{ color: '#99a', fontSize: '0.8rem' }}>{'›'}</span>
+        )}
+      </div>
+      <div style={{ fontSize: '0.85rem', color: '#aaa' }}>{detail}</div>
+    </div>
+  );
+}

--- a/src/plugins/claude/handler.ts
+++ b/src/plugins/claude/handler.ts
@@ -1,0 +1,171 @@
+// ── Claude IPC handlers ───────────────────────────────────────────────────────
+import { ipcMain } from 'electron';
+import type { Database as SqlJsDatabase } from 'sql.js';
+import type { BrowserWindow } from 'electron';
+import {
+  loadClaudeCodeCredentials,
+  refreshClaudeToken,
+  checkClaudeRateLimit,
+  isTokenExpired,
+  type ClaudeCredentials,
+} from '../../services/claude';
+import { getConfigValue, setConfigValue, saveDatabase } from '../../storage/database';
+import { encrypt, decrypt, getEncryptionKey } from '../../storage/encryption';
+
+// Config keys for the cached (encrypted) copy of refreshed OAuth tokens.
+// We never write back to Claude Code's credentials file; refreshed tokens
+// are kept here instead.
+const KEY_ACCESS = 'claude_access_token_enc';
+const KEY_REFRESH = 'claude_refresh_token_enc';
+const KEY_EXPIRES = 'claude_expires_at';
+const KEY_SUBSCRIPTION = 'claude_subscription_type';
+
+function loadStoredCredentials(db: SqlJsDatabase): ClaudeCredentials | null {
+  const encAccess = getConfigValue(db, KEY_ACCESS);
+  if (!encAccess) return null;
+  const key = getEncryptionKey();
+  try {
+    const encRefresh = getConfigValue(db, KEY_REFRESH);
+    const expiresRaw = getConfigValue(db, KEY_EXPIRES);
+    return {
+      accessToken: decrypt(encAccess, key),
+      refreshToken: encRefresh ? decrypt(encRefresh, key) : undefined,
+      expiresAt: expiresRaw !== null ? Number(expiresRaw) : undefined,
+      subscriptionType: getConfigValue(db, KEY_SUBSCRIPTION) ?? undefined,
+    };
+  } catch {
+    console.warn('[Claude] Failed to decrypt stored token — clearing it');
+    clearStoredCredentials(db);
+    return null;
+  }
+}
+
+function storeCredentials(db: SqlJsDatabase, creds: ClaudeCredentials): void {
+  const key = getEncryptionKey();
+  setConfigValue(db, KEY_ACCESS, encrypt(creds.accessToken, key));
+  if (creds.refreshToken) setConfigValue(db, KEY_REFRESH, encrypt(creds.refreshToken, key));
+  if (creds.expiresAt !== undefined) setConfigValue(db, KEY_EXPIRES, String(creds.expiresAt));
+  if (creds.subscriptionType) setConfigValue(db, KEY_SUBSCRIPTION, creds.subscriptionType);
+  saveDatabase();
+}
+
+function clearStoredCredentials(db: SqlJsDatabase): void {
+  db.run(`DELETE FROM config WHERE key IN (?, ?, ?, ?)`, [KEY_ACCESS, KEY_REFRESH, KEY_EXPIRES, KEY_SUBSCRIPTION]);
+  saveDatabase();
+}
+
+/**
+ * Resolve a usable access token. Order:
+ *   1. cached refreshed token (still valid)
+ *   2. Claude Code credentials file (still valid)
+ *   3. refresh via cached refresh token
+ *   4. refresh via the file's refresh token (persisted on success)
+ */
+async function resolveAccessToken(
+  db: SqlJsDatabase,
+): Promise<{ token: string; source: 'stored' | 'claude-code'; subscriptionType?: string; expiresAt?: number } | null> {
+  const stored = loadStoredCredentials(db);
+  if (stored && !isTokenExpired(stored.expiresAt)) {
+    return { token: stored.accessToken, source: 'stored', subscriptionType: stored.subscriptionType, expiresAt: stored.expiresAt };
+  }
+
+  const fromFile = loadClaudeCodeCredentials();
+  if (fromFile && !isTokenExpired(fromFile.expiresAt)) {
+    return { token: fromFile.accessToken, source: 'claude-code', subscriptionType: fromFile.subscriptionType, expiresAt: fromFile.expiresAt };
+  }
+
+  const refreshToken = stored?.refreshToken ?? fromFile?.refreshToken;
+  if (refreshToken) {
+    const refreshed = await refreshClaudeToken(refreshToken);
+    if (refreshed) {
+      const creds: ClaudeCredentials = { ...refreshed, subscriptionType: fromFile?.subscriptionType ?? stored?.subscriptionType };
+      storeCredentials(db, creds);
+      return { token: creds.accessToken, source: 'stored', subscriptionType: creds.subscriptionType, expiresAt: creds.expiresAt };
+    }
+  }
+
+  return null;
+}
+
+export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
+  ipcMain.handle('claude:status', async () => {
+    try {
+      const resolved = await resolveAccessToken(db);
+      if (!resolved) {
+        const fileExists = loadClaudeCodeCredentials() !== null;
+        return {
+          connected: false,
+          error: fileExists
+            ? 'Claude Code credentials found but expired — open Claude Code once to refresh them.'
+            : 'No Claude Code credentials found (~/.claude/.credentials.json). Sign in with Claude Code first.',
+        };
+      }
+      return {
+        connected: true,
+        subscriptionType: resolved.subscriptionType,
+        expiresAt: resolved.expiresAt,
+        source: resolved.source,
+      };
+    } catch (err) {
+      console.error('[claude] claude:status error:', err);
+      return { connected: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('claude:rate-limit', async () => {
+    const fetchedAt = new Date().toISOString();
+    try {
+      const resolved = await resolveAccessToken(db);
+      if (!resolved) {
+        return {
+          configured: false,
+          limited: false,
+          resetAt: null,
+          retryAfterSec: null,
+          fiveHour: null,
+          sevenDay: null,
+          fetchedAt,
+        };
+      }
+
+      let probe = await checkClaudeRateLimit(resolved.token);
+
+      // An expired token can slip past the skew check (clock drift); refresh once and retry.
+      if (probe.status === 401) {
+        clearStoredCredentials(db);
+        const retried = await resolveAccessToken(db);
+        if (retried && retried.token !== resolved.token) {
+          probe = await checkClaudeRateLimit(retried.token);
+        }
+      }
+
+      return {
+        configured: true,
+        limited: probe.limited,
+        resetAt: probe.resetAt,
+        retryAfterSec: probe.retryAfterSec,
+        fiveHour: probe.fiveHour,
+        sevenDay: probe.sevenDay,
+        error: probe.error,
+        fetchedAt,
+      };
+    } catch (err) {
+      console.error('[claude] claude:rate-limit error:', err);
+      return {
+        configured: true,
+        limited: false,
+        resetAt: null,
+        retryAfterSec: null,
+        fiveHour: null,
+        sevenDay: null,
+        error: err instanceof Error ? err.message : String(err),
+        fetchedAt,
+      };
+    }
+  });
+
+  ipcMain.handle('claude:disconnect', () => {
+    clearStoredCredentials(db);
+    return { ok: true };
+  });
+}

--- a/src/plugins/shared/utils.ts
+++ b/src/plugins/shared/utils.ts
@@ -25,6 +25,25 @@ export function relativeAge(dateStr: string): string {
   return `${weeks}w ago`;
 }
 
+/**
+ * Human-readable time until a unix-seconds timestamp (e.g. "resets in 23m",
+ * "resets in 2h 5m", "resets in 3d 4h"). `nowMs` is injectable for tests.
+ */
+export function formatDurationUntil(resetUnixSec: number, nowMs: number = Date.now()): string {
+  const msLeft = resetUnixSec * 1000 - nowMs;
+  if (msLeft <= 0) return 'resets soon';
+  const totalMins = Math.ceil(msLeft / 60_000);
+  if (totalMins < 60) return `resets in ${totalMins}m`;
+  const totalHours = Math.floor(totalMins / 60);
+  if (totalHours < 24) {
+    const mins = totalMins % 60;
+    return mins > 0 ? `resets in ${totalHours}h ${mins}m` : `resets in ${totalHours}h`;
+  }
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours > 0 ? `resets in ${days}d ${hours}h` : `resets in ${days}d`;
+}
+
 /** Returns a short description of a notification reason/type combination. */
 export function notifDescription(type: string, reason: string): string {
   if (reason === 'assign') return type === 'PullRequest' ? 'PR assigned to you' : 'Issue assigned to you';

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1200,6 +1200,150 @@ export interface GitHubRateLimit {
 
 
 
+// ── Claude (Claude Code OAuth) types ──────────────────────────────────────────
+
+
+
+
+
+/** Connection status of the Claude account link (via Claude Code credentials). */
+
+
+
+export interface ClaudeStatus {
+
+
+
+  connected: boolean;
+
+
+
+  /** e.g. "pro", "max" — as reported by the credentials file. */
+
+
+
+  subscriptionType?: string;
+
+
+
+  /** Access-token expiry in ms since epoch. */
+
+
+
+  expiresAt?: number;
+
+
+
+  /** Where the active token came from. */
+
+
+
+  source?: 'claude-code' | 'stored';
+
+
+
+  error?: string;
+
+
+
+}
+
+
+
+
+
+/** One unified rate-limit window (5-hour or 7-day). */
+
+
+
+export interface ClaudeRateLimitWindow {
+
+
+
+  /** Fraction of the window consumed, 0..1 (null when not reported). */
+
+
+
+  utilization: number | null;
+
+
+
+  /** Unix timestamp (seconds) when the window resets. */
+
+
+
+  reset: number | null;
+
+
+
+  /** True when this window is currently exhausted. */
+
+
+
+  limited: boolean;
+
+
+
+}
+
+
+
+
+
+export interface ClaudeRateLimit {
+
+
+
+  /** False when no Claude credentials are available at all. */
+
+
+
+  configured: boolean;
+
+
+
+  /** True when the account is currently rate limited (any window). */
+
+
+
+  limited: boolean;
+
+
+
+  /** Unix timestamp (seconds) when the binding limit lifts; null when not limited. */
+
+
+
+  resetAt: number | null;
+
+
+
+  retryAfterSec: number | null;
+
+
+
+  fiveHour: ClaudeRateLimitWindow | null;
+
+
+
+  sevenDay: ClaudeRateLimitWindow | null;
+
+
+
+  error?: string;
+
+
+
+  fetchedAt: string; // ISO timestamp
+
+
+
+}
+
+
+
+
+
 
 
 // ── Browser Companion types ───────────────────────────────────────────────────
@@ -2670,6 +2814,11 @@ export interface JarvisApi {
 
 
   getGitHubRateLimit(): Promise<GitHubRateLimit>;
+
+  // Claude (Claude Code OAuth) rate limit
+  getClaudeStatus(): Promise<ClaudeStatus>;
+  getClaudeRateLimit(): Promise<ClaudeRateLimit>;
+  disconnectClaude(): Promise<{ ok: boolean }>;
 
   // Auto-dismiss log
   logAutoDismiss(entries: AutoDismissLogInput[]): Promise<void>;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -20,7 +20,7 @@ import { LocalFolderConfigPanel } from '../plugins/local-repos/LocalFolderConfig
 import { LocalFolderPanel } from '../plugins/local-repos/LocalFolderPanel';
 import { LocalSubfolderPanel } from '../plugins/local-repos/LocalSubfolderPanel';
 import { LocalRepoPanelView } from '../plugins/local-repos/LocalRepoPanelView';
-import { getReposUnder, hasDeepRepos, setSystemLocale, formatNumber } from '../plugins/shared/utils';
+import { getReposUnder, hasDeepRepos, setSystemLocale, formatNumber, formatDurationUntil } from '../plugins/shared/utils';
 import { SecretsStep } from '../plugins/secrets/SecretsStep';
 import { SecretsScanPanel } from '../plugins/secrets/SecretsScanPanel';
 import { DashboardPanel } from '../plugins/dashboard/DashboardPanel';
@@ -31,6 +31,8 @@ import { OneNoteSectionPanel } from '../plugins/groups/OneNoteSectionPanel';
 import { OneNoteCachePanel } from '../plugins/groups/OneNoteCachePanel';
 import { GroupsDashboardPanel } from '../plugins/groups/GroupsDashboardPanel';
 import { AutoDismissHistoryPanel } from '../plugins/notifications/AutoDismissHistoryPanel';
+import { ClaudeStep } from '../plugins/claude/ClaudeStep';
+import { ClaudePanel } from '../plugins/claude/ClaudePanel';
 
 // ── Types (imported from single source of truth in plugins/types.ts) ─────────
 // The global augmentation `Window.jarvis` is declared in plugins/types.ts and
@@ -53,6 +55,8 @@ import type {
   SecretsScanProgress,
   Group,
   GitHubRateLimit,
+  ClaudeStatus,
+  ClaudeRateLimit,
   BackgroundTaskStatus,
 } from '../plugins/types';
 import '../plugins/types'; // activate the global Window augmentation
@@ -132,6 +136,12 @@ function App() {
   // GitHub rate limit
   const [rateLimit, setRateLimit] = useState<GitHubRateLimit | null>(null);
 
+  // Claude rate limit
+  const [claudeStatus, setClaudeStatus] = useState<ClaudeStatus | null>(null);
+  const [claudeRateLimit, setClaudeRateLimit] = useState<ClaudeRateLimit | null>(null);
+  const [showClaudePanel, setShowClaudePanel] = useState(false);
+  const [claudeRefreshing, setClaudeRefreshing] = useState(false);
+
   const currentUserLogin = oauthStatus?.login ?? null;
 
   // Tab state
@@ -192,6 +202,16 @@ function App() {
         console.error('[Jarvis] Error checking OAuth status:', err);
       }
     })();
+  }, []);
+
+  // Claude status + rate limit check on mount (independent of GitHub auth)
+  useEffect(() => {
+    window.jarvis.getClaudeStatus()
+      .then(setClaudeStatus)
+      .catch((err: unknown) => console.error('[Jarvis] Claude status check failed:', err));
+    window.jarvis.getClaudeRateLimit()
+      .then(setClaudeRateLimit)
+      .catch((err: unknown) => console.error('[Jarvis] Claude rate limit check failed:', err));
   }, []);
 
   // Ollama status + selected model check on mount
@@ -413,6 +433,22 @@ function App() {
     return () => window.clearInterval(id);
   }, [oauthStatus?.authenticated]);
 
+  // Claude rate limit polling — every 2 minutes normally, every 30s while
+  // limited so the ticker reflects the lift promptly.
+  useEffect(() => {
+    if (!claudeStatus?.connected) return;
+    const intervalMs = claudeRateLimit?.limited ? 30 * 1000 : 2 * 60 * 1000;
+    const id = window.setInterval(async () => {
+      try {
+        const rl = await window.jarvis.getClaudeRateLimit();
+        setClaudeRateLimit(rl);
+      } catch (e) {
+        console.warn('[Jarvis] Claude rate limit refresh failed:', e);
+      }
+    }, intervalMs);
+    return () => window.clearInterval(id);
+  }, [claudeStatus?.connected, claudeRateLimit?.limited]);
+
   // Keep refs so the effect below can always read the latest panel state
   // without adding them to the dependency array (which would re-fire on every
   // panel interaction rather than only when the underlying data changes).
@@ -514,6 +550,8 @@ function App() {
     setShowOllamaPanel(false);
     setShowChatPanel(false);
     localStorage.setItem('chat-panel-open', 'false');
+    // Claude
+    setShowClaudePanel(false);
   };
 
   const handleToggleOrgs = () => {
@@ -669,7 +707,7 @@ function App() {
     requestAnimationFrame(() => {
       main.scrollTo({ left: main.scrollWidth, behavior: 'smooth' });
     });
-  }, [repoPanel, notifRepoPanel, notifDive, showLocalPanel, showLocalConfig, localNavStack, localLeafFolder, localNotifRepoPanel, showOllamaPanel]);
+  }, [repoPanel, notifRepoPanel, notifDive, showLocalPanel, showLocalConfig, localNavStack, localLeafFolder, localNotifRepoPanel, showOllamaPanel, showClaudePanel]);
 
   // ── Secrets handlers ────────────────────────────────────────────────────────
 
@@ -728,6 +766,37 @@ function App() {
     const wasOpen = showOllamaPanel;
     closeAllPanels();
     if (!wasOpen) setShowOllamaPanel(true);
+  };
+
+  const handleClaudeToggle = () => {
+    const wasOpen = showClaudePanel;
+    closeAllPanels();
+    if (!wasOpen) {
+      setShowClaudePanel(true);
+      // Fresh numbers whenever the panel is opened
+      void handleClaudeRefresh();
+    }
+  };
+
+  const handleClaudeRefresh = async () => {
+    setClaudeRefreshing(true);
+    try {
+      const [status, rl] = await Promise.all([
+        window.jarvis.getClaudeStatus(),
+        window.jarvis.getClaudeRateLimit(),
+      ]);
+      setClaudeStatus(status);
+      setClaudeRateLimit(rl);
+    } catch (err) {
+      console.error('[Jarvis] Claude refresh failed:', err);
+    } finally {
+      setClaudeRefreshing(false);
+    }
+  };
+
+  const handleClaudeDisconnect = async () => {
+    await window.jarvis.disconnectClaude();
+    await handleClaudeRefresh();
   };
 
   const handleToggleFavoriteOrg = async (orgLogin: string) => {
@@ -1035,6 +1104,22 @@ function App() {
         )}
       </div>
 
+      <div class="ollama-layout">
+        <div class="ollama-step-wrapper">
+          <ClaudeStep status={claudeStatus} rateLimit={claudeRateLimit} onToggle={handleClaudeToggle} />
+        </div>
+        {showClaudePanel && claudeStatus?.connected && (
+          <ClaudePanel
+            status={claudeStatus}
+            rateLimit={claudeRateLimit}
+            refreshing={claudeRefreshing}
+            onRefresh={() => void handleClaudeRefresh()}
+            onDisconnect={() => void handleClaudeDisconnect()}
+            onClose={() => setShowClaudePanel(false)}
+          />
+        )}
+      </div>
+
       </>)}
         </div>
       </div>
@@ -1080,6 +1165,7 @@ function App() {
         localScanning={localScanning}
         localScanProgress={localScanProgress}
         rateLimit={rateLimit}
+        claudeRateLimit={claudeRateLimit}
       />
     </div>
   );
@@ -1094,6 +1180,7 @@ interface BackgroundStatusBarProps {
   localScanning: boolean;
   localScanProgress: LocalScanProgress | null;
   rateLimit: GitHubRateLimit | null;
+  claudeRateLimit: ClaudeRateLimit | null;
 }
 
 function BackgroundStatusBar({
@@ -1103,6 +1190,7 @@ function BackgroundStatusBar({
   localScanning,
   localScanProgress,
   rateLimit,
+  claudeRateLimit,
 }: BackgroundStatusBarProps) {
   const [ipcMessage, setIpcMessage] = useState<string | null>(null);
   const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1191,7 +1279,17 @@ function BackgroundStatusBar({
   // Build badges for OAuth and PAT sources (only when configured)
   const oauthBadge = rateLimit?.oauth.configured ? rateLimit.oauth : null;
   const patBadge = rateLimit?.pat.configured ? rateLimit.pat : null;
-  const hasAnyBadge = oauthBadge !== null || patBadge !== null;
+  const claudeBadge = claudeRateLimit?.configured ? claudeRateLimit : null;
+  const hasAnyBadge = oauthBadge !== null || patBadge !== null || claudeBadge !== null;
+
+  // Ticker: re-render every second while Claude is rate limited so the
+  // countdown to the reset stays live.
+  const [, setNowTick] = useState(0);
+  useEffect(() => {
+    if (!claudeBadge?.limited) return;
+    const id = window.setInterval(() => setNowTick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [claudeBadge?.limited]);
 
   // Keep --status-bar-height in sync so fixed panels (e.g. ec-panel) can avoid
   // being hidden behind the status bar.
@@ -1250,7 +1348,24 @@ function BackgroundStatusBar({
               </div>
             </div>
           )}
-          {hasAnyBadge && (
+          {claudeBadge && (
+            <span
+              class={`bg-status-rate-limit${claudeBadge.limited ? ' bg-status-rate-limit--limited' : ''}`}
+              title={claudeBadge.error
+                ? `Claude rate limit check failed: ${claudeBadge.error}`
+                : claudeBadge.limited
+                  ? `Claude usage limit reached — ${claudeBadge.resetAt !== null ? `${formatDurationUntil(claudeBadge.resetAt)} (${new Date(claudeBadge.resetAt * 1000).toLocaleString()})` : 'reset time unknown'}`
+                  : `Claude${claudeBadge.fiveHour?.utilization != null ? `: 5h window ${Math.round(claudeBadge.fiveHour.utilization * 100)}% used` : ' not rate limited'}`}
+              style={{ color: claudeBadge.error ? '#888' : claudeBadge.limited ? '#f44336' : '#4caf50' }}
+            >
+              {claudeBadge.error
+                ? '✦ Claude –'
+                : claudeBadge.limited
+                  ? `⏳ Claude limited · ${claudeBadge.resetAt !== null ? formatDurationUntil(claudeBadge.resetAt) : 'resets soon'}`
+                  : `✦ Claude${claudeBadge.fiveHour?.utilization != null ? ` ${Math.round(claudeBadge.fiveHour.utilization * 100)}%` : ' ok'}`}
+            </span>
+          )}
+          {hasAnyBadge && (oauthBadge || patBadge) && (
             <div class={`bg-status-rate-limits${oauthBadge && patBadge ? ' bg-status-rate-limits--both' : ''}`}>
               {oauthBadge && (
                 <span

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -4037,6 +4037,16 @@ h5.ec-heading { font-size: 0.9375rem; }
   cursor: default;
 }
 
+/* Pulsing countdown while an account is rate limited */
+.bg-status-rate-limit--limited {
+  animation: bg-status-limited-pulse 2s ease-in-out infinite;
+}
+
+@keyframes bg-status-limited-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
 /* ── Right-side group (tasks + rate limits) ──────────────────────────────── */
 .bg-status-right {
   margin-left: auto;

--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -1,0 +1,265 @@
+// ── Claude (Claude Code OAuth) rate limit service ────────────────────────────
+//
+// Connects to the user's Claude subscription by reusing the OAuth credentials
+// that Claude Code stores locally in ~/.claude/.credentials.json. Unlike a
+// Console API key, these credentials reflect the actual Pro/Max subscription
+// rate limits (unified 5-hour and 7-day windows).
+//
+// Rate-limit state is read from the `anthropic-ratelimit-unified-*` response
+// headers on a minimal /v1/messages probe (max_tokens: 1). When the limit is
+// exhausted the API responds with HTTP 429 and a `retry-after` header; the
+// `*-reset` headers tell us when each window lifts.
+import fs from 'fs';
+import path from 'path';
+
+// ── Credentials ───────────────────────────────────────────────────────────────
+
+export interface ClaudeCredentials {
+  accessToken: string;
+  refreshToken?: string;
+  /** Expiry in milliseconds since epoch (as stored by Claude Code). */
+  expiresAt?: number;
+  subscriptionType?: string;
+  scopes?: string[];
+}
+
+/** Path to the Claude Code credentials file (%USERPROFILE%\.claude\.credentials.json on Windows). */
+export function getClaudeCredentialsPath(): string {
+  const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
+  return path.join(home, '.claude', '.credentials.json');
+}
+
+/**
+ * Load Claude Code OAuth credentials from disk. Returns null when the file is
+ * missing, unreadable, or does not contain a claudeAiOauth access token.
+ */
+export function loadClaudeCodeCredentials(filePath: string = getClaudeCredentialsPath()): ClaudeCredentials | null {
+  try {
+    if (!filePath || !fs.existsSync(filePath)) return null;
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+      claudeAiOauth?: {
+        accessToken?: string;
+        refreshToken?: string;
+        expiresAt?: number;
+        subscriptionType?: string;
+        rateLimitTier?: string;
+        scopes?: string[];
+      };
+    };
+    const oauth = raw.claudeAiOauth;
+    if (!oauth?.accessToken) return null;
+    return {
+      accessToken: oauth.accessToken,
+      refreshToken: oauth.refreshToken,
+      expiresAt: typeof oauth.expiresAt === 'number' ? oauth.expiresAt : undefined,
+      subscriptionType: oauth.subscriptionType ?? oauth.rateLimitTier,
+      scopes: Array.isArray(oauth.scopes) ? oauth.scopes : undefined,
+    };
+  } catch (err) {
+    console.warn('[Claude] Failed to read Claude Code credentials:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/** True when the token expires within the next `skewMs` (default 60s). */
+export function isTokenExpired(expiresAt: number | undefined, nowMs: number = Date.now(), skewMs = 60_000): boolean {
+  if (typeof expiresAt !== 'number' || Number.isNaN(expiresAt)) return true;
+  return expiresAt <= nowMs + skewMs;
+}
+
+// ── Token refresh ─────────────────────────────────────────────────────────────
+
+// Public OAuth client id used by Claude Code (not a secret).
+const CLAUDE_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const TOKEN_ENDPOINTS = [
+  'https://console.anthropic.com/v1/oauth/token',
+  'https://api.anthropic.com/v1/oauth/token',
+];
+
+export interface RefreshedClaudeToken {
+  accessToken: string;
+  refreshToken: string;
+  /** Expiry in milliseconds since epoch. */
+  expiresAt: number;
+}
+
+/**
+ * Exchange a refresh token for a new access token. Tries both known token
+ * endpoints. Returns null when the refresh fails (caller should re-read the
+ * credentials file or prompt re-auth via Claude Code).
+ */
+export async function refreshClaudeToken(refreshToken: string): Promise<RefreshedClaudeToken | null> {
+  for (const endpoint of TOKEN_ENDPOINTS) {
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          client_id: CLAUDE_OAUTH_CLIENT_ID,
+        }),
+      });
+      if (!res.ok) continue;
+      const data = (await res.json()) as { access_token?: string; refresh_token?: string; expires_in?: number };
+      if (!data.access_token) continue;
+      return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token ?? refreshToken,
+        expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000,
+      };
+    } catch {
+      // try the next endpoint
+    }
+  }
+  return null;
+}
+
+// ── Rate limit probing ────────────────────────────────────────────────────────
+
+export interface ClaudeRateLimitWindow {
+  /** Fraction of the window consumed, 0..1 (null when not reported). */
+  utilization: number | null;
+  /** Unix timestamp (seconds) when the window resets. */
+  reset: number | null;
+  /** True when this window is currently exhausted. */
+  limited: boolean;
+}
+
+export interface ClaudeRateLimitProbe {
+  /** HTTP status of the probe request. */
+  status: number;
+  /** True when the account is currently rate limited (any window). */
+  limited: boolean;
+  /** Unix timestamp (seconds) when the binding limit lifts; null when not limited. */
+  resetAt: number | null;
+  /** `retry-after` value in seconds when the probe was rejected with 429. */
+  retryAfterSec: number | null;
+  fiveHour: ClaudeRateLimitWindow | null;
+  sevenDay: ClaudeRateLimitWindow | null;
+  error?: string;
+}
+
+const MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+// Cheapest models for the 1-token probe; tried in order on model-not-found.
+const PROBE_MODELS = ['claude-haiku-4-5', 'claude-3-5-haiku-latest'];
+
+/** Parse a header that may be unix seconds or an ISO-8601 timestamp → unix seconds. */
+function parseResetHeader(value: string | null): number | null {
+  if (value === null) return null;
+  const asNumber = Number(value);
+  if (!Number.isNaN(asNumber) && asNumber > 0) return asNumber;
+  const asDate = Date.parse(value);
+  return Number.isNaN(asDate) ? null : Math.floor(asDate / 1000);
+}
+
+function parseWindow(get: (name: string) => string | null, prefix: string): ClaudeRateLimitWindow | null {
+  const utilizationRaw = get(`${prefix}-utilization`);
+  const resetRaw = get(`${prefix}-reset`);
+  const status = (get(`${prefix}-status`) ?? '').toLowerCase();
+  const remainingRaw = get(`${prefix}-remaining`);
+  if (utilizationRaw === null && resetRaw === null && status === '' && remainingRaw === null) return null;
+
+  const utilization = utilizationRaw !== null && !Number.isNaN(Number(utilizationRaw)) ? Number(utilizationRaw) : null;
+  const reset = parseResetHeader(resetRaw);
+  const remaining = remainingRaw !== null && !Number.isNaN(Number(remainingRaw)) ? Number(remainingRaw) : null;
+
+  const limited =
+    status.includes('limit') ||
+    status.includes('reject') ||
+    remaining === 0 ||
+    (utilization !== null && utilization >= 1);
+
+  return { utilization, reset, limited };
+}
+
+/**
+ * Pure header-parsing helper (exported for tests). `get` should behave like
+ * `Headers.get`: return the header value or null when absent.
+ */
+export function parseRateLimitHeaders(status: number, get: (name: string) => string | null): ClaudeRateLimitProbe {
+  const fiveHour = parseWindow(get, 'anthropic-ratelimit-unified-5h');
+  const sevenDay = parseWindow(get, 'anthropic-ratelimit-unified-7d');
+
+  const retryAfterRaw = get('retry-after');
+  const retryAfterSec = retryAfterRaw !== null && !Number.isNaN(Number(retryAfterRaw)) ? Number(retryAfterRaw) : null;
+
+  const overallStatus = (get('anthropic-ratelimit-unified-status') ?? '').toLowerCase();
+  const overallReset = parseResetHeader(get('anthropic-ratelimit-unified-reset'));
+
+  const rejected = status === 429 || overallStatus.includes('limit') || overallStatus.includes('reject');
+  const limited = rejected || (fiveHour?.limited ?? false) || (sevenDay?.limited ?? false);
+
+  // The binding constraint is the exhausted window that lifts last — both
+  // windows must have capacity again before the account is usable.
+  let resetAt: number | null = null;
+  if (limited) {
+    const candidates = [fiveHour, sevenDay]
+      .filter((w): w is ClaudeRateLimitWindow => w !== null && w.limited && w.reset !== null)
+      .map((w) => w.reset as number);
+    if (candidates.length > 0) {
+      resetAt = Math.max(...candidates);
+    } else if (overallReset !== null) {
+      resetAt = overallReset;
+    } else if (retryAfterSec !== null) {
+      resetAt = Math.floor(Date.now() / 1000) + retryAfterSec;
+    }
+  }
+
+  return { status, limited, resetAt, retryAfterSec, fiveHour, sevenDay };
+}
+
+/**
+ * Probe the Anthropic API with a 1-token request and read the unified
+ * rate-limit headers. Rejected (429) probes do not consume quota.
+ */
+export async function checkClaudeRateLimit(accessToken: string): Promise<ClaudeRateLimitProbe> {
+  let lastError: string | undefined;
+
+  for (const model of PROBE_MODELS) {
+    try {
+      const res = await fetch(MESSAGES_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+          'anthropic-version': '2023-06-01',
+          'anthropic-beta': 'oauth-2025-04-20',
+          'x-app': 'cli',
+          'user-agent': 'claude-cli/2.0.0 (external, cli)',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 1,
+          // Claude Code OAuth credentials require the Claude Code system prompt.
+          system: "You are Claude Code, Anthropic's official CLI for Claude.",
+          messages: [{ role: 'user', content: 'ping' }],
+        }),
+      });
+
+      const probe = parseRateLimitHeaders(res.status, (name) => res.headers.get(name));
+
+      if (!res.ok && res.status !== 429) {
+        const body = await res.text().catch(() => '');
+        lastError = `HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ''}`;
+        // Model not found → try the next probe model; otherwise give up.
+        if (res.status === 404 && model !== PROBE_MODELS[PROBE_MODELS.length - 1]) continue;
+        probe.error = lastError;
+      }
+
+      return probe;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  return {
+    status: 0,
+    limited: false,
+    resetAt: null,
+    retryAfterSec: null,
+    fiveHour: null,
+    sevenDay: null,
+    error: lastError ?? 'Probe failed',
+  };
+}

--- a/tests/unit/claude.test.ts
+++ b/tests/unit/claude.test.ts
@@ -1,0 +1,167 @@
+/// <reference path="../../src/types/sql.js.d.ts" />
+/**
+ * Unit tests for the Claude (Claude Code OAuth) rate-limit service.
+ *
+ * Covers credential-file parsing, token-expiry logic, and parsing of the
+ * anthropic-ratelimit-unified-* response headers — all pure/offline.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  loadClaudeCodeCredentials,
+  isTokenExpired,
+  parseRateLimitHeaders,
+} from '../../src/services/claude';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-claude-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeCredentials(contents: unknown): string {
+  const file = path.join(tmpDir, '.credentials.json');
+  fs.writeFileSync(file, typeof contents === 'string' ? contents : JSON.stringify(contents));
+  return file;
+}
+
+function headerGetter(headers: Record<string, string>): (name: string) => string | null {
+  return (name) => headers[name] ?? null;
+}
+
+// ── loadClaudeCodeCredentials ─────────────────────────────────────────────────
+
+describe('loadClaudeCodeCredentials', () => {
+  it('returns null when the file does not exist', () => {
+    expect(loadClaudeCodeCredentials(path.join(tmpDir, 'missing.json'))).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(loadClaudeCodeCredentials(writeCredentials('not json{'))).toBeNull();
+  });
+
+  it('returns null when claudeAiOauth.accessToken is missing', () => {
+    expect(loadClaudeCodeCredentials(writeCredentials({ claudeAiOauth: {} }))).toBeNull();
+    expect(loadClaudeCodeCredentials(writeCredentials({}))).toBeNull();
+  });
+
+  it('parses a full credentials file', () => {
+    const file = writeCredentials({
+      claudeAiOauth: {
+        accessToken: 'sk-ant-oat01-abc',
+        refreshToken: 'sk-ant-ort01-xyz',
+        expiresAt: 1_800_000_000_000,
+        subscriptionType: 'pro',
+        scopes: ['user:profile'],
+      },
+    });
+    expect(loadClaudeCodeCredentials(file)).toEqual({
+      accessToken: 'sk-ant-oat01-abc',
+      refreshToken: 'sk-ant-ort01-xyz',
+      expiresAt: 1_800_000_000_000,
+      subscriptionType: 'pro',
+      scopes: ['user:profile'],
+    });
+  });
+
+  it('falls back to rateLimitTier for the subscription type', () => {
+    const file = writeCredentials({
+      claudeAiOauth: { accessToken: 'tok', rateLimitTier: 'max' },
+    });
+    expect(loadClaudeCodeCredentials(file)?.subscriptionType).toBe('max');
+  });
+});
+
+// ── isTokenExpired ────────────────────────────────────────────────────────────
+
+describe('isTokenExpired', () => {
+  const now = 1_000_000;
+
+  it('treats a missing expiry as expired', () => {
+    expect(isTokenExpired(undefined, now)).toBe(true);
+    expect(isTokenExpired(Number.NaN, now)).toBe(true);
+  });
+
+  it('applies the skew window', () => {
+    expect(isTokenExpired(now + 30_000, now)).toBe(true);  // within 60s skew
+    expect(isTokenExpired(now + 120_000, now)).toBe(false);
+  });
+});
+
+// ── parseRateLimitHeaders ─────────────────────────────────────────────────────
+
+describe('parseRateLimitHeaders', () => {
+  it('reports not limited on a healthy 200 response', () => {
+    const probe = parseRateLimitHeaders(200, headerGetter({
+      'anthropic-ratelimit-unified-5h-utilization': '0.42',
+      'anthropic-ratelimit-unified-5h-reset': '1800000000',
+      'anthropic-ratelimit-unified-status': 'allowed',
+    }));
+    expect(probe.limited).toBe(false);
+    expect(probe.resetAt).toBeNull();
+    expect(probe.fiveHour).toEqual({ utilization: 0.42, reset: 1_800_000_000, limited: false });
+    expect(probe.sevenDay).toBeNull();
+  });
+
+  it('detects a 429 with retry-after and derives resetAt from it', () => {
+    const before = Math.floor(Date.now() / 1000);
+    const probe = parseRateLimitHeaders(429, headerGetter({ 'retry-after': '1800' }));
+    expect(probe.limited).toBe(true);
+    expect(probe.retryAfterSec).toBe(1800);
+    expect(probe.resetAt).toBeGreaterThanOrEqual(before + 1800);
+  });
+
+  it('detects an exhausted 5h window on a 200 response', () => {
+    const probe = parseRateLimitHeaders(200, headerGetter({
+      'anthropic-ratelimit-unified-5h-utilization': '1',
+      'anthropic-ratelimit-unified-5h-reset': '1800003600',
+    }));
+    expect(probe.limited).toBe(true);
+    expect(probe.resetAt).toBe(1_800_003_600);
+  });
+
+  it('picks the latest reset when both windows are exhausted', () => {
+    const probe = parseRateLimitHeaders(429, headerGetter({
+      'anthropic-ratelimit-unified-5h-remaining': '0',
+      'anthropic-ratelimit-unified-5h-reset': '1800003600',
+      'anthropic-ratelimit-unified-7d-remaining': '0',
+      'anthropic-ratelimit-unified-7d-reset': '1800600000',
+    }));
+    expect(probe.limited).toBe(true);
+    expect(probe.resetAt).toBe(1_800_600_000);
+  });
+
+  it('falls back to the overall unified reset header', () => {
+    const probe = parseRateLimitHeaders(429, headerGetter({
+      'anthropic-ratelimit-unified-status': 'rate_limited',
+      'anthropic-ratelimit-unified-reset': '1800000000',
+    }));
+    expect(probe.limited).toBe(true);
+    expect(probe.resetAt).toBe(1_800_000_000);
+  });
+
+  it('accepts ISO-8601 reset values', () => {
+    const probe = parseRateLimitHeaders(200, headerGetter({
+      'anthropic-ratelimit-unified-5h-utilization': '1',
+      'anthropic-ratelimit-unified-5h-reset': '2027-01-15T10:00:00Z',
+    }));
+    expect(probe.fiveHour?.reset).toBe(Math.floor(Date.parse('2027-01-15T10:00:00Z') / 1000));
+    expect(probe.limited).toBe(true);
+  });
+
+  it('handles a response with no rate-limit headers at all', () => {
+    const probe = parseRateLimitHeaders(200, headerGetter({}));
+    expect(probe.limited).toBe(false);
+    expect(probe.fiveHour).toBeNull();
+    expect(probe.sevenDay).toBeNull();
+    expect(probe.resetAt).toBeNull();
+  });
+});

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -68,6 +68,10 @@ const EXPECTED_CHANNELS = [
   'github:start-oauth-discovery',
   'github:start-oauth',
   'github:get-rate-limit',
+  // claude plugin
+  'claude:status',
+  'claude:rate-limit',
+  'claude:disconnect',
   // discovery plugin
   'github:discovery-status',
   'github:start-discovery',


### PR DESCRIPTION
## Summary of Changes

Adds a new "Claude AI" setup step that connects to the user's Claude account and tracks the Pro/Max subscription rate limits, with a live countdown ticker in the bottom status bar when the limit is hit.

Key design decisions:

- **Credential source**: reuses the OAuth credentials Claude Code already stores locally (`~/.claude/.credentials.json`). A Console API key would track separate pay-as-you-go quotas, not the Pro subscription limits the user actually cares about. Refreshed tokens are cached encrypted in the Jarvis config store; Claude Code's own file is never modified.
- **Detection**: a minimal `POST /v1/messages` probe (max_tokens 1, cheapest Haiku model, `anthropic-beta: oauth-2025-04-20`) reads the `anthropic-ratelimit-unified-*` headers for the 5-hour and 7-day windows. On HTTP 429 the `retry-after` header is used; rejected probes don't consume quota. When both windows are exhausted, the binding reset is the later of the two.
- **UI**: new step tile in the Setup tab (Connected / Rate limited / Not found) opening a detail panel with per-window utilization, reset times, manual refresh, and a "forget cached token" action. The status bar shows a green `Claude 42%` badge when healthy and a pulsing red `Claude limited · resets in Xh Ym` ticker (1s countdown) while limited. Polling runs every 2 minutes, tightening to 30s while limited.

Structure follows the existing plugin pattern (`src/plugins/claude/` with handler/step/panel), mirroring the Ollama and GitHub rate-limit implementations.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. Sign in to Claude Code with a Pro/Max account so `~/.claude/.credentials.json` exists
2. Launch Jarvis, open the Setup tab, and verify the "Claude AI" step shows Connected with your subscription type; click it to open the detail panel with 5h/7d window utilization
3. Verify the status bar shows the green Claude badge; when the account is rate limited, verify the pulsing red countdown appears and ticks down, and disappears once the limit lifts

Unit tests cover credential parsing, token expiry, and rate-limit header parsing (`tests/unit/claude.test.ts`); new IPC channels are registered in the catalogue test.

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed