### PR TITLE
fix: standardize discovery IPC errors

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -165,6 +165,10 @@ Electron uses a multi-process architecture that maps well to Jarvis:
 | **Renderer process** | Settings UI, onboarding wizard, chat/prompt window |
 | **MCP server processes** | Spawned as child processes, managed by the main process |
 
+### IPC Handler Error Contract
+
+All new `ipcMain.handle` registrations should use `safeHandle` from `src/plugins/ipc-utils.ts`. It preserves successful return values and converts synchronous exceptions or rejected promises into a resolved `{ error: string }` payload, giving renderer callers one predictable failure shape. Handlers may still perform input validation and return domain-specific error objects when appropriate.
+
 ### System Tray Behavior
 
 - On install / first launch, Jarvis starts and places an icon in the Windows system tray.

--- a/src/plugins/discovery/handler.ts
+++ b/src/plugins/discovery/handler.ts
@@ -1,5 +1,4 @@
 // ── Discovery IPC handlers + startDiscoveryIfAuthed ──────────────────────────
-import { ipcMain } from 'electron';
 import type { Database as SqlJsDatabase } from 'sql.js';
 import type { BrowserWindow } from 'electron';
 import {
@@ -20,9 +19,10 @@ import {
   setActiveDiscovery,
   setLastDiscoveryProgress,
 } from './state';
+import { safeHandle } from '../ipc-utils';
 
 export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWindow | null): void {
-  ipcMain.handle('github:discovery-status', () => {
+  safeHandle('github:discovery-status', () => {
     if (lastDiscoveryProgress) {
       return {
         running: activeDiscovery !== null && !activeDiscovery.aborted,
@@ -42,12 +42,12 @@ export function registerHandlers(db: SqlJsDatabase, getWindow: () => BrowserWind
     };
   });
 
-  ipcMain.handle('github:start-discovery', () => {
+  safeHandle('github:start-discovery', () => {
     startDiscoveryIfAuthed(db, getWindow, true);
     return { started: true };
   });
 
-  ipcMain.handle('github:start-pat-discovery', () => {
+  safeHandle('github:start-pat-discovery', () => {
     const pat = loadGitHubPat(db);
     if (!pat) return { error: 'No PAT configured' };
 

--- a/src/plugins/ipc-utils.ts
+++ b/src/plugins/ipc-utils.ts
@@ -1,0 +1,28 @@
+import { ipcMain } from 'electron';
+
+export type IpcErrorResponse = { error: string };
+
+type IpcHandler = (event: Electron.IpcMainInvokeEvent, ...args: any[]) => unknown;
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Register an IPC handler that resolves failures as a predictable error payload. */
+export function safeHandle(channel: string, handler: IpcHandler): void {
+  ipcMain.handle(channel, (event, ...args) => {
+    try {
+      const result = handler(event, ...args);
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        return (result as Promise<unknown>).catch((error: unknown) => {
+          console.error(`[IPC] ${channel} failed:`, error);
+          return { error: errorMessage(error) } satisfies IpcErrorResponse;
+        });
+      }
+      return result;
+    } catch (error) {
+      console.error(`[IPC] ${channel} failed:`, error);
+      return { error: errorMessage(error) } satisfies IpcErrorResponse;
+    }
+  });
+}

--- a/tests/unit/discovery-handler.test.ts
+++ b/tests/unit/discovery-handler.test.ts
@@ -132,6 +132,14 @@ describe('Discovery plugin — IPC handlers', () => {
         rateLimit: null,
       });
     });
+
+    it('returns a structured error when the database read fails', () => {
+      vi.mocked(listOrgs).mockImplementationOnce(() => {
+        throw new Error('database unavailable');
+      });
+      const result = callHandler('github:discovery-status');
+      expect(result).toEqual({ error: 'database unavailable' });
+    });
   });
 
   // ── github:start-discovery ────────────────────────────────────────────────

--- a/tests/unit/ipc-utils.test.ts
+++ b/tests/unit/ipc-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+  },
+}));
+
+import { safeHandle } from '../../src/plugins/ipc-utils';
+
+describe('safeHandle', () => {
+  beforeEach(() => handlers.clear());
+
+  it('converts synchronous exceptions to an error payload', () => {
+    safeHandle('test:sync', () => {
+      throw new Error('sync failure');
+    });
+
+    expect(handlers.get('test:sync')!({})).toEqual({ error: 'sync failure' });
+  });
+
+  it('converts rejected promises to an error payload', async () => {
+    safeHandle('test:async', async () => {
+      throw new Error('async failure');
+    });
+
+    await expect(handlers.get('test:async')!({})).resolves.toEqual({ error: 'async failure' });
+  });
+
+  it('preserves successful return values', () => {
+    safeHandle('test:success', () => ({ ok: true }));
+
+    expect(handlers.get('test:success')!({})).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared `safeHandle()` IPC wrapper for structured `{ error: string }` failures
- migrate all discovery IPC handlers to the wrapper
- add sync/async wrapper tests and a discovery database-failure regression test
- document the IPC error contract

## Issue
Closes #275 (initial high-priority slice; follow-up plugin migrations can build on the helper)

## Validation
- `npm run build`
- `npm test` (49 files, 974 tests)