### PR TITLE
feat(settings): show runtime version with an About popup

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -17,6 +17,7 @@ contextBridge.exposeInMainWorld('jarvis', {
   getPreferences: () => ipcRenderer.invoke('app:get-preferences'),
   setPreferences: (prefs: Record<string, unknown>) => ipcRenderer.invoke('app:set-preferences', prefs),
   getStartupSettings: () => ipcRenderer.invoke('app:get-startup-settings'),
+  getAboutInfo: () => ipcRenderer.invoke('app:get-about-info'),
   setStartupSettings: (settings: { openAtLogin: boolean; startMinimized: boolean }) =>
     ipcRenderer.invoke('app:set-startup-settings', settings),
   checkOllama: () => ipcRenderer.invoke('ollama:status'),

--- a/src/plugins/config/handler.ts
+++ b/src/plugins/config/handler.ts
@@ -4,6 +4,7 @@ import type { Database as SqlJsDatabase } from 'sql.js';
 import type { BrowserWindow } from 'electron';
 import { getOnboardingStatus } from '../../agent/onboarding';
 import { loadConfig, saveConfig } from '../../agent/config';
+import { getAboutInfo } from '../../services/about';
 
 export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('onboarding:status', () => {
@@ -15,6 +16,14 @@ export function registerHandlers(db: SqlJsDatabase, _getWindow: () => BrowserWin
   });
 
   ipcMain.handle('app:get-system-locale', () => app.getSystemLocale());
+
+  ipcMain.handle('app:get-about-info', async () => {
+    try {
+      return await getAboutInfo();
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
 
   ipcMain.handle('app:get-preferences', () => {
     try {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2468,6 +2468,16 @@ export interface JarvisApi {
     canRegisterAtLogin: boolean;
   }>;
 
+  getAboutInfo(): Promise<{
+    displayVersion: string;
+    appVersion: string;
+    isDev: boolean;
+    branch: string | null;
+    releasedAt: string | null;
+    releaseUrl: string | null;
+    repoUrl: string;
+  }>;
+
   setStartupSettings(settings: {
     openAtLogin: boolean;
     startMinimized: boolean;

--- a/src/renderer/settings.css
+++ b/src/renderer/settings.css
@@ -243,3 +243,104 @@ code {
   outline: none;
   border-color: #4a70a8;
 }
+
+/* ── About ─────────────────────────────────────────────────────────────────── */
+.about-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.about-label {
+  color: #b0b8c8;
+  font-size: 0.9375rem;
+}
+
+.about-version {
+  font-family: 'Consolas', 'Fira Mono', monospace;
+  color: #e0e0e0;
+  background: #0f3460;
+  border-radius: 4px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.875rem;
+  word-break: break-all;
+}
+
+.btn-about {
+  background: transparent;
+  border: 1px solid #555;
+  color: #ccc;
+  margin-left: auto;
+}
+
+.btn-about:hover {
+  background: #0f3460;
+  border-color: #888;
+}
+
+.about-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.about-dialog {
+  background: #16213e;
+  border: 1px solid #1a4a8a;
+  border-radius: 10px;
+  padding: 1.25rem 1.4rem;
+  width: 400px;
+  max-width: 92vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.about-dialog h3 {
+  font-size: 1rem;
+  color: #e94560;
+  margin-bottom: 0.75rem;
+}
+
+.about-facts {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem 0.75rem;
+  align-items: baseline;
+  font-size: 0.9375rem;
+}
+
+.about-facts dt {
+  color: #8899aa;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+}
+
+.about-facts dd {
+  color: #e0e0e0;
+}
+
+.about-links {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  margin-top: 0.6rem;
+}
+
+.btn-link {
+  background: transparent;
+  border: none;
+  color: #6fa8ff;
+  padding: 0.1rem 0;
+  font-size: 0.9375rem;
+  text-decoration: underline;
+}
+
+.btn-link:hover {
+  background: transparent;
+  color: #9cc4ff;
+}

--- a/src/renderer/settings.tsx
+++ b/src/renderer/settings.tsx
@@ -18,6 +18,16 @@ interface PatStatus {
   avatarUrl?: string;
 }
 
+interface AboutInfo {
+  displayVersion: string;
+  appVersion: string;
+  isDev: boolean;
+  branch: string | null;
+  releasedAt: string | null;
+  releaseUrl: string | null;
+  repoUrl: string;
+}
+
 interface OnedriveRoot {
   id: number;
   path: string;
@@ -41,6 +51,8 @@ declare const window: Window & {
     onedriveRemoveRoot(rootId: number): Promise<{ ok: boolean; error?: string }>;
     groupsGetRuddrWorkspace(): Promise<{ ok: boolean; workspace: string }>;
     groupsSetRuddrWorkspace(workspace: string): Promise<{ ok: boolean; error?: string }>;
+    getAboutInfo(): Promise<AboutInfo>;
+    shellOpenUrl(url: string): Promise<{ ok: boolean; error?: string }>;
   };
 };
 
@@ -639,6 +651,7 @@ function App() {
       <RuddrSection />
       <DashboardSettingsSection />
       <AgentPromptsSection />
+      <AboutSection />
     </>
   );
 }
@@ -775,6 +788,86 @@ function DashboardSettingsSection() {
   );
 }
 
+// ── About section ────────────────────────────────────────────────────────────
+
+function formatReleaseDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+function AboutDialog({ info, onClose }: { info: AboutInfo; onClose: () => void }) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKeyDown);
+    return () => { window.removeEventListener('keydown', onKeyDown); };
+  }, [onClose]);
+
+  const openUrl = (url: string) => { void window.jarvis.shellOpenUrl(url); };
+
+  return (
+    <div class="about-overlay" onClick={onClose}>
+      <div class="about-dialog" role="dialog" aria-modal="true" aria-label="About Jarvis" onClick={(e) => e.stopPropagation()}>
+        <h3>About Jarvis</h3>
+
+        <dl class="about-facts">
+          <dt>{info.isDev ? 'Branch' : 'Version'}</dt>
+          <dd class="about-version">{info.displayVersion}</dd>
+
+          <dt>Released</dt>
+          <dd>
+            {info.isDev
+              ? 'Development build — not a released version'
+              : info.releasedAt
+                ? formatReleaseDate(info.releasedAt)
+                : 'Release date unavailable — could not reach GitHub'}
+          </dd>
+        </dl>
+
+        <p class="hint">Jarvis is open source — issues and contributions are welcome.</p>
+
+        <div class="about-links">
+          <button class="btn-link" onClick={() => openUrl(info.repoUrl)}>Open the GitHub repository</button>
+          {info.releaseUrl && (
+            <button class="btn-link" onClick={() => openUrl(info.releaseUrl!)}>View the release notes</button>
+          )}
+        </div>
+
+        <div class="btn-row">
+          <button class="btn-save" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AboutSection() {
+  const [info, setInfo] = useState<AboutInfo | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        setInfo(await window.jarvis.getAboutInfo());
+      } catch (err) {
+        console.error('[Settings] Failed to load about info:', err);
+      }
+    })();
+  }, []);
+
+  return (
+    <div class="section">
+      <h2>About</h2>
+      <div class="about-row">
+        <span class="about-label">{info?.isDev ? 'Branch' : 'Version'}</span>
+        <span class="about-version">{info ? info.displayVersion : '\u2026'}</span>
+        <button class="btn-about" onClick={() => setOpen(true)} disabled={!info}>About</button>
+      </div>
+      {open && info && <AboutDialog info={info} onClose={() => setOpen(false)} />}
+    </div>
+  );
+}
+
 // ── Mount ────────────────────────────────────────────────────────────────────
 
 const root = document.getElementById('app')!;

--- a/src/services/about.ts
+++ b/src/services/about.ts
@@ -1,0 +1,122 @@
+// ── About info (version, release date, repo link) ────────────────────────────
+import { app, net } from 'electron';
+import fs from 'fs';
+import path from 'path';
+
+export const REPO_URL = 'https://github.com/rajbos/Jarvis';
+const RELEASE_TAG_API = 'https://api.github.com/repos/rajbos/Jarvis/releases/tags/';
+
+export interface AboutInfo {
+  /** What to show as "the version": the release version when installed, the git branch in dev. */
+  displayVersion: string;
+  /** The version baked into the build (package.json / installer). */
+  appVersion: string;
+  /** True for a development run (not an installed build). */
+  isDev: boolean;
+  /** Current git branch during development, null when unavailable. */
+  branch: string | null;
+  /** ISO timestamp of the matching GitHub release, null when unknown. */
+  releasedAt: string | null;
+  /** Release page for the running version, null when unknown. */
+  releaseUrl: string | null;
+  /** Link back to the open source repository. */
+  repoUrl: string;
+}
+
+interface GitHubRelease {
+  published_at?: string | null;
+  created_at?: string | null;
+  html_url?: string | null;
+}
+
+/** Cache release lookups per tag so opening the About popup twice does not re-fetch. */
+const releaseCache = new Map<string, { releasedAt: string | null; releaseUrl: string | null }>();
+
+/**
+ * Read the checked-out branch straight from `.git/HEAD` — no git binary needed.
+ * Returns the short commit sha for a detached HEAD, or null when there is no repo.
+ */
+export function readGitBranch(startDir: string): string | null {
+  try {
+    let gitDir = path.join(startDir, '.git');
+    const stat = fs.statSync(gitDir);
+
+    if (stat.isFile()) {
+      // Worktrees and submodules store `gitdir: <path>` in a plain file.
+      const pointer = fs.readFileSync(gitDir, 'utf8').trim();
+      const match = pointer.match(/^gitdir:\s*(.+)$/);
+      if (!match) return null;
+      gitDir = path.resolve(startDir, match[1]);
+    }
+
+    const head = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
+    const refMatch = head.match(/^ref:\s*refs\/heads\/(.+)$/);
+    if (refMatch) return refMatch[1];
+    return head ? head.slice(0, 7) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchReleaseInfo(tag: string): Promise<{ releasedAt: string | null; releaseUrl: string | null }> {
+  const cached = releaseCache.get(tag);
+  if (cached) return cached;
+
+  let result: { releasedAt: string | null; releaseUrl: string | null } = { releasedAt: null, releaseUrl: null };
+  try {
+    const response = await net.fetch(`${RELEASE_TAG_API}${encodeURIComponent(tag)}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': `Jarvis/${app.getVersion()}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (response.ok) {
+      const release = await response.json() as GitHubRelease;
+      result = {
+        releasedAt: release.published_at ?? release.created_at ?? null,
+        releaseUrl: release.html_url ?? null,
+      };
+      releaseCache.set(tag, result);
+    }
+  } catch (error) {
+    console.warn('[About] Release lookup failed:', error);
+  }
+
+  return result;
+}
+
+export async function getAboutInfo(): Promise<AboutInfo> {
+  const appVersion = app.getVersion();
+  const isDev = !app.isPackaged;
+
+  if (isDev) {
+    const branch = readGitBranch(app.getAppPath());
+    return {
+      displayVersion: branch ?? `${appVersion} (dev)`,
+      appVersion,
+      isDev: true,
+      branch,
+      releasedAt: null,
+      releaseUrl: null,
+      repoUrl: REPO_URL,
+    };
+  }
+
+  const { releasedAt, releaseUrl } = await fetchReleaseInfo(`v${appVersion}`);
+  return {
+    displayVersion: appVersion,
+    appVersion,
+    isDev: false,
+    branch: null,
+    releasedAt,
+    releaseUrl,
+    repoUrl: REPO_URL,
+  };
+}
+
+/** Test seam: drop the cached release lookups. */
+export function clearReleaseCache(): void {
+  releaseCache.clear();
+}

--- a/tests/unit/about.test.ts
+++ b/tests/unit/about.test.ts
@@ -1,0 +1,183 @@
+/**
+ * About service tests.
+ *
+ * Covers the two runtime modes:
+ * - Packaged: version comes from the installer, release date from GitHub.
+ * - Development: the checked-out git branch stands in for the version.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+const mocks = vi.hoisted(() => ({
+  app: {
+    isPackaged: true,
+    getVersion: vi.fn(() => '1.2.3'),
+    getAppPath: vi.fn(() => '/repo'),
+  },
+  fetch: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: mocks.app,
+  net: { fetch: mocks.fetch },
+}));
+
+import { getAboutInfo, readGitBranch, clearReleaseCache, REPO_URL } from '../../src/services/about';
+
+function makeTempRepo(): string {
+  return mkdtempSync(path.join(tmpdir(), 'jarvis-about-'));
+}
+
+describe('about service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearReleaseCache();
+    mocks.app.isPackaged = true;
+    mocks.app.getVersion.mockReturnValue('1.2.3');
+    mocks.app.getAppPath.mockReturnValue('/repo');
+  });
+
+  describe('readGitBranch', () => {
+    it('reads the branch name from .git/HEAD', () => {
+      const dir = makeTempRepo();
+      try {
+        mkdirSync(path.join(dir, '.git'));
+        writeFileSync(path.join(dir, '.git', 'HEAD'), 'ref: refs/heads/feature/about-popup\n');
+        expect(readGitBranch(dir)).toBe('feature/about-popup');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns a short sha for a detached HEAD', () => {
+      const dir = makeTempRepo();
+      try {
+        mkdirSync(path.join(dir, '.git'));
+        writeFileSync(path.join(dir, '.git', 'HEAD'), '0123456789abcdef0123456789abcdef01234567\n');
+        expect(readGitBranch(dir)).toBe('0123456');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('follows a .git file that points at a worktree gitdir', () => {
+      const dir = makeTempRepo();
+      try {
+        mkdirSync(path.join(dir, 'real-git'));
+        writeFileSync(path.join(dir, 'real-git', 'HEAD'), 'ref: refs/heads/main\n');
+        writeFileSync(path.join(dir, '.git'), 'gitdir: real-git\n');
+        expect(readGitBranch(dir)).toBe('main');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns null when there is no git repository', () => {
+      const dir = makeTempRepo();
+      try {
+        expect(readGitBranch(dir)).toBeNull();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('getAboutInfo', () => {
+    it('reports the release version and date for a packaged app', async () => {
+      mocks.fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          published_at: '2026-01-15T10:00:00Z',
+          html_url: 'https://github.com/rajbos/Jarvis/releases/tag/v1.2.3',
+        }),
+      });
+
+      const info = await getAboutInfo();
+
+      expect(mocks.fetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/rajbos/Jarvis/releases/tags/v1.2.3',
+        expect.anything(),
+      );
+      expect(info).toMatchObject({
+        displayVersion: '1.2.3',
+        appVersion: '1.2.3',
+        isDev: false,
+        branch: null,
+        releasedAt: '2026-01-15T10:00:00Z',
+        releaseUrl: 'https://github.com/rajbos/Jarvis/releases/tag/v1.2.3',
+        repoUrl: REPO_URL,
+      });
+    });
+
+    it('caches the release lookup between calls', async () => {
+      mocks.fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ published_at: '2026-01-15T10:00:00Z', html_url: null }),
+      });
+
+      await getAboutInfo();
+      await getAboutInfo();
+
+      expect(mocks.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('still returns version info when the release lookup fails', async () => {
+      mocks.fetch.mockRejectedValue(new Error('offline'));
+
+      const info = await getAboutInfo();
+
+      expect(info.displayVersion).toBe('1.2.3');
+      expect(info.releasedAt).toBeNull();
+      expect(info.releaseUrl).toBeNull();
+    });
+
+    it('falls back to no release date on a 404', async () => {
+      mocks.fetch.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+      const info = await getAboutInfo();
+
+      expect(info.releasedAt).toBeNull();
+    });
+
+    it('shows the git branch instead of a version during development', async () => {
+      const dir = makeTempRepo();
+      try {
+        mkdirSync(path.join(dir, '.git'));
+        writeFileSync(path.join(dir, '.git', 'HEAD'), 'ref: refs/heads/feature/about\n');
+        mocks.app.isPackaged = false;
+        mocks.app.getAppPath.mockReturnValue(dir);
+
+        const info = await getAboutInfo();
+
+        expect(info).toMatchObject({
+          displayVersion: 'feature/about',
+          appVersion: '1.2.3',
+          isDev: true,
+          branch: 'feature/about',
+          releasedAt: null,
+          repoUrl: REPO_URL,
+        });
+        expect(mocks.fetch).not.toHaveBeenCalled();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('falls back to the app version in development without a git checkout', async () => {
+      const dir = makeTempRepo();
+      try {
+        mocks.app.isPackaged = false;
+        mocks.app.getAppPath.mockReturnValue(dir);
+
+        const info = await getAboutInfo();
+
+        expect(info.displayVersion).toBe('1.2.3 (dev)');
+        expect(info.branch).toBeNull();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -38,6 +38,18 @@ vi.mock('../../src/agent/onboarding', () => ({
   }),
 }));
 
+vi.mock('../../src/services/about', () => ({
+  getAboutInfo: vi.fn().mockResolvedValue({
+    displayVersion: '9.9.9',
+    appVersion: '9.9.9',
+    isDev: false,
+    branch: null,
+    releasedAt: '2026-02-01T12:00:00Z',
+    releaseUrl: 'https://github.com/rajbos/Jarvis/releases/tag/v9.9.9',
+    repoUrl: 'https://github.com/rajbos/Jarvis',
+  }),
+}));
+
 vi.mock('../../src/agent/config', () => ({
   loadConfig: vi.fn().mockReturnValue({
     electron: { openAtLogin: true, startMinimized: false },
@@ -50,6 +62,7 @@ import { registerHandlers } from '../../src/plugins/config/handler';
 import { getOnboardingStatus } from '../../src/agent/onboarding';
 import { loadConfig, saveConfig } from '../../src/agent/config';
 import { app } from 'electron';
+import { getAboutInfo } from '../../src/services/about';
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 
@@ -116,6 +129,27 @@ describe('Config plugin — IPC handlers', () => {
       const result = callHandler('app:get-system-locale');
       expect(app.getSystemLocale).toHaveBeenCalled();
       expect(result).toBe('en-US');
+    });
+  });
+
+  // ── app:get-about-info ────────────────────────────────────────────────────
+
+  describe('app:get-about-info', () => {
+    it('returns the about info from the service', async () => {
+      const result = await callHandler('app:get-about-info');
+      expect(getAboutInfo).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        displayVersion: '9.9.9',
+        releasedAt: '2026-02-01T12:00:00Z',
+        repoUrl: 'https://github.com/rajbos/Jarvis',
+      });
+    });
+
+    it('returns an error object when the service throws', async () => {
+      vi.mocked(getAboutInfo).mockRejectedValueOnce(new Error('boom'));
+      const result = await callHandler('app:get-about-info') as Record<string, unknown>;
+      expect(result.ok).toBe(false);
+      expect(typeof result.error).toBe('string');
     });
   });
 

--- a/tests/unit/ipc-registration.test.ts
+++ b/tests/unit/ipc-registration.test.ts
@@ -44,6 +44,7 @@ const EXPECTED_CHANNELS = [
   // config plugin
   'onboarding:status',
   'app:get-system-locale',
+  'app:get-about-info',
   'app:get-preferences',
   'app:set-preferences',
   'app:get-startup-settings',


### PR DESCRIPTION
## Summary of Changes

Settings now shows which version of Jarvis is actually running, plus a new **About** option that opens a popup with the version, when it was released, and a link back to the open source repo.

- **New `src/services/about.ts`** resolves the runtime version:
  - Installed app → the version baked into the installer (`app.getVersion()`), with the release date and release URL looked up from the GitHub Releases API (`releases/tags/v<version>`) and cached per tag, so opening the popup twice does not re-fetch. A failed or 404 lookup still returns the version, just without a date.
  - Development run → the checked-out git branch, read straight from `.git/HEAD` (no git binary needed; handles detached HEAD and a `.git` file pointing at a worktree gitdir), falling back to `<version> (dev)` when there is no checkout.
- **New `app:get-about-info` IPC channel** in the config plugin, exposed on the preload bridge as `getAboutInfo()` and declared in `JarvisApi`.
- **Settings renderer** gains `AboutSection` (version row + About button) and `AboutDialog` — a modal closed by Escape, the Close button, or clicking the overlay. Repo and release-notes links open in the system browser through the existing `shell:open-url` channel. Styles added to `settings.css`.

## Related Issue

n/a

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests

## How to Test

1. `npm run dev` (or `npm start`) and open **Settings** — the new About section at the bottom shows `Branch` with the current git branch name, since a dev run is not a released build.
2. Click **About** — the popup shows the branch, "Development build — not a released version", and a link to the GitHub repository. Escape, the overlay, and Close all dismiss it.
3. In an installed build the same section shows `Version 0.1.1` and the popup shows the release date from GitHub Releases plus a "View the release notes" link; with no network the version still shows and the date reads as unavailable.
4. `npm run build`, `npm run lint`, `npm test`.

## Checklist

- [x] Tests pass (`npm test`) — 51 files / 995 tests, including new `tests/unit/about.test.ts` and `app:get-about-info` cases in `tests/unit/config-handler.test.ts`; the channel is registered in the `EXPECTED_CHANNELS` catalogue
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qo9RC9WrwBz2tHYzShK1Gk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qo9RC9WrwBz2tHYzShK1Gk)_