### PR TITLE
fix: repair YAML indentation in gh-aw-version-check workflow

### DIFF
--- a/.github/workflows/gh-aw-version-check.yml
+++ b/.github/workflows/gh-aw-version-check.yml
@@ -107,25 +107,25 @@ jobs:
             --label "maintenance" \
             --body "## gh-aw Lock File Version Drift Detected
 
-The following lock file(s) were compiled with an older version of \`gh-aw\` than the latest available release:
+          The following lock file(s) were compiled with an older version of \`gh-aw\` than the latest available release:
 
-${FILE_LIST}
-### Details
+          ${FILE_LIST}
+          ### Details
 
-| | Version |
-|---|---|
-| Compiler version in lock file(s) | \`${COMPILER_LABEL}\` |
-| Latest \`gh-aw-actions\` release | \`${LATEST_VERSION}\` |
+          | | Version |
+          |---|---|
+          | Compiler version in lock file(s) | \`${COMPILER_LABEL}\` |
+          | Latest \`gh-aw-actions\` release | \`${LATEST_VERSION}\` |
 
-### Fix
+          ### Fix
 
-Run the following commands to upgrade the compiler extension and regenerate the lock files:
+          Run the following commands to upgrade the compiler extension and regenerate the lock files:
 
-\`\`\`bash
-gh extension upgrade gh-aw
-gh aw compile
-\`\`\`
+          \`\`\`bash
+          gh extension upgrade gh-aw
+          gh aw compile
+          \`\`\`
 
-Then commit and push the regenerated lock files."
+          Then commit and push the regenerated lock files."
 
           echo "Issue created: $ISSUE_TITLE"


### PR DESCRIPTION
## Summary of Changes

Fixes the YAML-invalid `.github/workflows/gh-aw-version-check.yml` workflow. The multi-line `--body "..."` string in the `gh issue create` step (lines 109–129) was written at column 0, which broke out of the `run: |` block scalar and made the entire workflow file unparseable.

The workflow has been **YAML-invalid since it was added in PR #137** (2026-05-20). Evidence:

- The workflow's registered name on GitHub is its file path (not "gh-aw Version Drift Check"), meaning GitHub can't parse `name:`/`on:`.
- `gh workflow run` returns HTTP 422 "Workflow does not have 'workflow_dispatch' trigger" even though the trigger is in the file.
- All ~100 runs in API history are `push`/`failure` with zero jobs across every branch since Aug 25 — it has never executed successfully, including its daily cron. This caused failure noise on every push.

**The fix:** indent the issue body lines by 10 spaces so the whole string stays inside the `run: |` block scalar. Because the block scalar's common indentation is stripped back out, the script bash receives at runtime is **byte-identical to the original intent** — the created issue body is not indented, and no `sed` stripping is needed.

This PR was triggered by the check failure on PR #255.

## Related Issue

Relates to PR #255 (check failure that surfaced this) and PR #137 (which introduced the broken workflow).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. Parse the file with a YAML parser — it now parses cleanly (previously failed at line 112 with `could not find expected ':'`).
2. `actionlint .github/workflows/gh-aw-version-check.yml` passes with no errors.
3. After merge, the workflow should register on GitHub under its real name ("gh-aw Version Drift Check") instead of its file path, and `gh workflow run gh-aw-version-check.yml` should be accepted (no more HTTP 422).

## Checklist

- [x] Tests pass (`npm test`) — no application code changed; workflow-only fix
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets or sensitive data committed