### PR TITLE
test: cover background task IPC push channels

### DIFF
--- a/tests/unit/ipc-push-completeness.test.ts
+++ b/tests/unit/ipc-push-completeness.test.ts
@@ -20,6 +20,7 @@ const root = resolve(__dirname, '../../src');
  */
 const SOURCE_FILES = [
   'main/index.ts',
+  'main/background-tasks.ts',
   'plugins/notifications/handler.ts',
   'plugins/discovery/handler.ts',
   'plugins/secrets/handler.ts',


### PR DESCRIPTION
## Summary\n- include src/main/background-tasks.ts in the IPC push-channel completeness test\n- ensure 	asks:run-complete remains checked against preload listeners\n\n## Validation\n- 
pm run build\n- 
pm test (968 tests)