### PR TITLE
fix: restrict OneDrive file reads to configured roots

### DIFF
--- a/src/plugins/onedrive/handler.ts
+++ b/src/plugins/onedrive/handler.ts
@@ -20,6 +20,14 @@ import {
 import { readUrlShortcut } from '../../services/url-shortcut';
 import { getGroup } from '../../services/groups';
 
+function isPathWithinConfiguredRoot(db: SqlJsDatabase, filePath: string): boolean {
+  const resolvedFile = path.resolve(filePath);
+  return listOnedriveRoots(db).some((root) => {
+    const relative = path.relative(path.resolve(root.path), resolvedFile);
+    return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+  });
+}
+
 export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
   // Resolve PS1 script path relative to the compiled main JS, or resourcesPath when packaged.
   const scriptPath = app.isPackaged
@@ -139,6 +147,9 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
     if (!filePath.toLowerCase().endsWith('.one')) {
       return { ok: false, error: 'Only .one files are supported' };
     }
+    if (!isPathWithinConfiguredRoot(db, filePath)) {
+      return { ok: false, error: 'File must be inside a configured OneDrive root' };
+    }
     try {
       const section = readOneNoteSection(filePath);
       return { ok: true, section };
@@ -154,6 +165,9 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
     }
     if (!filePath.toLowerCase().endsWith('.url')) {
       return { ok: false, error: 'Only .url files are supported' };
+    }
+    if (!isPathWithinConfiguredRoot(db, filePath)) {
+      return { ok: false, error: 'File must be inside a configured OneDrive root' };
     }
     try {
       const info = readUrlShortcut(filePath);

--- a/tests/unit/onedrive-handler.test.ts
+++ b/tests/unit/onedrive-handler.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../src/storage/database', async (importOriginal) => {
 });
 
 vi.mock('../../src/services/onedrive', () => ({
-  listOnedriveRoots: vi.fn().mockReturnValue([]),
+  listOnedriveRoots: vi.fn().mockReturnValue([{ id: 1, path: '/path', label: 'Test root', addedAt: '' }]),
   addOnedriveRoot: vi.fn().mockImplementation((_db: unknown, path: string, label: string) => ({
     id: 1,
     path,
@@ -118,10 +118,10 @@ describe('OneDrive plugin — IPC handlers', () => {
   // ── onedrive:list-roots ───────────────────────────────────────────────────
 
   describe('onedrive:list-roots', () => {
-    it('returns empty array on a fresh DB', () => {
+    it('returns configured roots', () => {
       const result = callHandler('onedrive:list-roots');
       expect(listOnedriveRoots).toHaveBeenCalledWith(db);
-      expect(result).toEqual([]);
+      expect(result).toEqual([{ id: 1, path: '/path', label: 'Test root', addedAt: '' }]);
     });
   });
 
@@ -284,6 +284,11 @@ describe('OneDrive plugin — IPC handlers', () => {
       const result = callHandler('onedrive:read-onenote-file', '/path/to/notes.one') as Record<string, unknown>;
       expect(result.ok).toBe(true);
     });
+
+    it('rejects paths outside configured OneDrive roots', () => {
+      const result = callHandler('onedrive:read-onenote-file', '/path/../secret.one') as Record<string, unknown>;
+      expect(result).toEqual({ ok: false, error: 'File must be inside a configured OneDrive root' });
+    });
   });
 
   // ── onedrive:read-url-shortcut ────────────────────────────────────────────
@@ -304,6 +309,11 @@ describe('OneDrive plugin — IPC handlers', () => {
     it('returns ok:true for a valid .url file path', () => {
       const result = callHandler('onedrive:read-url-shortcut', '/path/link.url') as Record<string, unknown>;
       expect(result.ok).toBe(true);
+    });
+
+    it('rejects paths outside configured OneDrive roots', () => {
+      const result = callHandler('onedrive:read-url-shortcut', '/path/../secret.url') as Record<string, unknown>;
+      expect(result).toEqual({ ok: false, error: 'File must be inside a configured OneDrive root' });
     });
   });
 


### PR DESCRIPTION
## Summary\n- reject renderer-supplied .one and .url paths outside configured OneDrive roots\n- add regression coverage for path traversal/out-of-root reads\n\n## Validation\n- 
pm run build\n- 
pm test (968 tests)