### PR TITLE
chore: release v0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jarvis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jarvis",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Jarvis — a locally-hosted personal assistant agent for GitHub repository maintenance",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
Version bump to 0.1.1 so a release tag can be cut from `main`.

The `main` ruleset requires pull requests, so the version bump cannot be pushed directly. Once this merges, tagging `v0.1.1` will run the release workflow, which now builds with `--publish never` (#280) and publishes assets through its explicit `gh release` step.