### PR TITLE
Toast notification when the Claude rate limit lifts

### DIFF
--- a/src/plugins/claude/handler.ts
+++ b/src/plugins/claude/handler.ts
@@ -1,5 +1,5 @@
 // ── Claude IPC handlers ───────────────────────────────────────────────────────
-import { ipcMain, shell } from 'electron';
+import { ipcMain, shell, Notification } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import type { BrowserWindow } from 'electron';
 import {
@@ -96,6 +96,9 @@ async function resolveAccessToken(
 }
 
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
+  // Tracks the previous probe outcome so we can notify once when the limit lifts.
+  let wasLimited = false;
+
   ipcMain.handle('claude:status', async () => {
     try {
       const resolved = await resolveAccessToken(db);
@@ -145,6 +148,19 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
         if (retried && retried.token !== resolved.token) {
           probe = await checkClaudeRateLimit(retried.token);
         }
+      }
+
+      // Notify once when the rate limit lifts (limited → usable transition).
+      // Probes that failed outright (network error, status 0) don't change the
+      // tracked state, so the notification still fires on the next good probe.
+      if (!probe.error || probe.status !== 0) {
+        if (wasLimited && !probe.limited) {
+          new Notification({
+            title: 'Jarvis',
+            body: 'Claude rate limit lifted — your Claude account is usable again.',
+          }).show();
+        }
+        wasLimited = probe.limited;
       }
 
       return {


### PR DESCRIPTION
## Summary of Changes

Follow-up to #258: previously, when the Claude rate limit lifted, the status-bar ticker simply disappeared on the next poll -- the user got no signal that their account was usable again.

The `claude:rate-limit` handler now tracks the limited state across probes in the main process and fires an Electron toast notification ("Claude rate limit lifted -- your Claude account is usable again.") exactly once on the limited-to-usable transition, same pattern as the existing GitHub sign-in notification.

Since the renderer already polls every 30s while limited, the toast appears within about 30 seconds of the reset. Probes that fail outright (network errors) don't reset the tracked state, so a transient failure doesn't swallow or duplicate the notification.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. While rate limited (ticker showing in the status bar), keep Jarvis running
2. When the limit resets, verify a Windows toast notification appears once
3. Verify no repeat notifications fire while the account stays usable

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed