### PR TITLE
fix: restore Jarvis window when saved bounds are off-screen

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -3,12 +3,18 @@ import path from 'path';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import { saveDatabase } from '../storage/database';
 
-interface WindowBounds {
+export interface WindowBounds {
   x: number;
   y: number;
   width: number;
   height: number;
 }
+
+interface DisplayBounds {
+  workArea: WindowBounds;
+}
+
+const DEFAULT_WINDOW_SIZE = { width: 600, height: 500 };
 
 function loadWindowBounds(db: SqlJsDatabase): WindowBounds | null {
   try {
@@ -33,28 +39,71 @@ function saveWindowBounds(db: SqlJsDatabase, bounds: WindowBounds): void {
   saveDatabase();
 }
 
-function boundsAreVisible(bounds: WindowBounds): boolean {
-  const displays = screen.getAllDisplays();
-  return displays.some((display) => {
-    const { x, y, width, height } = display.workArea;
-    // Check that at least part of the window is within this display
-    return (
-      bounds.x < x + width &&
-      bounds.x + bounds.width > x &&
-      bounds.y < y + height &&
-      bounds.y + bounds.height > y
-    );
-  });
+function overlapArea(bounds: WindowBounds, display: DisplayBounds): number {
+  const area = display.workArea;
+  const width = Math.max(0, Math.min(bounds.x + bounds.width, area.x + area.width) - Math.max(bounds.x, area.x));
+  const height = Math.max(0, Math.min(bounds.y + bounds.height, area.y + area.height) - Math.max(bounds.y, area.y));
+  return width * height;
+}
+
+function centerWindowBounds(
+  size: Pick<WindowBounds, 'width' | 'height'>,
+  display: DisplayBounds,
+): WindowBounds {
+  const workArea = display.workArea;
+  const width = Math.min(size.width, workArea.width);
+  const height = Math.min(size.height, workArea.height);
+  return {
+    width,
+    height,
+    x: workArea.x + Math.floor((workArea.width - width) / 2),
+    y: workArea.y + Math.floor((workArea.height - height) / 2),
+  };
+}
+
+export function ensureWindowBoundsVisible(
+  bounds: WindowBounds,
+  displays: DisplayBounds[],
+  primaryDisplay: DisplayBounds,
+): WindowBounds {
+  const targetDisplay = displays.reduce<{ display: DisplayBounds; overlap: number } | null>((best, display) => {
+    const overlap = overlapArea(bounds, display);
+    return !best || overlap > best.overlap ? { display, overlap } : best;
+  }, null);
+
+  if (!targetDisplay || targetDisplay.overlap === 0) {
+    return centerWindowBounds(bounds, primaryDisplay);
+  }
+
+  const area = targetDisplay.display.workArea;
+  const width = Math.min(bounds.width, area.width);
+  const height = Math.min(bounds.height, area.height);
+  const adjusted = {
+    width,
+    height,
+    x: Math.min(Math.max(bounds.x, area.x), area.x + area.width - width),
+    y: Math.min(Math.max(bounds.y, area.y), area.y + area.height - height),
+  };
+
+  return adjusted.x === bounds.x && adjusted.y === bounds.y &&
+    adjusted.width === bounds.width && adjusted.height === bounds.height
+    ? bounds
+    : adjusted;
 }
 
 export function createOnboardingWindow(db: SqlJsDatabase): BrowserWindow {
   const saved = loadWindowBounds(db);
-  const useSaved = saved && boundsAreVisible(saved);
+  const primaryDisplay = screen.getPrimaryDisplay();
+  const bounds = saved
+    ? ensureWindowBoundsVisible(saved, screen.getAllDisplays(), primaryDisplay)
+    : centerWindowBounds(DEFAULT_WINDOW_SIZE, primaryDisplay);
+
+  if (saved && bounds !== saved) {
+    saveWindowBounds(db, bounds);
+  }
 
   const win = new BrowserWindow({
-    width: useSaved ? saved.width : 600,
-    height: useSaved ? saved.height : 500,
-    ...(useSaved ? { x: saved.x, y: saved.y } : {}),
+    ...bounds,
     title: 'Jarvis — Setup',
     resizable: true,
     show: false,
@@ -67,6 +116,26 @@ export function createOnboardingWindow(db: SqlJsDatabase): BrowserWindow {
   });
 
   win.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'));
+
+  const ensureCurrentBoundsVisible = () => {
+    if (win.isDestroyed()) return;
+    const currentBounds = win.getBounds();
+    const visibleBounds = ensureWindowBoundsVisible(
+      currentBounds,
+      screen.getAllDisplays(),
+      screen.getPrimaryDisplay(),
+    );
+    if (visibleBounds !== currentBounds) {
+      win.setBounds(visibleBounds);
+      saveWindowBounds(db, visibleBounds);
+    }
+  };
+
+  // Re-check the actual native window position after creation and whenever the
+  // monitor layout changes while Jarvis is running.
+  win.once('ready-to-show', ensureCurrentBoundsVisible);
+  screen.on('display-removed', ensureCurrentBoundsVisible);
+  screen.on('display-metrics-changed', ensureCurrentBoundsVisible);
 
   // Prevent the window from navigating to external URLs
   win.webContents.on('will-navigate', (event, url) => {
@@ -83,6 +152,10 @@ export function createOnboardingWindow(db: SqlJsDatabase): BrowserWindow {
   };
   win.on('resized', persistBounds);
   win.on('moved', persistBounds);
+  win.on('closed', () => {
+    screen.removeListener('display-removed', ensureCurrentBoundsVisible);
+    screen.removeListener('display-metrics-changed', ensureCurrentBoundsVisible);
+  });
 
   return win;
 }

--- a/tests/unit/windows.test.ts
+++ b/tests/unit/windows.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  screen: {
+    getAllDisplays: vi.fn(),
+    getPrimaryDisplay: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/storage/database', () => ({
+  saveDatabase: vi.fn(),
+}));
+
+import { ensureWindowBoundsVisible, type WindowBounds } from '../../src/main/windows';
+
+const primaryDisplay = {
+  workArea: { x: 0, y: 0, width: 1920, height: 1040 },
+};
+
+describe('ensureWindowBoundsVisible', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps bounds that overlap a connected display', () => {
+    const bounds: WindowBounds = { x: 100, y: 100, width: 600, height: 500 };
+
+    expect(ensureWindowBoundsVisible(bounds, [primaryDisplay], primaryDisplay)).toBe(bounds);
+  });
+
+  it('moves partially visible bounds fully into the connected display', () => {
+    const bounds: WindowBounds = { x: -500, y: -200, width: 600, height: 500 };
+
+    expect(ensureWindowBoundsVisible(bounds, [primaryDisplay], primaryDisplay)).toEqual({
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 500,
+    });
+  });
+
+  it('centers off-screen bounds on the primary display', () => {
+    const bounds: WindowBounds = { x: 2200, y: 100, width: 600, height: 500 };
+
+    expect(ensureWindowBoundsVisible(bounds, [primaryDisplay], primaryDisplay)).toEqual({
+      x: 660,
+      y: 270,
+      width: 600,
+      height: 500,
+    });
+  });
+
+  it('fits an oversized off-screen window within the primary work area', () => {
+    const bounds: WindowBounds = { x: -3000, y: 0, width: 2400, height: 1200 };
+
+    expect(ensureWindowBoundsVisible(bounds, [primaryDisplay], primaryDisplay)).toEqual({
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1040,
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The Jarvis window position is persisted in `config.window_bounds`. When a monitor is disconnected, those saved coordinates can point at a display that no longer exists, so the window is created off-screen and is effectively invisible.

## Fix

`ensureWindowBoundsVisible()` in `src/main/windows.ts` now:

- Picks the display with the largest overlap with the saved bounds and clamps the window **fully** inside that display's work area (previously any tiny overlap was accepted as-is).
- Centers the window on the primary display when no display overlaps at all.
- Shrinks oversized windows to fit the available work area.

`createOnboardingWindow()` additionally:

- Re-checks the actual native bounds on `ready-to-show` and repositions if needed.
- Listens for `display-removed` and `display-metrics-changed` so an already-open window is recovered when the monitor layout changes at runtime, and unsubscribes on `closed`.
- Persists any corrected bounds so the fix survives the next restart.
- Centers newly created windows instead of relying on the OS default.

## Testing

- `npm run build` — passes
- `npm test` — 966 tests passed (48 files), including new `tests/unit/windows.test.ts` covering the visible, partially-visible, fully off-screen and oversized cases.
- Verified manually: with the dual monitor disconnected, Jarvis reappeared on the laptop display.
