### PR TITLE
Add Claude OAuth sign-in and fix credential detection

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1400,7 +1400,10 @@ Jarvis can track the user's Claude **subscription** (Pro/Max) usage limits — n
 
 ### Credential Source
 
-The app reuses the OAuth credentials that Claude Code stores locally in `~/.claude/.credentials.json` (`claudeAiOauth.accessToken` / `refreshToken` / `expiresAt`). Refreshed tokens are cached encrypted in the Jarvis config store — Claude Code's own file is never modified.
+Two ways to connect:
+
+1. **Direct OAuth sign-in (PKCE)** — a "Sign in with Claude" button in the Claude panel opens `claude.ai/oauth/authorize` with the public Claude Code OAuth client; the user pastes the displayed code back into Jarvis. Tokens are stored encrypted in the Jarvis config store.
+2. **Claude Code credentials fallback** — reuses `~/.claude/.credentials.json` (`claudeAiOauth.*`) when present. Tokens with missing/zero expiry are tried anyway; a 401 from the probe triggers refresh + retry. Refreshed tokens are cached encrypted in Jarvis — Claude Code's file is never modified.
 
 ### Probing the Limit
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -310,6 +310,8 @@ contextBridge.exposeInMainWorld('jarvis', {
   getClaudeStatus: () => ipcRenderer.invoke('claude:status'),
   getClaudeRateLimit: () => ipcRenderer.invoke('claude:rate-limit'),
   disconnectClaude: () => ipcRenderer.invoke('claude:disconnect'),
+  beginClaudeOAuth: () => ipcRenderer.invoke('claude:begin-oauth'),
+  completeClaudeOAuth: (code: string) => ipcRenderer.invoke('claude:complete-oauth', code),
   // Auto-dismiss log
   logAutoDismiss: (entries: unknown[]) => ipcRenderer.invoke('github:log-auto-dismiss', entries),
   listAutoDismissLog: (limit?: number) => ipcRenderer.invoke('github:list-auto-dismiss-log', limit),

--- a/src/plugins/claude/ClaudePanel.tsx
+++ b/src/plugins/claude/ClaudePanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'preact/hooks';
 import type { ClaudeStatus, ClaudeRateLimit, ClaudeRateLimitWindow } from '../types';
 import { formatDurationUntil } from '../shared/utils';
 
@@ -39,6 +40,91 @@ function WindowRow({ label, win }: { label: string; win: ClaudeRateLimitWindow |
 }
 
 export function ClaudePanel({ status, rateLimit, refreshing, onRefresh, onDisconnect, onClose }: ClaudePanelProps) {
+  const [oauthPending, setOauthPending] = useState(false);
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [oauthError, setOauthError] = useState<string | null>(null);
+
+  const handleConnect = async () => {
+    setBusy(true);
+    setOauthError(null);
+    try {
+      const result = await window.jarvis.beginClaudeOAuth();
+      if (result.ok) {
+        setOauthPending(true);
+      } else {
+        setOauthError(result.error ?? 'Could not start sign-in');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleComplete = async () => {
+    setBusy(true);
+    setOauthError(null);
+    try {
+      const result = await window.jarvis.completeClaudeOAuth(code);
+      if (result.ok) {
+        setOauthPending(false);
+        setCode('');
+        onRefresh();
+      } else {
+        setOauthError(result.error ?? 'Sign-in failed');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!status.connected) {
+    return (
+      <div class="org-panel ollama-panel">
+        <div class="org-panel-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span>Claude AI</span>
+          <button class="repo-panel-close" title="Close" onClick={onClose}>&times;</button>
+        </div>
+        {status.error && (
+          <div style={{ fontSize: '0.82rem', color: '#99aabb', marginBottom: '0.75rem' }}>{status.error}</div>
+        )}
+        {oauthError && (
+          <div style={{ fontSize: '0.8rem', color: '#ff8080', marginBottom: '0.6rem' }}>{oauthError}</div>
+        )}
+        {!oauthPending ? (
+          <button
+            style={{ fontSize: '0.82rem', padding: '0.4rem 1rem', background: '#0a3d1f', color: '#51cf66', border: '1px solid #2b8a3e', borderRadius: '5px', cursor: 'pointer' }}
+            disabled={busy}
+            onClick={() => void handleConnect()}
+          >
+            {busy ? 'Opening browser…' : 'Sign in with Claude'}
+          </button>
+        ) : (
+          <div>
+            <div style={{ fontSize: '0.82rem', color: '#99aabb', marginBottom: '0.5rem' }}>
+              A browser tab was opened. Authorize Jarvis, then paste the code shown on the confirmation page:
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <input
+                type="text"
+                value={code}
+                placeholder="Paste code here"
+                style={{ flex: 1, fontSize: '0.82rem', padding: '0.35rem 0.5rem', background: '#0f3460', color: '#dde', border: '1px solid #2b5c9e', borderRadius: '5px' }}
+                onInput={(e) => setCode((e.target as HTMLInputElement).value)}
+              />
+              <button
+                style={{ fontSize: '0.82rem', padding: '0.35rem 0.9rem', background: '#0a3d1f', color: '#51cf66', border: '1px solid #2b8a3e', borderRadius: '5px', cursor: 'pointer' }}
+                disabled={busy || !code.trim()}
+                onClick={() => void handleComplete()}
+              >
+                {busy ? 'Verifying…' : 'Connect'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   const plan = status.subscriptionType ?? 'unknown plan';
   return (
     <div class="org-panel ollama-panel">
@@ -48,7 +134,7 @@ export function ClaudePanel({ status, rateLimit, refreshing, onRefresh, onDiscon
       </div>
       <div style={{ fontSize: '0.82rem', color: '#99aabb', marginBottom: '0.75rem' }}>
         Subscription: <code style={{ background: '#0f3460', padding: '0.1rem 0.4rem', borderRadius: '3px' }}>{plan}</code>
-        {' '}via Claude Code credentials
+        {' '}{status.source === 'stored' ? 'via Jarvis sign-in' : 'via Claude Code credentials'}
       </div>
 
       {rateLimit?.error && (

--- a/src/plugins/claude/ClaudeStep.tsx
+++ b/src/plugins/claude/ClaudeStep.tsx
@@ -26,22 +26,22 @@ export function ClaudeStep({ status, rateLimit, onToggle }: ClaudeStepProps) {
       }
     } else {
       badgeStatus = 'pending';
-      badgeLabel = 'Not found';
-      detail = status.error ?? 'Claude Code credentials not found.';
+      badgeLabel = 'Not connected';
+      detail = 'Click to sign in with your Claude account.';
     }
   }
 
   return (
     <div
-      class={`step${status?.connected ? ' ollama-step-clickable' : ''}`}
+      class="step ollama-step-clickable"
       id="claude-step"
-      onClick={status?.connected ? onToggle : undefined}
+      onClick={status !== null ? onToggle : undefined}
     >
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.4rem' }}>
         <h2 style={{ marginBottom: 0 }}>
           Claude AI <StatusBadge status={badgeStatus} label={badgeLabel} />
         </h2>
-        {status?.connected && (
+        {status !== null && (
           <span style={{ color: '#99a', fontSize: '0.8rem' }}>{'›'}</span>
         )}
       </div>

--- a/src/plugins/claude/handler.ts
+++ b/src/plugins/claude/handler.ts
@@ -1,13 +1,18 @@
 // ── Claude IPC handlers ───────────────────────────────────────────────────────
-import { ipcMain } from 'electron';
+import { ipcMain, shell } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import type { BrowserWindow } from 'electron';
 import {
   loadClaudeCodeCredentials,
   refreshClaudeToken,
   checkClaudeRateLimit,
-  isTokenExpired,
+  isTokenPotentiallyUsable,
+  generatePkce,
+  buildAuthorizeUrl,
+  parseAuthorizationCode,
+  exchangeCodeForToken,
   type ClaudeCredentials,
+  type PkcePair,
 } from '../../services/claude';
 import { getConfigValue, setConfigValue, saveDatabase } from '../../storage/database';
 import { encrypt, decrypt, getEncryptionKey } from '../../storage/encryption';
@@ -56,21 +61,24 @@ function clearStoredCredentials(db: SqlJsDatabase): void {
 
 /**
  * Resolve a usable access token. Order:
- *   1. cached refreshed token (still valid)
- *   2. Claude Code credentials file (still valid)
+ *   1. cached refreshed token (still valid, or expiry unknown)
+ *   2. Claude Code credentials file (still valid, or expiry unknown)
  *   3. refresh via cached refresh token
  *   4. refresh via the file's refresh token (persisted on success)
+ *
+ * Tokens with a missing/zero expiry are tried anyway — the probe's 401 is the
+ * authoritative expiry signal and triggers a refresh + retry.
  */
 async function resolveAccessToken(
   db: SqlJsDatabase,
 ): Promise<{ token: string; source: 'stored' | 'claude-code'; subscriptionType?: string; expiresAt?: number } | null> {
   const stored = loadStoredCredentials(db);
-  if (stored && !isTokenExpired(stored.expiresAt)) {
+  if (stored && isTokenPotentiallyUsable(stored.expiresAt)) {
     return { token: stored.accessToken, source: 'stored', subscriptionType: stored.subscriptionType, expiresAt: stored.expiresAt };
   }
 
   const fromFile = loadClaudeCodeCredentials();
-  if (fromFile && !isTokenExpired(fromFile.expiresAt)) {
+  if (fromFile && isTokenPotentiallyUsable(fromFile.expiresAt)) {
     return { token: fromFile.accessToken, source: 'claude-code', subscriptionType: fromFile.subscriptionType, expiresAt: fromFile.expiresAt };
   }
 
@@ -96,8 +104,8 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
         return {
           connected: false,
           error: fileExists
-            ? 'Claude Code credentials found but expired — open Claude Code once to refresh them.'
-            : 'No Claude Code credentials found (~/.claude/.credentials.json). Sign in with Claude Code first.',
+            ? 'Claude Code credentials found but unusable — open this panel to sign in with your Claude account.'
+            : 'Not connected — open this panel to sign in with your Claude account.',
         };
       }
       return {
@@ -166,6 +174,49 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
 
   ipcMain.handle('claude:disconnect', () => {
     clearStoredCredentials(db);
+    return { ok: true };
+  });
+
+  // ── OAuth sign-in (PKCE, out-of-band code paste) ──────────────────────────
+  let pendingPkce: PkcePair | null = null;
+
+  ipcMain.handle('claude:begin-oauth', () => {
+    try {
+      pendingPkce = generatePkce();
+      const url = buildAuthorizeUrl(pendingPkce);
+      void shell.openExternal(url);
+      return { ok: true, authorizeUrl: url };
+    } catch (err) {
+      pendingPkce = null;
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('claude:complete-oauth', async (_event, pastedCode: string) => {
+    if (!pendingPkce) {
+      return { ok: false, error: 'No sign-in in progress — click "Sign in with Claude" first.' };
+    }
+    if (typeof pastedCode !== 'string') {
+      return { ok: false, error: 'Invalid code' };
+    }
+    const parsed = parseAuthorizationCode(pastedCode);
+    if (!parsed) {
+      return { ok: false, error: 'Empty code — paste the code shown on the Claude page.' };
+    }
+    if (parsed.state && parsed.state !== pendingPkce.state) {
+      return { ok: false, error: 'State mismatch — restart the sign-in and paste the latest code.' };
+    }
+    const tokens = await exchangeCodeForToken(parsed.code, pendingPkce.verifier, parsed.state ?? pendingPkce.state);
+    if (!tokens) {
+      return { ok: false, error: 'Token exchange failed — the code may have expired. Try signing in again.' };
+    }
+    pendingPkce = null;
+    const creds: ClaudeCredentials = {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken || undefined,
+      expiresAt: tokens.expiresAt,
+    };
+    storeCredentials(db, creds);
     return { ok: true };
   });
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2819,6 +2819,8 @@ export interface JarvisApi {
   getClaudeStatus(): Promise<ClaudeStatus>;
   getClaudeRateLimit(): Promise<ClaudeRateLimit>;
   disconnectClaude(): Promise<{ ok: boolean }>;
+  beginClaudeOAuth(): Promise<{ ok: boolean; authorizeUrl?: string; error?: string }>;
+  completeClaudeOAuth(code: string): Promise<{ ok: boolean; error?: string }>;
 
   // Auto-dismiss log
   logAutoDismiss(entries: AutoDismissLogInput[]): Promise<void>;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1108,7 +1108,7 @@ function App() {
         <div class="ollama-step-wrapper">
           <ClaudeStep status={claudeStatus} rateLimit={claudeRateLimit} onToggle={handleClaudeToggle} />
         </div>
-        {showClaudePanel && claudeStatus?.connected && (
+        {showClaudePanel && claudeStatus && (
           <ClaudePanel
             status={claudeStatus}
             rateLimit={claudeRateLimit}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1349,20 +1349,47 @@ function BackgroundStatusBar({
             </div>
           )}
           {claudeBadge && (
-            <span
-              class={`bg-status-rate-limit${claudeBadge.limited ? ' bg-status-rate-limit--limited' : ''}`}
-              title={claudeBadge.error
-                ? `Claude rate limit check failed: ${claudeBadge.error}`
-                : claudeBadge.limited
-                  ? `Claude usage limit reached — ${claudeBadge.resetAt !== null ? `${formatDurationUntil(claudeBadge.resetAt)} (${new Date(claudeBadge.resetAt * 1000).toLocaleString()})` : 'reset time unknown'}`
-                  : `Claude${claudeBadge.fiveHour?.utilization != null ? `: 5h window ${Math.round(claudeBadge.fiveHour.utilization * 100)}% used` : ' not rate limited'}`}
-              style={{ color: claudeBadge.error ? '#888' : claudeBadge.limited ? '#f44336' : '#4caf50' }}
-            >
-              {claudeBadge.error
-                ? '✦ Claude –'
-                : claudeBadge.limited
-                  ? `⏳ Claude limited · ${claudeBadge.resetAt !== null ? formatDurationUntil(claudeBadge.resetAt) : 'resets soon'}`
-                  : `✦ Claude${claudeBadge.fiveHour?.utilization != null ? ` ${Math.round(claudeBadge.fiveHour.utilization * 100)}%` : ' ok'}`}
+            <span class="bg-status-claude">
+              <span
+                class={`bg-status-rate-limit${claudeBadge.limited ? ' bg-status-rate-limit--limited' : ''}`}
+                style={{ color: claudeBadge.error ? '#888' : claudeBadge.limited ? '#f44336' : '#4caf50' }}
+              >
+                {claudeBadge.error
+                  ? '✦ Claude –'
+                  : claudeBadge.limited
+                    ? `⏳ Claude limited · ${claudeBadge.resetAt !== null ? formatDurationUntil(claudeBadge.resetAt) : 'resets soon'}`
+                    : `✦ Claude${claudeBadge.fiveHour?.utilization != null ? ` ${Math.round(claudeBadge.fiveHour.utilization * 100)}%` : ' ok'}`}
+              </span>
+              <div class="bg-status-claude-pop">
+                {([
+                  ['5-hour window', claudeBadge.fiveHour],
+                  ['7-day window', claudeBadge.sevenDay],
+                ] as const).map(([label, win]) => (
+                  <div class="bg-status-claude-row" key={label}>
+                    <span class="bg-status-claude-label">{label}</span>
+                    {win ? (
+                      <>
+                        <span style={{ color: win.limited ? '#f44336' : win.utilization !== null && win.utilization >= 0.8 ? '#ff9800' : '#4caf50', fontWeight: 600 }}>
+                          {win.limited ? 'exhausted' : win.utilization !== null ? `${Math.round(win.utilization * 100)}% used` : 'ok'}
+                        </span>
+                        {win.reset !== null && (
+                          <span class="bg-status-claude-reset">
+                            {formatDurationUntil(win.reset)} · {new Date(win.reset * 1000).toLocaleTimeString()}
+                          </span>
+                        )}
+                      </>
+                    ) : (
+                      <span style={{ color: '#667' }}>no data</span>
+                    )}
+                  </div>
+                ))}
+                {claudeBadge.error && (
+                  <div class="bg-status-claude-row" style={{ color: '#ff9800' }}>Check failed: {claudeBadge.error}</div>
+                )}
+                <div class="bg-status-claude-row" style={{ color: '#556', fontSize: '0.72rem' }}>
+                  Last checked {new Date(claudeBadge.fetchedAt).toLocaleTimeString()}
+                </div>
+              </div>
             </span>
           )}
           {hasAnyBadge && (oauthBadge || patBadge) && (

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -4060,6 +4060,62 @@ h5.ec-heading { font-size: 0.9375rem; }
   50% { opacity: 0.55; }
 }
 
+/* Claude badge hover popover (mirrors the setup panel info) */
+.bg-status-claude {
+  position: relative;
+  pointer-events: auto;
+  flex-shrink: 0;
+}
+
+.bg-status-claude-pop {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  min-width: 240px;
+  background: #0d1a2e;
+  border: 1px solid #1e3a5a;
+  border-radius: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  padding: 0.4rem 0;
+  z-index: 1000;
+}
+
+.bg-status-claude-pop::before {
+  content: '';
+  position: absolute;
+  bottom: -10px;
+  left: 0;
+  right: 0;
+  height: 10px;
+}
+
+.bg-status-claude:hover .bg-status-claude-pop,
+.bg-status-claude:focus-within .bg-status-claude-pop {
+  display: block;
+}
+
+.bg-status-claude-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8125rem;
+  color: #c8d0e0;
+  cursor: default;
+  white-space: nowrap;
+}
+
+.bg-status-claude-label {
+  flex: 1;
+  color: #99aabb;
+}
+
+.bg-status-claude-reset {
+  font-size: 0.72rem;
+  color: #667;
+}
+
 /* ── Right-side group (tasks + rate limits) ──────────────────────────────── */
 .bg-status-right {
   margin-left: auto;

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -4049,9 +4049,10 @@ h5.ec-heading { font-size: 0.9375rem; }
   cursor: default;
 }
 
-/* Pulsing countdown while an account is rate limited */
+/* Pulsing countdown while an account is rate limited — blinks 5 times when
+   the badge appears, then stays static to avoid ongoing distraction. */
 .bg-status-rate-limit--limited {
-  animation: bg-status-limited-pulse 2s ease-in-out infinite;
+  animation: bg-status-limited-pulse 2s ease-in-out 5;
 }
 
 @keyframes bg-status-limited-pulse {

--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -104,7 +104,7 @@ export async function refreshClaudeToken(refreshToken: string): Promise<Refreshe
     try {
       const res = await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'User-Agent': 'anthropic' },
         body: JSON.stringify({
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
@@ -147,12 +147,12 @@ function base64UrlEncode(buf: Buffer): string {
   return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
-/** Generate a PKCE verifier/challenge pair plus a random state. */
+/** Generate a PKCE verifier/challenge pair. In this flow `state` equals the verifier. */
 export function generatePkce(): PkcePair {
   const verifier = base64UrlEncode(crypto.randomBytes(32));
   const challenge = base64UrlEncode(crypto.createHash('sha256').update(verifier).digest());
-  const state = base64UrlEncode(crypto.randomBytes(16));
-  return { verifier, challenge, state };
+  // The Anthropic authorization server expects state to be the verifier value.
+  return { verifier, challenge, state: verifier };
 }
 
 /** Build the authorize URL the user must visit in a browser. */
@@ -201,7 +201,7 @@ export async function exchangeCodeForToken(code: string, verifier: string, state
     try {
       const res = await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'User-Agent': 'anthropic' },
         body: JSON.stringify(body),
       });
       if (!res.ok) continue;
@@ -328,7 +328,7 @@ export async function checkClaudeRateLimit(accessToken: string): Promise<ClaudeR
           Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
           'anthropic-version': '2023-06-01',
-          'anthropic-beta': 'oauth-2025-04-20',
+          'anthropic-beta': 'oauth-2025-04-20,claude-code-20250219',
           'x-app': 'cli',
           'user-agent': 'claude-cli/2.0.0 (external, cli)',
         },

--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -9,6 +9,7 @@
 // headers on a minimal /v1/messages probe (max_tokens: 1). When the limit is
 // exhausted the API responds with HTTP 429 and a `retry-after` header; the
 // `*-reset` headers tell us when each window lifts.
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -67,6 +68,16 @@ export function isTokenExpired(expiresAt: number | undefined, nowMs: number = Da
   return expiresAt <= nowMs + skewMs;
 }
 
+/**
+ * True when a token is worth trying. Tokens with a missing or zero expiry
+ * (Claude Code sometimes writes expiresAt: 0) are considered usable — a 401
+ * from the API is the authoritative signal, and callers retry with a refresh.
+ */
+export function isTokenPotentiallyUsable(expiresAt: number | undefined, nowMs: number = Date.now()): boolean {
+  if (typeof expiresAt !== 'number' || Number.isNaN(expiresAt) || expiresAt === 0) return true;
+  return !isTokenExpired(expiresAt, nowMs);
+}
+
 // ── Token refresh ─────────────────────────────────────────────────────────────
 
 // Public OAuth client id used by Claude Code (not a secret).
@@ -106,6 +117,99 @@ export async function refreshClaudeToken(refreshToken: string): Promise<Refreshe
       return {
         accessToken: data.access_token,
         refreshToken: data.refresh_token ?? refreshToken,
+        expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000,
+      };
+    } catch {
+      // try the next endpoint
+    }
+  }
+  return null;
+}
+
+// ── OAuth (PKCE) sign-in ──────────────────────────────────────────────────────
+//
+// Uses the same public OAuth client as Claude Code, so the resulting token
+// carries the user's subscription rate limits. The flow is out-of-band: the
+// browser lands on a page that displays the authorization code, and the user
+// pastes it back into Jarvis.
+
+const OAUTH_AUTHORIZE_URL = 'https://claude.ai/oauth/authorize';
+const OAUTH_REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
+const OAUTH_SCOPES = 'org:create_api_key user:profile user:inference';
+
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+  state: string;
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Generate a PKCE verifier/challenge pair plus a random state. */
+export function generatePkce(): PkcePair {
+  const verifier = base64UrlEncode(crypto.randomBytes(32));
+  const challenge = base64UrlEncode(crypto.createHash('sha256').update(verifier).digest());
+  const state = base64UrlEncode(crypto.randomBytes(16));
+  return { verifier, challenge, state };
+}
+
+/** Build the authorize URL the user must visit in a browser. */
+export function buildAuthorizeUrl(pkce: PkcePair): string {
+  const params = new URLSearchParams({
+    code: 'true',
+    client_id: CLAUDE_OAUTH_CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: OAUTH_REDIRECT_URI,
+    scope: OAUTH_SCOPES,
+    code_challenge: pkce.challenge,
+    code_challenge_method: 'S256',
+    state: pkce.state,
+  });
+  return `${OAUTH_AUTHORIZE_URL}?${params.toString()}`;
+}
+
+/**
+ * Split a pasted authorization code into code + state. The callback page
+ * displays them joined as `code#state`; a bare code is also accepted.
+ */
+export function parseAuthorizationCode(pasted: string): { code: string; state?: string } | null {
+  const trimmed = pasted.trim();
+  if (!trimmed) return null;
+  const hashIdx = trimmed.indexOf('#');
+  if (hashIdx === -1) return { code: trimmed };
+  const code = trimmed.slice(0, hashIdx);
+  const state = trimmed.slice(hashIdx + 1);
+  return code ? { code, state: state || undefined } : null;
+}
+
+/**
+ * Exchange an authorization code for tokens. Returns null on failure.
+ */
+export async function exchangeCodeForToken(code: string, verifier: string, state?: string): Promise<RefreshedClaudeToken | null> {
+  const body: Record<string, string> = {
+    grant_type: 'authorization_code',
+    code,
+    client_id: CLAUDE_OAUTH_CLIENT_ID,
+    redirect_uri: OAUTH_REDIRECT_URI,
+    code_verifier: verifier,
+  };
+  if (state) body.state = state;
+
+  for (const endpoint of TOKEN_ENDPOINTS) {
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) continue;
+      const data = (await res.json()) as { access_token?: string; refresh_token?: string; expires_in?: number };
+      if (!data.access_token) continue;
+      return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token ?? '',
         expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000,
       };
     } catch {

--- a/tests/unit/claude.test.ts
+++ b/tests/unit/claude.test.ts
@@ -12,8 +12,13 @@ import path from 'path';
 import {
   loadClaudeCodeCredentials,
   isTokenExpired,
+  isTokenPotentiallyUsable,
   parseRateLimitHeaders,
+  generatePkce,
+  buildAuthorizeUrl,
+  parseAuthorizationCode,
 } from '../../src/services/claude';
+import crypto from 'crypto';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -93,6 +98,75 @@ describe('isTokenExpired', () => {
   it('applies the skew window', () => {
     expect(isTokenExpired(now + 30_000, now)).toBe(true);  // within 60s skew
     expect(isTokenExpired(now + 120_000, now)).toBe(false);
+  });
+});
+
+// ── isTokenPotentiallyUsable ─────────────────────────────────────────────────
+
+describe('isTokenPotentiallyUsable', () => {
+  const now = 1_000_000;
+
+  it('treats zero/missing expiry as usable (Claude Code sometimes writes 0)', () => {
+    expect(isTokenPotentiallyUsable(0, now)).toBe(true);
+    expect(isTokenPotentiallyUsable(undefined, now)).toBe(true);
+    expect(isTokenPotentiallyUsable(Number.NaN, now)).toBe(true);
+  });
+
+  it('respects real expiry', () => {
+    expect(isTokenPotentiallyUsable(now + 120_000, now)).toBe(true);
+    expect(isTokenPotentiallyUsable(now - 1, now)).toBe(false);
+  });
+});
+
+// ── OAuth PKCE helpers ────────────────────────────────────────────────────────
+
+describe('generatePkce', () => {
+  it('produces a verifier, its S256 challenge, and a state', () => {
+    const pkce = generatePkce();
+    expect(pkce.verifier.length).toBeGreaterThan(40);
+    expect(pkce.state.length).toBeGreaterThan(20);
+    const expected = crypto.createHash('sha256').update(pkce.verifier).digest()
+      .toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(pkce.challenge).toBe(expected);
+  });
+
+  it('generates unique values per call', () => {
+    const a = generatePkce();
+    const b = generatePkce();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.state).not.toBe(b.state);
+  });
+});
+
+describe('buildAuthorizeUrl', () => {
+  it('includes the PKCE parameters and Claude Code client id', () => {
+    const url = buildAuthorizeUrl({ verifier: 'v', challenge: 'ch', state: 'st' });
+    expect(url.startsWith('https://claude.ai/oauth/authorize?')).toBe(true);
+    expect(url).toContain('code_challenge=ch');
+    expect(url).toContain('code_challenge_method=S256');
+    expect(url).toContain('state=st');
+    expect(url).toContain('client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e');
+    expect(url).toContain('response_type=code');
+  });
+});
+
+describe('parseAuthorizationCode', () => {
+  it('accepts a bare code', () => {
+    expect(parseAuthorizationCode('abc123')).toEqual({ code: 'abc123' });
+  });
+
+  it('splits code#state as shown on the callback page', () => {
+    expect(parseAuthorizationCode('abc123#state456')).toEqual({ code: 'abc123', state: 'state456' });
+  });
+
+  it('trims whitespace and rejects empty input', () => {
+    expect(parseAuthorizationCode('  abc  ')).toEqual({ code: 'abc' });
+    expect(parseAuthorizationCode('   ')).toBeNull();
+    expect(parseAuthorizationCode('')).toBeNull();
+  });
+
+  it('treats a trailing # as no state', () => {
+    expect(parseAuthorizationCode('abc#')).toEqual({ code: 'abc', state: undefined });
   });
 });
 

--- a/tests/unit/claude.test.ts
+++ b/tests/unit/claude.test.ts
@@ -121,10 +121,10 @@ describe('isTokenPotentiallyUsable', () => {
 // ── OAuth PKCE helpers ────────────────────────────────────────────────────────
 
 describe('generatePkce', () => {
-  it('produces a verifier, its S256 challenge, and a state', () => {
+  it('produces a verifier, its S256 challenge, and state equal to the verifier', () => {
     const pkce = generatePkce();
     expect(pkce.verifier.length).toBeGreaterThan(40);
-    expect(pkce.state.length).toBeGreaterThan(20);
+    expect(pkce.state).toBe(pkce.verifier);
     const expected = crypto.createHash('sha256').update(pkce.verifier).digest()
       .toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
     expect(pkce.challenge).toBe(expected);
@@ -134,7 +134,6 @@ describe('generatePkce', () => {
     const a = generatePkce();
     const b = generatePkce();
     expect(a.verifier).not.toBe(b.verifier);
-    expect(a.state).not.toBe(b.state);
   });
 });
 

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -72,6 +72,8 @@ const EXPECTED_CHANNELS = [
   'claude:status',
   'claude:rate-limit',
   'claude:disconnect',
+  'claude:begin-oauth',
+  'claude:complete-oauth',
   // discovery plugin
   'github:discovery-status',
   'github:start-discovery',


### PR DESCRIPTION
## Summary of Changes

Follow-up to #256: the Claude step could get stuck on "Not found" even for logged-in users, and there was no way to connect without Claude Code's credentials file. This adds a first-party OAuth sign-in and hardens credential detection.

Why users were stuck:

- Status was only checked once at app startup with no recheck path when not connected (the step wasn't clickable and the panel never rendered).
- Claude Code sometimes writes `expiresAt: 0` in `.credentials.json`; this was treated as expired, and if the token refresh failed the user saw "Not found" forever.

What changed:

- **PKCE OAuth flow**: "Sign in with Claude" in the Claude panel opens `claude.ai/oauth/authorize` (public Claude Code OAuth client, so tokens carry the subscription's rate limits); the user pastes the displayed `code#state` back into the panel, and tokens are stored encrypted in the Jarvis config store. New channels: `claude:begin-oauth`, `claude:complete-oauth`.
- **Expiry handling**: missing/zero expiry is now treated as "usable until proven otherwise" -- the probe's HTTP 401 is the authoritative expiry signal and triggers refresh + retry.
- **UI**: the Claude step is always clickable, rechecks status when the panel opens, and the panel renders in the not-connected state with the sign-in UI.

Note: Claude Code's own credentials file is still only read, never written.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. With no/invalid Claude credentials, open the Setup tab: the Claude AI step shows "Not connected" and is clickable
2. Click it, then "Sign in with Claude": a browser tab opens on the Claude consent page; authorize and paste the shown code into the panel; the step flips to Connected and the status bar badge appears
3. With a Claude Code credentials file containing `expiresAt: 0`, verify the step shows Connected instead of "Not found"

Unit tests cover PKCE generation, the authorize URL, pasted-code parsing, and the new expiry rule (`tests/unit/claude.test.ts`).

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed