### PR TITLE
fix: disable implicit electron-builder publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "copy-static": "node -e \"const fs=require('fs');const p=require('path');fs.mkdirSync('dist/renderer',{recursive:true});for(const f of fs.readdirSync('src/renderer')){if(f.endsWith('.html'))fs.cpSync(p.join('src/renderer',f),p.join('dist/renderer',f));}\"",
     "start": "npm run build && electron dist/main/index.js",
     "pack:win": "npm run build && electron-builder --win --dir",
-    "dist:win": "npm run build && electron-builder --win nsis",
+    "dist:win": "npm run build && electron-builder --win nsis --publish never",
     "publish:win": "npm run build && electron-builder --win nsis --publish always",
     "dev:tsc": "tsc --watch --preserveWatchOutput",
     "dev:esbuild": "node scripts/build-renderer.mjs --watch",


### PR DESCRIPTION
## Summary
- pass `--publish never` to `dist:win`
- keep installer creation separate from the workflow's explicit `gh release` publishing step

## Cause
Electron-builder v26 detected the Git tag and configured GitHub provider, then implicitly attempted to publish during the build. That step intentionally had no token because publishing belongs to the following workflow step.

## Validation
- `npm run dist:win` completed successfully
- generated the NSIS installer and blockmap without attempting a GitHub upload