### PR TITLE
fix: validate resolved path is an existing directory in local:open-terminal

### DIFF
--- a/src/plugins/local-repos/handler.ts
+++ b/src/plugins/local-repos/handler.ts
@@ -40,7 +40,7 @@ function openTerminal(folderPath: string): void {
   // Normalize the path and confirm it resolves to an existing directory
   // before handing it to a spawned shell process.
   const resolvedPath = path.resolve(folderPath);
-  let isDirectory = false;
+  let isDirectory: boolean;
   try {
     isDirectory = fs.statSync(resolvedPath).isDirectory();
   } catch (err) {

--- a/src/plugins/local-repos/handler.ts
+++ b/src/plugins/local-repos/handler.ts
@@ -1,5 +1,7 @@
 // ── Local repos IPC handlers ──────────────────────────────────────────────────
 import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { ipcMain, shell, dialog, BrowserWindow } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import { saveDatabase } from '../../storage/database';
@@ -35,11 +37,26 @@ function launchDetached(command: string, args: string[], folderPath: string, onE
 }
 
 function openTerminal(folderPath: string): void {
+  // Normalize the path and confirm it resolves to an existing directory
+  // before handing it to a spawned shell process.
+  const resolvedPath = path.resolve(folderPath);
+  let isDirectory = false;
+  try {
+    isDirectory = fs.statSync(resolvedPath).isDirectory();
+  } catch (err) {
+    console.error('[IPC] local:open-terminal failed: invalid folder path', resolvedPath, err);
+    return;
+  }
+  if (!isDirectory) {
+    console.error('[IPC] local:open-terminal failed: not a directory', resolvedPath);
+    return;
+  }
+
   // Prefer Windows Terminal when available, but keep working on machines that
   // only have the classic command prompt.
-  launchDetached('wt.exe', ['-d', folderPath], folderPath, () => {
+  launchDetached('wt.exe', ['-d', resolvedPath], resolvedPath, () => {
     const commandShell = process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe';
-    launchDetached(commandShell, ['/k'], folderPath, (err) => {
+    launchDetached(commandShell, ['/k'], resolvedPath, (err) => {
       console.error('[IPC] local:open-terminal failed:', err);
     });
   });

--- a/tests/unit/handler-validation.test.ts
+++ b/tests/unit/handler-validation.test.ts
@@ -31,6 +31,8 @@ const spawnMock = vi.hoisted(() => vi.fn(() => ({
   unref: vi.fn(),
 })));
 
+const statSyncMock = vi.hoisted(() => vi.fn(() => ({ isDirectory: () => true })));
+
 // ── Track registered handlers so we can invoke them directly ──────────────────
 const handlers = new Map<string, (...args: unknown[]) => unknown>();
 
@@ -56,6 +58,10 @@ vi.mock('node:child_process', () => ({
   spawn: spawnMock,
 }));
 
+vi.mock('node:fs', () => ({
+  statSync: statSyncMock,
+}));
+
 vi.mock('../../src/storage/database', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/storage/database')>();
   return { ...actual, saveDatabase: vi.fn() };
@@ -76,6 +82,7 @@ vi.mock('../../src/agent/config', () => ({
 
 import { registerIpcHandlers } from '../../src/main/ipc-handlers';
 import { shell } from 'electron';
+import * as path from 'node:path';
 
 // Helper to call a handler with a fake IPC event
 function callHandler(channel: string, ...args: unknown[]): unknown {
@@ -133,17 +140,32 @@ describe('IPC handler input validation', () => {
     });
 
     it('launches a terminal for a valid path', () => {
+      const resolvedPath = path.resolve('C:/Users/example/projects');
       callHandler('local:open-terminal', 'C:/Users/example/projects');
       expect(spawnMock).toHaveBeenCalledWith(
         'wt.exe',
-        ['-d', 'C:/Users/example/projects'],
+        ['-d', resolvedPath],
         expect.objectContaining({
-          cwd: 'C:/Users/example/projects',
+          cwd: resolvedPath,
           detached: true,
           stdio: 'ignore',
           windowsHide: false,
         }),
       );
+    });
+
+    it('does nothing when the resolved path is not a directory', () => {
+      statSyncMock.mockReturnValueOnce({ isDirectory: () => false } as ReturnType<typeof statSyncMock>);
+      callHandler('local:open-terminal', 'C:/Users/example/not-a-folder.txt');
+      expect(spawnMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the resolved path does not exist', () => {
+      statSyncMock.mockImplementationOnce(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+      callHandler('local:open-terminal', '../../../etc/passwd');
+      expect(spawnMock).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
Closes the last remaining task from #263 (Repository Quality: IPC Channel Hygiene & Input Boundary Defense). PR #266 already fixed Task 2 (OneDrive path traversal) and PR #267 fixed Task 1 (push-completeness test). This PR addresses Task 3:

- `local:open-terminal` previously only checked `folderPath` was a non-empty string before spawning `wt.exe -d <path>` / `cmd.exe` with it as `cwd`.
- Now the path is normalized with `path.resolve()` and verified to be an existing directory via `fs.statSync()` before being passed to the spawn helper. Invalid/non-existent paths are logged and rejected without spawning a shell.

## Validation
- `npm run build`
- `npm test` (970 tests passing, 2 new regression tests added)

Fixes #263