### PR TITLE
Add breathing room next to scrollbars in Repo Dashboard

### DIFF
--- a/src/renderer/onboarding.css
+++ b/src/renderer/onboarding.css
@@ -81,7 +81,11 @@ button:disabled {
   margin-bottom: 1.25rem;
   border-bottom: 2px solid #0f3460;
   overflow-x: auto;
-  scrollbar-width: thin;
+  scrollbar-width: none; /* still scrollable if tabs overflow, just no visible track */
+}
+
+.tab-bar::-webkit-scrollbar {
+  display: none;
 }
 
 .tab-btn {
@@ -1679,7 +1683,7 @@ body.onboarding {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding: 2rem;
+  padding: 2rem 2.75rem 2rem 2rem;
   min-height: 0; /* allow shrinking */
 }
 


### PR DESCRIPTION
## Summary of Changes

The Repo Dashboard's cards and repo list sat flush against the main vertical scrollbar, and the tab bar showed a visible horizontal scrollbar track under the nav even though it's just a thin overflow sliver.

- Widened `.main-scroll`'s right padding (`2rem` → `2rem 2.75rem 2rem 2rem`) so dashboard content has breathing room before the scrollbar.
- Hid the tab bar's horizontal scrollbar track (`scrollbar-width: none` + `::-webkit-scrollbar { display: none }`) — it's still scrollable via wheel/drag if tabs ever overflow, it just no longer shows a visible bar under the nav.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

1. Open the app and go to the Repo Dashboard tab.
2. Confirm the summary cards and repo list no longer sit flush against the right-hand scrollbar.
3. Confirm no scrollbar track appears under the tab bar (Repo Dashboard / Groups Dashboard / Browser / Setup / Dismissed).

## Checklist

- [ ] Tests pass (`npm test`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLZ62sZBTMNyNpuCAJB1r1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLZ62sZBTMNyNpuCAJB1r1)_