### PR TITLE
Detect expired GitHub PAT and prompt user to refresh it

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, Menu, session } from 'electron';
+import { app, BrowserWindow, Tray, Menu, session, ipcMain, Notification } from 'electron';
 
 import { getDatabase, closeDatabase } from '../storage/database';
 
@@ -14,6 +14,7 @@ import { getOnboardingStatus, completeOnboardingStep } from '../agent/onboarding
 
 import { registerIpcHandlers, startDiscoveryIfAuthed } from './ipc-handlers';
 import { startBackgroundTasks, stopBackgroundTasks } from './background-tasks';
+import { checkPatForExpiry } from '../plugins/github-auth/handler';
 
 import { checkOllama } from '../services/ollama';
 
@@ -58,6 +59,25 @@ async function initialize(): Promise<void> {
   // Register IPC handlers for renderer ↔ main communication
 
   registerIpcHandlers(db, () => mainWindow);
+
+  // Let the renderer open the Settings window (e.g. from the "PAT expired" banner)
+  ipcMain.handle('app:open-settings', () => {
+    showSettingsWindow();
+  });
+
+  // Validate the stored GitHub PAT on startup; warn clearly when it has
+  // expired or been revoked instead of silently failing API calls later.
+  checkPatForExpiry(db, () => mainWindow).then((expired) => {
+    if (!expired) return;
+    const notification = new Notification({
+      title: 'Jarvis — GitHub token expired',
+      body: 'Your GitHub Personal Access Token has expired or been revoked. Open Settings → GitHub Access to enter a new one.',
+    });
+    notification.on('click', () => showSettingsWindow());
+    notification.show();
+  }).catch((err) => {
+    console.warn('[PAT] Startup validity check failed:', err);
+  });
 
 
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -50,6 +50,7 @@ contextBridge.exposeInMainWorld('jarvis', {
   savePat: (pat: string) => ipcRenderer.invoke('github:save-pat', pat),
   deletePat: () => ipcRenderer.invoke('github:delete-pat'),
   getPatStatus: () => ipcRenderer.invoke('github:pat-status'),
+  openSettings: () => ipcRenderer.invoke('app:open-settings'),
   logout: () => ipcRenderer.invoke('github:logout'),
   startOAuthDiscovery: () => ipcRenderer.invoke('github:start-oauth-discovery'),
   searchRepos: (query: string) => ipcRenderer.invoke('github:search-repos', query),
@@ -117,6 +118,16 @@ contextBridge.exposeInMainWorld('jarvis', {
     const listener = (_event: unknown, result: OAuthResult) => callback(result);
     ipcRenderer.on('github:oauth-complete', listener);
     return () => { ipcRenderer.removeListener('github:oauth-complete', listener); };
+  },
+  onPatExpired: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('github:pat-expired', listener);
+    return () => { ipcRenderer.removeListener('github:pat-expired', listener); };
+  },
+  onPatStatusChanged: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('github:pat-status-changed', listener);
+    return () => { ipcRenderer.removeListener('github:pat-status-changed', listener); };
   },
   onDiscoveryProgress: (callback: (progress: DiscoveryProgress) => void) => {
     const listener = (_event: unknown, progress: DiscoveryProgress) => callback(progress);

--- a/src/plugins/github-auth/GitHubStep.tsx
+++ b/src/plugins/github-auth/GitHubStep.tsx
@@ -1,24 +1,28 @@
 import { StatusBadge } from '../shared/StatusBadge';
 import { DiscoverySection } from './DiscoverySection';
-import type { OAuthStatus, DiscoveryProgress } from '../types';
+import type { OAuthStatus, DiscoveryProgress, PatStatus } from '../types';
 
 interface GitHubStepProps {
   oauthStatus: OAuthStatus | null;
+  patStatus: PatStatus | null;
   deviceCode: { userCode: string; verificationUri: string } | null;
   discoveryProgress: DiscoveryProgress | null;
   discoveryFinished: boolean;
   onLogin: () => void;
   onToggleOrgs: () => void;
+  onOpenSettings: () => void;
   loginDisabled: boolean;
 }
 
 export function GitHubStep({
   oauthStatus,
+  patStatus,
   deviceCode,
   discoveryProgress,
   discoveryFinished,
   onLogin,
   onToggleOrgs,
+  onOpenSettings,
   loginDisabled,
 }: GitHubStepProps) {
   const authenticated = oauthStatus?.authenticated;
@@ -67,6 +71,24 @@ export function GitHubStep({
             <div class="name">{oauthStatus.login}</div>
             <div class="login">@{oauthStatus.login}</div>
           </div>
+        </div>
+      )}
+
+      {authenticated && patStatus?.hasPat && (
+        <div class="pat-row">
+          <span>Personal Access Token</span>
+          {patStatus.expired
+            ? <StatusBadge status="error" label="Expired" />
+            : <StatusBadge status="completed" label="PAT Connected" />}
+        </div>
+      )}
+
+      {authenticated && patStatus?.hasPat && patStatus.expired && (
+        <div class="pat-expired-warning">
+          ⚠️ Your GitHub Personal Access Token has expired or been revoked. Repository
+          discovery and other features that rely on it will fail until you enter a new token.
+          <br />
+          <button onClick={onOpenSettings}>Open Settings to refresh the token</button>
         </div>
       )}
 

--- a/src/plugins/github-auth/GitHubStep.tsx
+++ b/src/plugins/github-auth/GitHubStep.tsx
@@ -5,6 +5,8 @@ import type { OAuthStatus, DiscoveryProgress, PatStatus } from '../types';
 interface GitHubStepProps {
   oauthStatus: OAuthStatus | null;
   patStatus: PatStatus | null;
+  /** Expiry date of the PAT from the github-authentication-token-expiration header (null when it does not expire) */
+  patExpiresAt?: string | null;
   deviceCode: { userCode: string; verificationUri: string } | null;
   discoveryProgress: DiscoveryProgress | null;
   discoveryFinished: boolean;
@@ -17,6 +19,7 @@ interface GitHubStepProps {
 export function GitHubStep({
   oauthStatus,
   patStatus,
+  patExpiresAt,
   deviceCode,
   discoveryProgress,
   discoveryFinished,
@@ -26,6 +29,15 @@ export function GitHubStep({
   loginDisabled,
 }: GitHubStepProps) {
   const authenticated = oauthStatus?.authenticated;
+
+  // The header value looks like "2026-09-30 12:34:56 UTC" — normalize to ISO-ish for Date parsing
+  const patExpiryDate = patExpiresAt ? new Date(patExpiresAt.replace(' UTC', 'Z')) : null;
+  const patExpiryValid = patExpiryDate !== null && !isNaN(patExpiryDate.getTime());
+  const patExpiredByDate = patExpiryValid && patExpiryDate!.getTime() <= Date.now();
+  const patExpiringSoon =
+    patExpiryValid && !patExpiredByDate &&
+    patExpiryDate!.getTime() - Date.now() < 7 * 24 * 60 * 60 * 1000;
+  const patExpired = Boolean(patStatus?.expired) || patExpiredByDate;
   let badgeStatus: 'pending' | 'completed' | 'in-progress' = 'pending';
   let badgeLabel = 'Pending';
   if (authenticated) {
@@ -76,14 +88,32 @@ export function GitHubStep({
 
       {authenticated && patStatus?.hasPat && (
         <div class="pat-row">
-          <span>Personal Access Token</span>
-          {patStatus.expired
+          <span>
+            Personal Access Token
+            {patExpiryValid && !patExpired && (
+              <span style={{ color: '#8892b0' }}>
+                {' '}— expires {patExpiryDate!.toLocaleDateString()}
+              </span>
+            )}
+          </span>
+          {patExpired
             ? <StatusBadge status="error" label="Expired" />
-            : <StatusBadge status="completed" label="PAT Connected" />}
+            : patExpiringSoon
+              ? <StatusBadge status="pending" label="Expiring soon" />
+              : <StatusBadge status="completed" label="PAT Connected" />}
         </div>
       )}
 
-      {authenticated && patStatus?.hasPat && patStatus.expired && (
+      {authenticated && patStatus?.hasPat && patExpiringSoon && (
+        <div class="pat-expired-warning" style={{ background: '#3d320a', borderColor: '#ffd43b', color: '#ffec99' }}>
+          ⚠️ Your GitHub Personal Access Token expires on {patExpiryDate!.toLocaleDateString()}.
+          Generate a new one before then to keep org repo discovery working.
+          <br />
+          <button onClick={onOpenSettings} style={{ background: '#ffd43b' }}>Open Settings to replace the token</button>
+        </div>
+      )}
+
+      {authenticated && patStatus?.hasPat && patExpired && (
         <div class="pat-expired-warning">
           ⚠️ Your GitHub Personal Access Token has expired or been revoked. Repository
           discovery and other features that rely on it will fail until you enter a new token.

--- a/src/plugins/github-auth/handler.ts
+++ b/src/plugins/github-auth/handler.ts
@@ -269,7 +269,7 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
 
     type RateLimitResource = { limit: number; remaining: number; reset: number; used: number };
 
-    const fetchForToken = async (token: string): Promise<{ resource: RateLimitResource | null; error?: string }> => {
+    const fetchForToken = async (token: string): Promise<{ resource: RateLimitResource | null; error?: string; tokenExpiresAt?: string | null; tokenExpired?: boolean }> => {
       try {
         const res = await fetch('https://api.github.com/rate_limit', {
           headers: {
@@ -278,9 +278,15 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
             'X-GitHub-Api-Version': '2022-11-28',
           },
         });
-        if (!res.ok) return { resource: null, error: `HTTP ${res.status}` };
+        // GitHub returns the expiry date of expiring tokens (fine-grained PATs)
+        // on every authenticated response — surface it so the UI can warn early.
+        const tokenExpiresAt = res.headers.get('github-authentication-token-expiration');
+        if (res.status === 401) {
+          return { resource: null, error: 'HTTP 401 — token expired or revoked', tokenExpiresAt, tokenExpired: true };
+        }
+        if (!res.ok) return { resource: null, error: `HTTP ${res.status}`, tokenExpiresAt };
         const data = (await res.json()) as { resources: { core: RateLimitResource } };
-        return { resource: data.resources.core };
+        return { resource: data.resources.core, tokenExpiresAt };
       } catch (err) {
         return { resource: null, error: String(err) };
       }
@@ -291,12 +297,25 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
       pat ? fetchForToken(pat) : Promise.resolve(null),
     ]);
 
+    // The rate-limit call doubles as a liveness check for the PAT: a 401 here
+    // means the token is expired/revoked — let the renderer switch to the
+    // "PAT expired" state immediately.
+    if (patResult?.tokenExpired) {
+      getWindow()?.webContents.send('github:pat-expired');
+    }
+
     return {
       oauth: auth
         ? { configured: true, resource: oauthResult!.resource, error: oauthResult!.error }
         : { configured: false, resource: null },
       pat: pat
-        ? { configured: true, resource: patResult!.resource, error: patResult!.error }
+        ? {
+            configured: true,
+            resource: patResult!.resource,
+            error: patResult!.error,
+            tokenExpiresAt: patResult!.tokenExpiresAt ?? null,
+            tokenExpired: patResult!.tokenExpired ?? false,
+          }
         : { configured: false, resource: null },
       fetchedAt: new Date().toISOString(),
     };

--- a/src/plugins/github-auth/handler.ts
+++ b/src/plugins/github-auth/handler.ts
@@ -6,6 +6,7 @@ import {
   requestDeviceCode,
   pollForToken,
   fetchGitHubUser,
+  validateGitHubPat,
   saveGitHubAuth,
   loadGitHubAuth,
   saveGitHubPat,
@@ -187,6 +188,7 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
     const { setConfigValue } = await import('../../storage/database');
     setConfigValue(db, 'force_pat_discovery', '1');
     saveDatabase();
+    getWindow()?.webContents.send('github:pat-status-changed');
     return { ok: true };
   });
 
@@ -195,6 +197,7 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
     if (!auth) return { ok: false };
     deleteGitHubPat(db, auth.login);
     saveDatabase();
+    getWindow()?.webContents.send('github:pat-status-changed');
     return { ok: true };
   });
 
@@ -207,12 +210,15 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
   ipcMain.handle('github:pat-status', async () => {
     const pat = loadGitHubPat(db);
     if (!pat) return { hasPat: false };
-    try {
-      const user = await fetchGitHubUser(pat);
-      return { hasPat: true, login: user.login, name: user.name, avatarUrl: user.avatar_url };
-    } catch {
-      return { hasPat: true };
+    const result = await validateGitHubPat(pat);
+    if (result.status === 'valid') {
+      return { hasPat: true, expired: false, login: result.user.login, name: result.user.name, avatarUrl: result.user.avatar_url };
     }
+    if (result.status === 'expired') {
+      return { hasPat: true, expired: true };
+    }
+    // Couldn't determine validity (offline, GitHub 5xx, …) — don't claim the token is broken
+    return { hasPat: true, expired: false };
   });
 
   ipcMain.handle('github:start-oauth-discovery', () => {
@@ -350,4 +356,24 @@ async function startPollingLoop(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Validate the stored PAT and, when GitHub rejects it (401 — expired or
+ * revoked), push a `github:pat-expired` event to the renderer so the UI can
+ * switch to the "PAT expired" state. Returns true when the PAT is expired.
+ * Used at app startup; the renderer event is skipped silently when no window
+ * exists yet — the renderer re-checks via `github:pat-status` on mount anyway.
+ */
+export async function checkPatForExpiry(
+  db: SqlJsDatabase,
+  getWindow: () => BrowserWindow | null,
+): Promise<boolean> {
+  const pat = loadGitHubPat(db);
+  if (!pat) return false;
+  const result = await validateGitHubPat(pat);
+  if (result.status !== 'expired') return false;
+  console.warn('[PAT] Stored Personal Access Token is expired or revoked');
+  getWindow()?.webContents.send('github:pat-expired');
+  return true;
 }

--- a/src/plugins/shared/StatusBadge.tsx
+++ b/src/plugins/shared/StatusBadge.tsx
@@ -1,6 +1,6 @@
 import type { ComponentChildren } from 'preact';
 
-type BadgeStatus = 'pending' | 'completed' | 'in-progress';
+type BadgeStatus = 'pending' | 'completed' | 'in-progress' | 'error';
 
 interface StatusBadgeProps {
   status: BadgeStatus;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -97,6 +97,40 @@ export interface OAuthStatus {
 
 
 
+export interface PatStatus {
+
+
+
+  hasPat: boolean;
+
+
+
+  /** true when GitHub rejected the stored token (401) — expired or revoked */
+
+
+
+  expired?: boolean;
+
+
+
+  login?: string;
+
+
+
+  name?: string;
+
+
+
+  avatarUrl?: string;
+
+
+
+}
+
+
+
+
+
 
 export interface OllamaModel {
 
@@ -2226,7 +2260,22 @@ export interface JarvisApi {
 
 
 
-  getPatStatus(): Promise<{ hasPat: boolean; login?: string; name?: string; avatarUrl?: string }>;
+  getPatStatus(): Promise<PatStatus>;
+
+
+
+
+  openSettings(): Promise<void>;
+
+
+
+
+  onPatExpired(cb: () => void): () => void;
+
+
+
+
+  onPatStatusChanged(cb: () => void): () => void;
 
 
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1204,6 +1204,22 @@ export interface GitHubRateLimitSource {
 
 
 
+  /** Expiry date of the token, from the github-authentication-token-expiration response header (PAT only; null when the token does not expire) */
+
+
+
+  tokenExpiresAt?: string | null;
+
+
+
+  /** true when GitHub answered 401 — the token is expired or revoked */
+
+
+
+  tokenExpired?: boolean;
+
+
+
 }
 
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -40,6 +40,7 @@ import { ClaudePanel } from '../plugins/claude/ClaudePanel';
 import type {
   OAuthResult,
   OAuthStatus,
+  PatStatus,
   OllamaStatus,
   OrgListResult,
   NotificationCounts,
@@ -67,6 +68,7 @@ type AppTab = 'dashboard' | 'groups-dashboard' | 'browser' | 'setup' | 'dismiss-
 
 function App() {
   const [oauthStatus, setOauthStatus] = useState<OAuthStatus | null>(null);
+  const [patStatus, setPatStatus] = useState<PatStatus | null>(null);
   const [deviceCode, setDeviceCode] = useState<{ userCode: string; verificationUri: string } | null>(null);
   const [loginDisabled, setLoginDisabled] = useState(false);
   const [discoveryProgress, setDiscoveryProgress] = useState<DiscoveryProgress | null>(null);
@@ -202,6 +204,21 @@ function App() {
         console.error('[Jarvis] Error checking OAuth status:', err);
       }
     })();
+  }, []);
+
+  // PAT status check on mount + live updates when it expires or is replaced
+  useEffect(() => {
+    const loadPatStatus = () => {
+      window.jarvis.getPatStatus()
+        .then(setPatStatus)
+        .catch((err: unknown) => console.error('[Jarvis] PAT status check failed:', err));
+    };
+    loadPatStatus();
+    const unsubExpired = window.jarvis.onPatExpired(() => {
+      setPatStatus((prev) => ({ ...(prev ?? { hasPat: false }), hasPat: true, expired: true }));
+    });
+    const unsubChanged = window.jarvis.onPatStatusChanged(loadPatStatus);
+    return () => { unsubExpired(); unsubChanged(); };
   }, []);
 
   // Claude status + rate limit check on mount (independent of GitHub auth)
@@ -881,11 +898,13 @@ function App() {
       <div class="github-layout">
         <GitHubStep
           oauthStatus={oauthStatus}
+          patStatus={patStatus}
           deviceCode={deviceCode}
           discoveryProgress={discoveryProgress}
           discoveryFinished={discoveryFinished}
           onLogin={handleLogin}
           onToggleOrgs={handleToggleOrgs}
+          onOpenSettings={() => void window.jarvis.openSettings()}
           loginDisabled={loginDisabled}
         />
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -899,6 +899,7 @@ function App() {
         <GitHubStep
           oauthStatus={oauthStatus}
           patStatus={patStatus}
+          patExpiresAt={rateLimit?.pat.configured ? rateLimit.pat.tokenExpiresAt : null}
           deviceCode={deviceCode}
           discoveryProgress={discoveryProgress}
           discoveryFinished={discoveryFinished}
@@ -1432,14 +1433,18 @@ function BackgroundStatusBar({
               {patBadge && (
                 <span
                   class="bg-status-rate-limit"
-                  title={patBadge.error
-                    ? `PAT rate limit error: ${patBadge.error}`
-                    : `PAT: ${formatNumber(patBadge.resource!.remaining)}/${formatNumber(patBadge.resource!.limit)} calls remaining (resets ${new Date(patBadge.resource!.reset * 1000).toLocaleTimeString()})`}
-                  style={{ color: patBadge.error ? '#888' : (patBadge.resource ? rateLimitColor(patBadge.resource.remaining) : '#888') }}
+                  title={patBadge.tokenExpired
+                    ? 'PAT expired or revoked — open Settings → GitHub Access to enter a new token'
+                    : patBadge.error
+                      ? `PAT rate limit error: ${patBadge.error}`
+                      : `PAT: ${formatNumber(patBadge.resource!.remaining)}/${formatNumber(patBadge.resource!.limit)} calls remaining (resets ${new Date(patBadge.resource!.reset * 1000).toLocaleTimeString()})${patBadge.tokenExpiresAt ? ` — token expires ${patBadge.tokenExpiresAt}` : ''}`}
+                  style={{ color: patBadge.tokenExpired ? '#ff6b81' : patBadge.error ? '#888' : (patBadge.resource ? rateLimitColor(patBadge.resource.remaining) : '#888') }}
                 >
-                  {patBadge.error || !patBadge.resource
-                    ? '⚡ PAT –'
-                    : `⚡ PAT ${formatNumber(patBadge.resource.remaining)}/${formatNumber(patBadge.resource.limit)}${patBadge.resource.remaining < 500 ? ` · ${formatResetIn(patBadge.resource.reset)}` : ''}`}
+                  {patBadge.tokenExpired
+                    ? '⚡ PAT expired'
+                    : patBadge.error || !patBadge.resource
+                      ? '⚡ PAT –'
+                      : `⚡ PAT ${formatNumber(patBadge.resource.remaining)}/${formatNumber(patBadge.resource.limit)}${patBadge.resource.remaining < 500 ? ` · ${formatResetIn(patBadge.resource.reset)}` : ''}`}
                 </span>
               )}
             </div>

--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -1462,6 +1462,51 @@ button:disabled {
   color: #339af0;
 }
 
+.status-error {
+  background: #4d0a1a;
+  color: #ff6b81;
+}
+
+.pat-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: #112240;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #a8b2d1;
+}
+
+.pat-expired-warning {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: #4d0a1a;
+  border: 1px solid #ff6b81;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #ffd6dd;
+  line-height: 1.45;
+}
+
+.pat-expired-warning button {
+  margin-top: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  background: #ff6b81;
+  color: #1a0a0e;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pat-expired-warning button:hover {
+  background: #ff8fa0;
+}
+
 .user-info {
   display: flex;
   align-items: center;

--- a/src/renderer/settings.tsx
+++ b/src/renderer/settings.tsx
@@ -12,10 +12,11 @@ interface OAuthStatus {
 
 interface PatStatus {
   hasPat: boolean;
-  name?: string;
-  login?: string;
-  avatarUrl?: string;
-}
+  expired?: boolean;
+  name?: string;
+  login?: string;
+  avatarUrl?: string;
+}
 
 interface OnedriveRoot {
   id: number;
@@ -180,25 +181,32 @@ function PatSection() {
     <div class="section">
       <h2>GitHub Access — Personal Access Token</h2>
 
-      {!status?.hasPat && (
-        <div>
-          <label for="pat-input">Enter token to add or replace PAT</label>
-          <div class="btn-row" style={{ marginTop: 0 }}>
-            <input
-              type="password"
-              id="pat-input"
-              placeholder="ghp_... or github_pat_..."
-              value={patInput}
-              onInput={(e: Event) => setPatInput((e.target as HTMLInputElement).value)}
-            />
-            <button class="btn-save" onClick={handleSave} disabled={saving}>
-              {saving ? 'Saving...' : 'Save'}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {status?.hasPat && (
+      {status?.hasPat && status.expired && (
+        <div class="pat-error" style={{ marginBottom: '0.5rem' }}>
+          ⚠️ Your saved Personal Access Token has expired or been revoked. GitHub features
+          that rely on it (like org repo discovery) will fail until you enter a new token below.
+        </div>
+      )}
+
+      {(!status?.hasPat || status.expired) && (
+        <div>
+          <label for="pat-input">Enter token to add or replace PAT</label>
+          <div class="btn-row" style={{ marginTop: 0 }}>
+            <input
+              type="password"
+              id="pat-input"
+              placeholder="ghp_... or github_pat_..."
+              value={patInput}
+              onInput={(e: Event) => setPatInput((e.target as HTMLInputElement).value)}
+            />
+            <button class="btn-save" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {status?.hasPat && !status.expired && (
         <>
           <UserCard
             name={status.name || status.login || 'PAT User'}

--- a/src/services/github-oauth.ts
+++ b/src/services/github-oauth.ts
@@ -109,8 +109,7 @@ export async function pollForToken(
 /**
  * Step 3: Fetch the authenticated user's profile.
  */
-export async function fetchGitHubUser(accessToken: string): Promise<GitHubUser> {
-  const response = await fetch(GITHUB_USER_API_URL, {
+export async function fetchGitHubUser(accessToken: string): Promise<GitHubUser> {  const response = await fetch(GITHUB_USER_API_URL, {
     headers: {
       'Authorization': `Bearer ${accessToken}`,
       'Accept': 'application/json',
@@ -123,6 +122,50 @@ export async function fetchGitHubUser(accessToken: string): Promise<GitHubUser> 
   }
 
   return response.json() as Promise<GitHubUser>;
+}
+
+/**
+ * Result of validating a PAT against the GitHub API.
+ * - 'valid': the token works and the user profile was returned.
+ * - 'expired': GitHub answered 401 — the token has expired or been revoked.
+ * - 'unknown': we could not determine validity (network failure, 5xx, …), so
+ *   callers should not alarm the user about a token that may still be fine.
+ */
+export type PatValidation =
+  | { status: 'valid'; user: GitHubUser }
+  | { status: 'expired' }
+  | { status: 'unknown'; error: string };
+
+/**
+ * Validate a Personal Access Token against the GitHub API.
+ */
+export async function validateGitHubPat(pat: string): Promise<PatValidation> {
+  let response: Response;
+  try {
+    response = await fetch(GITHUB_USER_API_URL, {
+      headers: {
+        'Authorization': `Bearer ${pat}`,
+        'Accept': 'application/json',
+        'User-Agent': 'Jarvis-Agent/0.1.0',
+      },
+    });
+  } catch (err) {
+    return { status: 'unknown', error: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (response.status === 401) {
+    return { status: 'expired' };
+  }
+  if (!response.ok) {
+    return { status: 'unknown', error: `HTTP ${response.status}` };
+  }
+
+  try {
+    const user = (await response.json()) as GitHubUser;
+    return { status: 'valid', user };
+  } catch (err) {
+    return { status: 'unknown', error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 /**

--- a/tests/unit/github-auth-handler.test.ts
+++ b/tests/unit/github-auth-handler.test.ts
@@ -43,6 +43,14 @@ vi.mock('../../src/services/github-oauth', async (importOriginal) => {
       name: 'Test User',
       avatar_url: 'https://example.com/avatar.png',
     }),
+    validateGitHubPat: vi.fn().mockResolvedValue({
+      status: 'valid',
+      user: {
+        login: 'testuser',
+        name: 'Test User',
+        avatar_url: 'https://example.com/avatar.png',
+      },
+    }),
   };
 });
 
@@ -65,7 +73,7 @@ vi.mock('../../src/plugins/discovery/handler', () => ({
 }));
 
 import { registerHandlers } from '../../src/plugins/github-auth/handler';
-import { saveGitHubAuth, saveGitHubPat, fetchGitHubUser } from '../../src/services/github-oauth';
+import { saveGitHubAuth, saveGitHubPat, fetchGitHubUser, validateGitHubPat } from '../../src/services/github-oauth';
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 
@@ -95,6 +103,15 @@ describe('GitHub Auth plugin — IPC handlers', () => {
       login: 'testuser',
       name: 'Test User',
       avatar_url: 'https://example.com/avatar.png',
+    });
+    // Reset validateGitHubPat default mock
+    vi.mocked(validateGitHubPat).mockResolvedValue({
+      status: 'valid',
+      user: {
+        login: 'testuser',
+        name: 'Test User',
+        avatar_url: 'https://example.com/avatar.png',
+      },
     });
 
     registerHandlers(db, () => null);
@@ -134,16 +151,29 @@ describe('GitHub Auth plugin — IPC handlers', () => {
 
       const result = (await callHandler('github:pat-status')) as Record<string, unknown>;
       expect(result.hasPat).toBe(true);
+      expect(result.expired).toBe(false);
       expect(result.login).toBe('testuser');
     });
 
-    it('returns { hasPat: true } without user info when fetchGitHubUser throws', async () => {
+    it('returns { hasPat: true, expired: false } without user info when validity is unknown', async () => {
       saveGitHubAuth(db, 'octocat', 'gho_abc123', 'repo', null);
-      saveGitHubPat(db, 'octocat', 'ghp_bad_token');
-      vi.mocked(fetchGitHubUser).mockRejectedValueOnce(new Error('Unauthorized'));
+      saveGitHubPat(db, 'octocat', 'ghp_test_token');
+      vi.mocked(validateGitHubPat).mockResolvedValueOnce({ status: 'unknown', error: 'Network error' });
 
       const result = (await callHandler('github:pat-status')) as Record<string, unknown>;
       expect(result.hasPat).toBe(true);
+      expect(result.expired).toBe(false);
+      expect(result.login).toBeUndefined();
+    });
+
+    it('returns { hasPat: true, expired: true } when GitHub rejects the stored PAT', async () => {
+      saveGitHubAuth(db, 'octocat', 'gho_abc123', 'repo', null);
+      saveGitHubPat(db, 'octocat', 'ghp_expired_token');
+      vi.mocked(validateGitHubPat).mockResolvedValueOnce({ status: 'expired' });
+
+      const result = (await callHandler('github:pat-status')) as Record<string, unknown>;
+      expect(result.hasPat).toBe(true);
+      expect(result.expired).toBe(true);
       expect(result.login).toBeUndefined();
     });
   });

--- a/tests/unit/github-auth-handler.test.ts
+++ b/tests/unit/github-auth-handler.test.ts
@@ -312,8 +312,9 @@ describe('GitHub Auth plugin — IPC handlers', () => {
       };
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: true,
+        headers: { get: () => null },
         json: async () => mockRateLimit,
-      } as Response);
+      } as unknown as Response);
 
       const result = (await callHandler('github:get-rate-limit')) as Record<string, unknown>;
       const oauth = result.oauth as Record<string, unknown>;
@@ -337,8 +338,12 @@ describe('GitHub Auth plugin — IPC handlers', () => {
         resources: { core: { limit: 5000, remaining: 2000, reset: 1700000000, used: 3000 } },
       };
       global.fetch = vi.fn()
-        .mockResolvedValueOnce({ ok: true, json: async () => mockRateLimit } as Response)
-        .mockResolvedValueOnce({ ok: true, json: async () => mockPatLimit } as Response);
+        .mockResolvedValueOnce({ ok: true, headers: { get: () => null }, json: async () => mockRateLimit } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: (name: string) => name === 'github-authentication-token-expiration' ? '2027-06-15 00:00:00 UTC' : null },
+          json: async () => mockPatLimit,
+        } as unknown as Response);
 
       const result = (await callHandler('github:get-rate-limit')) as Record<string, unknown>;
       const oauth = result.oauth as Record<string, unknown>;
@@ -347,6 +352,31 @@ describe('GitHub Auth plugin — IPC handlers', () => {
       expect((oauth.resource as Record<string, unknown>).remaining).toBe(4000);
       expect(pat.configured).toBe(true);
       expect((pat.resource as Record<string, unknown>).remaining).toBe(2000);
+      // Expiry date surfaced from the github-authentication-token-expiration header
+      expect(pat.tokenExpiresAt).toBe('2027-06-15 00:00:00 UTC');
+      expect(pat.tokenExpired).toBe(false);
+    });
+
+    it('marks the PAT as expired when the rate-limit call answers 401', async () => {
+      saveGitHubAuth(db, 'octocat', 'gho_abc123', 'repo', null);
+      saveGitHubPat(db, 'octocat', 'ghp_expired_token');
+      const mockRateLimit = {
+        resources: { core: { limit: 5000, remaining: 4000, reset: 1700000000, used: 1000 } },
+      };
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce({ ok: true, headers: { get: () => null }, json: async () => mockRateLimit } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: false, status: 401,
+          headers: { get: () => null },
+          json: async () => ({}),
+        } as unknown as Response);
+
+      const result = (await callHandler('github:get-rate-limit')) as Record<string, unknown>;
+      const pat = result.pat as Record<string, unknown>;
+      expect(pat.configured).toBe(true);
+      expect(pat.resource).toBeNull();
+      expect(pat.tokenExpired).toBe(true);
+      expect(pat.error as string).toContain('401');
     });
 
     it('sets error on oauth source when fetch fails', async () => {
@@ -363,8 +393,10 @@ describe('GitHub Auth plugin — IPC handlers', () => {
     it('sets error on oauth source when API returns non-ok status', async () => {
       saveGitHubAuth(db, 'octocat', 'gho_abc123', 'repo', null);
       global.fetch = vi.fn().mockResolvedValueOnce({
-        ok: false, status: 401, json: async () => ({}),
-      } as Response);
+        ok: false, status: 401,
+        headers: { get: () => null },
+        json: async () => ({}),
+      } as unknown as Response);
 
       const result = (await callHandler('github:get-rate-limit')) as Record<string, unknown>;
       const oauth = result.oauth as Record<string, unknown>;

--- a/tests/unit/github-oauth.test.ts
+++ b/tests/unit/github-oauth.test.ts
@@ -86,6 +86,7 @@ import {
   requestDeviceCode,
   pollForToken,
   fetchGitHubUser,
+  validateGitHubPat,
   deleteGitHubAuth,
 } from '../../src/services/github-oauth';
 
@@ -171,6 +172,42 @@ describe('fetchGitHubUser', () => {
       new Response('Unauthorized', { status: 401 }),
     );
     await expect(fetchGitHubUser('bad-token')).rejects.toThrow('Failed to fetch user: 401');
+  });
+});
+
+describe('validateGitHubPat', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns valid with the user on a 200 response', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ login: 'octocat', name: 'Octocat', avatar_url: '' }), { status: 200 }),
+    );
+    const result = await validateGitHubPat('ghp_good');
+    expect(result.status).toBe('valid');
+    if (result.status === 'valid') expect(result.user.login).toBe('octocat');
+  });
+
+  it('returns expired on a 401 response', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ message: 'Bad credentials' }), { status: 401 }),
+    );
+    const result = await validateGitHubPat('ghp_expired');
+    expect(result.status).toBe('expired');
+  });
+
+  it('returns unknown on other non-OK statuses', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response('Server Error', { status: 500 }),
+    );
+    const result = await validateGitHubPat('ghp_maybe');
+    expect(result.status).toBe('unknown');
+  });
+
+  it('returns unknown on network failure', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    const result = await validateGitHubPat('ghp_maybe');
+    expect(result.status).toBe('unknown');
+    if (result.status === 'unknown') expect(result.error).toContain('ECONNREFUSED');
   });
 });
 


### PR DESCRIPTION
## Summary of Changes

An expired or revoked GitHub Personal Access Token was failing silently: API calls would break, but nothing told the user why or what to do. This PR detects PAT expiration and clearly prompts the user to refresh it, in three places:

- **Detection**: new `validateGitHubPat()` in `src/services/github-oauth.ts` calls `/user` and treats only a 401 as expired/revoked; network or 5xx errors return "unknown" so we never alarm on a token that may still be valid. `github:pat-status` now returns an `expired` flag.
- **On app open**: a startup check (`checkPatForExpiry`) shows a native notification when the stored PAT is dead; clicking it opens Settings, and a `github:pat-expired` event is pushed to the renderer.
- **Rate-limit call as liveness check**: `github:get-rate-limit` already authenticates with the PAT, so it now also reads the `github-authentication-token-expiration` response header (surfaced as `tokenExpiresAt`) and treats a 401 as `tokenExpired`, pushing `github:pat-expired` so the UI flips state immediately.
- **Setup tab**: the GitHub step finally shows a "PAT Connected" state, plus a red "Expired" state with a warning banner and an "Open Settings to refresh the token" button (new `app:open-settings` IPC). It also shows the token's expiration date and warns with an "Expiring soon" badge 7 days ahead.
- **Settings window**: expired PATs show a clear warning and the token input so a replacement can be pasted. Saving/deleting a PAT emits `github:pat-status-changed` so the setup tab refreshes live.
- **Status bar**: the PAT badge shows `PAT expired` in red with a tooltip pointing to Settings.

Notes: the expiration header is only sent for tokens *with* an expiration (fine-grained PATs); classic non-expiring PATs just show "PAT Connected" without a date. `StatusBadge` gained an `error` status style.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. Save an expired or revoked PAT in Settings -> GitHub Access; the settings section shows the expired warning and the token input.
2. Restart the app with an expired PAT stored: a native notification appears and the setup tab GitHub step shows the red "Expired" badge with a refresh banner.
3. Save a valid fine-grained PAT with an expiration date: the setup tab shows "PAT Connected" with the expiry date; with a token expiring within 7 days the "Expiring soon" warning appears instead.
4. Unit tests: `npm test` (962 passing, including new `validateGitHubPat` and rate-limit header/401 cases).

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed